### PR TITLE
Export main table as dated Excel file

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@ TTR01AM-4 14125
 
         <div class="cardContent">
           <div class="row">
-            <button class="secondary" id="btnDownloadMainCSV">下載主表 CSV</button>
+    <button class="secondary" id="btnDownloadMainCSV">下載主表 Excel</button>
             <div class="row" style="margin:0;">
               <span class="hint">主表排序：</span>
               <button class="secondary" id="btnSortSpeed">速度由大到小</button>
@@ -1212,11 +1212,25 @@ function getDiscontinuedReason(sku) {
     document.body.appendChild(a); a.click(); a.remove();
     URL.revokeObjectURL(url);
   }
+  function downloadRowsAsExcel(headers, rows, filename, sheetName = "主表") {
+    const wb = XLSX.utils.book_new();
+    const sheetData = [headers, ...rows];
+    const ws = XLSX.utils.aoa_to_sheet(sheetData);
+    XLSX.utils.book_append_sheet(wb, ws, sheetName);
+    XLSX.writeFile(wb, filename);
+  }
   function csvFromRows(headers, rows) {
     const q = (v) => `"${String(v ?? "").replace(/"/g, '""')}"`;
     const head = headers.map(q).join(",");
     const body = rows.map(r => r.map(q).join(",")).join("\n");
     return head + "\n" + body;
+  }
+  function getDateStamp() {
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    return `${yyyy}${mm}${dd}`;
   }
 
   function exportMainRowsFiltered() {
@@ -1288,7 +1302,9 @@ function getDiscontinuedReason(sku) {
   // Export buttons
   document.getElementById("btnDownloadMainCSV").addEventListener("click", () => {
     const ex = exportMainRowsFiltered();
-    download("主表.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
+    const dateStamp = getDateStamp();
+    const filename = `${dateStamp}_Supply.xlsx`;
+    downloadRowsAsExcel(ex.headers, ex.body, filename, "Supply");
   });
 
   document.getElementById("btnDownloadReorderCSV").addEventListener("click", () => {


### PR DESCRIPTION
### Motivation
- Replace the main-table CSV download with an Excel export and name the file using a date + `Supply` to match requested naming and format preferences.

### Description
- Updated the main table download button label in `index.html` from "下載主表 CSV" to "下載主表 Excel".
- Added a helper `downloadRowsAsExcel(headers, rows, filename, sheetName)` that builds an XLSX workbook via `XLSX.utils` and writes it with `XLSX.writeFile`.
- Added a `getDateStamp()` helper that returns a `YYYYMMDD` date string and used it to construct the filename `${dateStamp}_Supply.xlsx` for the main-table export.
- Updated the `btnDownloadMainCSV` click handler to call the new Excel helper; other CSV exports were left unchanged.

### Testing
- Launched a local server with `python -m http.server` and ran a Playwright (Python) script to load `index.html` and capture a screenshot to verify the page and updated button label, which succeeded.
- No unit tests were added or run; change is a front-end HTML/JS update and was manually validated via the browser script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977024248608320aafb685a581ec401)