### PR TITLE
Rename to 訂單分析器, simplify UI, add 非火雞筋品項 filter, hide ASIN in UI & CSV-only exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>SKU 工具：速度/訂單/美國總數/可銷售天數 + 下單清單 + 台灣廠篩選</title>
+  <title>訂單分析器</title>
   <style>
     :root { font-family: system-ui, -apple-system, "Segoe UI", Arial, "Noto Sans TC", sans-serif; color: #0f1d2b; }
     body { margin: 0; padding: 32px 18px 48px; background: radial-gradient(circle at 10% 20%, #f3f6ff 0, #f7f9fc 30%, #f9fbff 60%, #fff 100%); }
@@ -49,31 +49,12 @@
 </head>
 <body>
   <div class="page">
-    <h1>SKU 自動整理：速度 / 訂單 / 美國總數 / 可銷售天數 + 下單清單</h1>
+    <h1>訂單分析器</h1>
 
     <div class="row">
-      <button id="btnBuild">整理（重建表格）</button>
+      <button id="btnBuild">整理表格</button>
       <button class="secondary" id="btnClear">清空</button>
 
-      <label style="display:flex; gap:6px; align-items:center;">
-        <input type="checkbox" id="chkDedupe" checked />
-        H10 去重（以 ASIN+SKU）
-      </label>
-      <label style="display:flex; gap:6px; align-items:center;">
-        <input type="checkbox" id="chkMissingOrderAsZero" checked />
-        H10 找不到訂單時填 0
-      </label>
-      <label style="display:flex; gap:6px; align-items:center;">
-        <input type="checkbox" id="chkMissingUsAsBlank" />
-        H10 找不到美國總數時留空（不勾選則填 0）
-      </label>
-      <label style="display:flex; gap:6px; align-items:center;">
-        <input type="checkbox" id="chkNormalizeSku" checked />
-        SKU 正規化（去空白、轉大寫）
-      </label>
-    </div>
-
-    <div class="row">
       <label>主表排序：</label>
       <select id="sortMode">
         <option value="normal">正常（速度由大到小）</option>
@@ -82,8 +63,6 @@
 
       <label>下單門檻（天）：</label>
       <input id="daysThreshold" type="number" min="1" step="1" value="180" />
-
-      <span class="hint">可銷售天數 = (美國總數 + 訂單) ÷ 速度</span>
     </div>
 
     <div class="row">
@@ -92,8 +71,43 @@
       <button class="secondary" id="btnOnlyTW">只看台灣廠（E 開頭）</button>
       <button class="secondary" id="btnShowAll">顯示全部</button>
       <span class="modeTag" id="factoryModeTag">目前：顯示全部</span>
-      <span class="hint">提示：此篩選會套用在「下單清單 / 主表 / 新品表」</span>
     </div>
+
+    <div class="row">
+      <label>品項篩選：</label>
+      <button class="secondary" id="btnHideNonTurkey">非火雞筋品項</button>
+      <span class="modeTag" id="itemFilterTag">目前：顯示全部</span>
+    </div>
+
+    <details class="card" id="advancedSettings">
+      <summary>
+        <div>
+          <p class="eyebrow">設定</p>
+          <h2>進階設定（可展開）</h2>
+        </div>
+        <span class="pill">可收合</span>
+      </summary>
+      <div class="cardContent">
+        <div class="row">
+          <label style="display:flex; gap:6px; align-items:center;">
+            <input type="checkbox" id="chkDedupe" checked />
+            H10 去重（以 ASIN+SKU）
+          </label>
+          <label style="display:flex; gap:6px; align-items:center;">
+            <input type="checkbox" id="chkMissingOrderAsZero" checked />
+            H10 找不到訂單時填 0
+          </label>
+          <label style="display:flex; gap:6px; align-items:center;">
+            <input type="checkbox" id="chkMissingUsAsBlank" />
+            H10 找不到美國總數時留空（不勾選則填 0）
+          </label>
+          <label style="display:flex; gap:6px; align-items:center;">
+            <input type="checkbox" id="chkNormalizeSku" checked />
+            SKU 正規化（去空白、轉大寫）
+          </label>
+        </div>
+      </div>
+    </details>
 
     <div class="grid">
       <details class="card" open>
@@ -155,7 +169,6 @@ TTR01AM-4 14125
 
         <div class="cardContent">
           <div class="row">
-            <button id="btnCopyReorderTSV">複製下單清單 TSV</button>
             <button class="secondary" id="btnDownloadReorderCSV">下載下單清單 CSV</button>
           </div>
 
@@ -169,7 +182,7 @@ TTR01AM-4 14125
           <div>
             <p class="eyebrow">重點檢視 ②</p>
             <h2>主表（H10 產品）</h2>
-            <div class="hint">SKU / ASIN / 速度 / 訂單 / 美國總數 / 可銷售天數</div>
+            <div class="hint">SKU / 速度 / 訂單 / 美國總數 / 可銷售天數</div>
           </div>
           <div class="hint" style="display:flex; flex-direction:column; gap:6px; align-items:flex-end;">
             <div>筆數：<span class="count" id="countMain">0</span></div>
@@ -183,7 +196,6 @@ TTR01AM-4 14125
 
         <div class="cardContent">
           <div class="row">
-            <button id="btnCopyMainTSV">複製主表 TSV</button>
             <button class="secondary" id="btnDownloadMainCSV">下載主表 CSV</button>
           </div>
 
@@ -206,7 +218,6 @@ TTR01AM-4 14125
 
         <div class="cardContent">
           <div class="row">
-            <button id="btnCopyNewOrderTSV">複製新品(訂單) TSV</button>
             <button class="secondary" id="btnDownloadNewOrderCSV">下載新品(訂單) CSV</button>
           </div>
 
@@ -233,7 +244,6 @@ TTR01AM-4 14125
           </div>
 
           <div class="row">
-            <button id="btnCopyNewUSTSV">複製新品(美國總數) TSV</button>
             <button class="secondary" id="btnDownloadNewUSCSV">下載新品(美國總數) CSV</button>
           </div>
 
@@ -277,10 +287,43 @@ TTR01AM-4 14125
   const sumReorderAvailEl = document.getElementById('sumReorderAvail');
 
   const factoryModeTag = document.getElementById('factoryModeTag');
+  const itemFilterTag = document.getElementById('itemFilterTag');
   const newUSDetails = document.getElementById('newUSDetails');
 
   // 工廠篩選狀態：all | hideTW | onlyTW
   let factoryMode = "all";
+  let hideNonTurkey = false;
+
+  const nonTurkeySkuSet = new Set(`
+    AFA13AM AFA14AM
+    AFA21AM AFA22AM AFA25AM AFA135AM
+    GTS01 GTR01 GTB01 GTP01 GTZ01 GTA01 GTC01
+    GTB03 GTR03 GTP03 GTS03 GTZ03
+    GTB05 GTP05 GTB07
+    GSF01 GSF02
+    GTSL01 GTRL01 GTPL01 GTBL01 GTAL01 GTCL01
+    GTRL03 GTPL03 GTBL03 GTZL03
+    GTPL05 GTBL05
+    GSFL01 GSFL02
+    ATS01 ATB01 ATR01AM ATP01 ATZ01
+    ATB03 ATR03 ATP03 ATZ03
+    ATB05 ATP05 ATA01 ATAL01
+    KTB01AM TRP01AM TTR01AM TPZ01AM
+    KTB03AM TRP03AM TTR03AM TPZ03AM
+    TRP05AM KTB05AM TTR05AM TPZ05AM TTS05AM
+    KTB06AM
+    KTB01AM-4 TTR01AM-4 TRP01AM-4 TPZ01AM-4
+    KTB03AM-2 TRP03AM-2 TTR03AM-2 TPZ03AM-2
+    KTB05AM-1 TRP05AM-1 TTR05AM-1 TPZ05AM-1 TTS05AM-1
+    KTB06AM-4
+    KTBL01 TTRL01 TPZL01 TRPL01
+    KTBL03 TTRL03 TPZL03 TRPL03
+    TTRL05 TRPL05 TPZL05 KTBL05 TTSL05
+    AFML01 AFML03 AFML05
+    GTT01 GTT03
+    VTS01-1 VTB01-4 VTR01-4 VTB05-1 VTB06-4
+    HDR01AM HDP01AM HDS03AM
+  `.trim().split(/\s+/).filter(Boolean).map(s => s.trim().toUpperCase()));
 
   /** @type {{sku:string, asin:string, speed:(number|null), order:(number|null), us:(number|null), avail:(number|null), days:(number|null)}[]} */
   let mainRowsAll = [];
@@ -304,6 +347,9 @@ TTR01AM-4 14125
     if (!chkNormalizeSku.checked) return String(sku ?? "");
     return String(sku ?? "").trim().toUpperCase();
   }
+  function normalizeSkuValue(sku) {
+    return String(sku ?? "").trim().toUpperCase();
+  }
   function fmtDays(n) {
     if (n === null || n === undefined) return "";
     return (Math.round(n * 10) / 10).toFixed(1);
@@ -320,10 +366,20 @@ TTR01AM-4 14125
     return list;
   }
 
+  function applyFilters(list) {
+    let rows = applyFactoryFilter(list);
+    if (!hideNonTurkey) return rows;
+    return rows.filter(r => !nonTurkeySkuSet.has(normalizeSkuValue(r.sku)));
+  }
+
   function updateFactoryTag() {
     if (factoryMode === "all") factoryModeTag.textContent = "目前：顯示全部";
     if (factoryMode === "hideTW") factoryModeTag.textContent = "目前：隱藏台灣廠（E 開頭）";
     if (factoryMode === "onlyTW") factoryModeTag.textContent = "目前：只看台灣廠（E 開頭）";
+  }
+
+  function updateItemFilterTag() {
+    itemFilterTag.textContent = hideNonTurkey ? "目前：已隱藏非火雞筋品項" : "目前：顯示全部";
   }
 
   function parseH10ToRows(raw) {
@@ -496,7 +552,7 @@ TTR01AM-4 14125
   }
 
   function renderReorder() {
-    const rows = applyFactoryFilter(reorderRowsAll);
+    const rows = applyFilters(reorderRowsAll);
     countReorderEl.textContent = String(rows.length);
     sumReorderAvailEl.textContent = `可售總量(美國+訂單)：${sum(rows, "avail")}`;
 
@@ -506,7 +562,6 @@ TTR01AM-4 14125
       <tr>
         <td>${idx + 1}</td>
         <td>${escapeHtml(r.sku)}</td>
-        <td>${escapeHtml(r.asin)}</td>
         <td class="ok">${escapeHtml(String(r.speed))}</td>
         <td class="ok">${escapeHtml(String(r.order))}</td>
         <td class="ok">${escapeHtml(String(r.us))}</td>
@@ -519,7 +574,7 @@ TTR01AM-4 14125
       <table>
         <thead>
           <tr>
-            <th>#</th><th>SKU</th><th>ASIN</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可售總量</th><th>可銷售天數</th>
+            <th>#</th><th>SKU</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可售總量</th><th>可銷售天數</th>
           </tr>
         </thead>
         <tbody>${body}</tbody>
@@ -528,7 +583,7 @@ TTR01AM-4 14125
   }
 
   function renderMain() {
-    const rows = applyFactoryFilter(mainRowsAll);
+    const rows = applyFilters(mainRowsAll);
     countMainEl.textContent = String(rows.length);
     sumOrdersMainEl.textContent = `訂單總和：${sum(rows, "order")}`;
     sumUsMainEl.textContent = `美國總數總和：${sum(rows, "us")}`;
@@ -547,7 +602,6 @@ TTR01AM-4 14125
         <tr>
           <td>${idx + 1}</td>
           <td>${escapeHtml(r.sku)}</td>
-          <td>${escapeHtml(r.asin)}</td>
           ${speedCell}
           ${orderCell}
           ${usCell}
@@ -561,7 +615,7 @@ TTR01AM-4 14125
       <table>
         <thead>
           <tr>
-            <th>#</th><th>SKU</th><th>ASIN</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可售總量</th><th>可銷售天數</th>
+            <th>#</th><th>SKU</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可售總量</th><th>可銷售天數</th>
           </tr>
         </thead>
         <tbody>${body}</tbody>
@@ -570,7 +624,7 @@ TTR01AM-4 14125
   }
 
   function renderNewOrder() {
-    const rows = applyFactoryFilter(newOrderRowsAll);
+    const rows = applyFilters(newOrderRowsAll);
     countNewOrderEl.textContent = String(rows.length);
     if (rows.length === 0) { newOrderWrap.innerHTML = ""; return; }
 
@@ -597,7 +651,7 @@ TTR01AM-4 14125
   }
 
   function renderNewUS() {
-    const rows = applyFactoryFilter(newUSRowsAll);
+    const rows = applyFilters(newUSRowsAll);
     // countNewUS 只有在展開時才顯示也可以，但這裡保留更新
     countNewUSEl.textContent = String(rows.length);
     if (rows.length === 0) { newUSWrap.innerHTML = ""; return; }
@@ -621,15 +675,6 @@ TTR01AM-4 14125
   }
 
   // ---- Export ----
-  async function copyToClipboard(text, okMsg) {
-    try { await navigator.clipboard.writeText(text); alert(okMsg); }
-    catch {
-      const ta = document.createElement("textarea");
-      ta.value = text; document.body.appendChild(ta);
-      ta.select(); document.execCommand("copy"); ta.remove();
-      alert(okMsg + "（備援方式）");
-    }
-  }
   function download(filename, content, mime) {
     const blob = new Blob([content], { type: mime });
     const url = URL.createObjectURL(blob);
@@ -644,12 +689,9 @@ TTR01AM-4 14125
     const body = rows.map(r => r.map(q).join(",")).join("\n");
     return head + "\n" + body;
   }
-  function tsvFromRows(headers, rows) {
-    return [headers.join("\t"), ...rows.map(r => r.join("\t"))].join("\n");
-  }
 
   function exportMainRowsFiltered() {
-    const rows = applyFactoryFilter(mainRowsAll);
+    const rows = applyFilters(mainRowsAll);
     const headers = ["SKU","ASIN","速度","訂單","美國總數","可售總量(美國+訂單)","可銷售天數"];
     const body = rows.map(r => [
       r.sku, r.asin,
@@ -662,7 +704,7 @@ TTR01AM-4 14125
     return { headers, body };
   }
   function exportReorderRowsFiltered() {
-    const rows = applyFactoryFilter(reorderRowsAll);
+    const rows = applyFilters(reorderRowsAll);
     const headers = ["SKU","ASIN","速度","訂單","美國總數","可售總量(美國+訂單)","可銷售天數"];
     const body = rows.map(r => [
       r.sku, r.asin, String(r.speed), String(r.order), String(r.us), String(r.avail), fmtDays(r.days)
@@ -670,13 +712,13 @@ TTR01AM-4 14125
     return { headers, body };
   }
   function exportNewOrderRowsFiltered() {
-    const rows = applyFactoryFilter(newOrderRowsAll);
+    const rows = applyFilters(newOrderRowsAll);
     const headers = ["SKU","訂單","美國總數"];
     const body = rows.map(r => [r.sku, String(r.order), (r.us ?? "").toString()]);
     return { headers, body };
   }
   function exportNewUSRowsFiltered() {
-    const rows = applyFactoryFilter(newUSRowsAll);
+    const rows = applyFilters(newUSRowsAll);
     const headers = ["SKU","美國總數"];
     const body = rows.map(r => [r.sku, String(r.us)]);
     return { headers, body };
@@ -693,6 +735,7 @@ TTR01AM-4 14125
     sumOrdersMainEl.textContent = "訂單總和：0"; sumUsMainEl.textContent = "美國總數總和：0";
     sumAvailMainEl.textContent = "可售總量(美國+訂單)：0"; sumReorderAvailEl.textContent = "可售總量(美國+訂單)：0";
     factoryMode = "all"; updateFactoryTag();
+    hideNonTurkey = false; updateItemFilterTag();
     // ⑦維持收折（預設）
     newUSDetails.open = false;
   });
@@ -710,39 +753,26 @@ TTR01AM-4 14125
   document.getElementById("btnShowAll").addEventListener("click", () => {
     factoryMode = "all"; updateFactoryTag(); renderAll();
   });
+  document.getElementById("btnHideNonTurkey").addEventListener("click", () => {
+    hideNonTurkey = !hideNonTurkey; updateItemFilterTag(); renderAll();
+  });
 
   // Export buttons
-  document.getElementById("btnCopyMainTSV").addEventListener("click", () => {
-    const ex = exportMainRowsFiltered();
-    copyToClipboard(tsvFromRows(ex.headers, ex.body), "已複製主表 TSV（含目前工廠篩選）。");
-  });
   document.getElementById("btnDownloadMainCSV").addEventListener("click", () => {
     const ex = exportMainRowsFiltered();
     download("主表.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
   });
 
-  document.getElementById("btnCopyReorderTSV").addEventListener("click", () => {
-    const ex = exportReorderRowsFiltered();
-    copyToClipboard(tsvFromRows(ex.headers, ex.body), "已複製下單清單 TSV（含目前工廠篩選）。");
-  });
   document.getElementById("btnDownloadReorderCSV").addEventListener("click", () => {
     const ex = exportReorderRowsFiltered();
     download("下單清單.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
   });
 
-  document.getElementById("btnCopyNewOrderTSV").addEventListener("click", () => {
-    const ex = exportNewOrderRowsFiltered();
-    copyToClipboard(tsvFromRows(ex.headers, ex.body), "已複製新品(訂單) TSV（含目前工廠篩選）。");
-  });
   document.getElementById("btnDownloadNewOrderCSV").addEventListener("click", () => {
     const ex = exportNewOrderRowsFiltered();
     download("新品_訂單.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
   });
 
-  document.getElementById("btnCopyNewUSTSV").addEventListener("click", () => {
-    const ex = exportNewUSRowsFiltered();
-    copyToClipboard(tsvFromRows(ex.headers, ex.body), "已複製新品(美國總數) TSV（含目前工廠篩選）。");
-  });
   document.getElementById("btnDownloadNewUSCSV").addEventListener("click", () => {
     const ex = exportNewUSRowsFiltered();
     download("新品_美國總數.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
@@ -751,6 +781,7 @@ TTR01AM-4 14125
   // ⑦ 預設收折
   newUSDetails.open = false;
   updateFactoryTag();
+  updateItemFilterTag();
 })();
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- 簡化介面與操作：把次要選項收進進階設定，不要讓主要操作區看起來太複雜。
- 加入「非火雞筋品項」篩選，讓使用者一鍵隱藏一大批不需要的 SKU。
- 在畫面上隱藏 ASIN（但保留匯出 CSV 時包含 ASIN），並只提供 CSV 下載（不再提供 TSV / 複製動作）。
- 改善按鈕/標題文字以更貼近功能描述（改名為 `訂單分析器`）。

### Description
- UI / 文案變更：將頁面標題與主標題從原本的 SKU 工具改為 `訂單分析器`，並將 `btnBuild` 文案改為 `整理表格`。
- 把先前頂部大量選項移到一個可收合的 `#advancedSettings`（`details`），預設收起，保留原有選項但不佔主要視覺空間。
- 新增「非火雞筋品項」篩選：加入 `nonTurkeySkuSet`（清單中的多個 SKU），以及 `hideNonTurkey` 切換按鈕 `#btnHideNonTurkey`，透過 `applyFilters()` 將此篩選套用到所有表格。
- 隱藏畫面上所有表格的 ASIN 欄位（保留匯出函式 `export*` 仍會把 ASIN 包含在 CSV 內），並移除原先的 TSV/複製到剪貼簿功能，改以 CSV 下載 (`download`) 為唯一匯出途徑。
- 主要檔案修改：`index.html`（調整 DOM、樣式與 JS 行為：`applyFilters`, `nonTurkeySkuSet`, `hideNonTurkey`, 移除 `copyToClipboard` / TSV 相關 UI 與綁定）。

### Testing
- Launched a simple static server and rendered the updated `index.html`, then captured a screenshot via a Playwright script — succeeded (screenshot artifact produced).
- Verified the page still builds tables and CSV export handlers exist by exercising the download code paths in-browser (manual render + click tested in the browser run).
- No unit tests were added; changes are primarily static UI/JS adjustments.
- File modified: `index.html` (UI and client-side logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6944c13016388320a655a309b8668700)