### PR TITLE
新增「熱銷品專區」、熱銷標記與一鍵加入訂單產生器

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,6 +300,12 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #ffe5e5; color: #c62828; border: 1px solid #f2b3b3;
     }
+    .hot-text { color: #b45309; font-weight: 700; }
+    .hot-tag {
+      display: inline-block; margin-left: 6px; padding: 2px 7px;
+      border-radius: 999px; font-size: 11px; font-weight: 700;
+      background: #fff1d6; color: #b45309; border: 1px solid #ffd59a;
+    }
     .discontinued-list-wrap { max-height: 380px; overflow: auto; }
     /* user-tip提示 */
     .order-generator .user-tip {
@@ -598,11 +604,33 @@ TTR01AM-4 14125
         </div>
       </details>
 
-      <!-- 新品（訂單有但H10沒有） -->
+      <!-- 熱銷品專區 -->
       <details class="card priority" open>
         <summary>
           <div>
             <p class="eyebrow">重點檢視 ③</p>
+            <h2>熱銷品專區</h2>
+            <div class="hint">SKU / 速度 / 訂單 / 美國總數 / 可銷售天數</div>
+          </div>
+          <div class="hint">
+            筆數：<span class="count" id="countHot">0</span>
+          </div>
+        </summary>
+
+        <div class="cardContent">
+          <div class="row">
+            <button class="secondary" id="btnAddHotToGenerator">一鍵加入訂單產生器</button>
+          </div>
+
+          <div class="tableWrap" id="hotTableWrap"></div>
+        </div>
+      </details>
+
+      <!-- 新品（訂單有但H10沒有） -->
+      <details class="card priority" open>
+        <summary>
+          <div>
+            <p class="eyebrow">重點檢視 ④</p>
             <h2>新品（訂單有，但 H10 沒有）</h2>
             <div class="hint">SKU / 訂單 / 美國總數(若有)</div>
           </div>
@@ -754,6 +782,42 @@ function getDiscontinuedReason(sku) {
   return discontinuedSkuReasons.get(normalizeSkuKey(sku)) || "";
 }
 
+const hotSkuList = [
+  "TTS05AM-1",
+  "TTSL05",
+  "TTS05AM",
+  "AFA12AM",
+  "GTSL01",
+  "GTB01",
+  "GTS01",
+  "GTB05",
+  "TTR01AM",
+  "AFA11AM",
+  "GTBL05",
+  "KTB01AM-4",
+  "KTBL05",
+  "KTB05AM-1",
+  "VTS01-1",
+  "GCBL02",
+  "KTB01AM",
+  "ATA01",
+  "KTB05AM",
+  "AFA22AM",
+  "GBSL03",
+  "GSFL02",
+  "GTRL01",
+  "ASF01",
+  "GTPL03",
+  "GSCL01",
+  "ACBL03",
+  "1ABRD004A0",
+  "ASCL01"
+];
+const hotSkuSet = new Set(hotSkuList.map(sku => normalizeSkuKey(sku)));
+function isHotSku(sku) {
+  return hotSkuSet.has(normalizeSkuKey(sku));
+}
+
 (() => {
   const h10El = document.getElementById('inputH10');
   const ordersEl = document.getElementById('inputOrders');
@@ -772,10 +836,12 @@ function getDiscontinuedReason(sku) {
 
   const mainWrap = document.getElementById('mainTableWrap');
   const reorderWrap = document.getElementById('reorderTableWrap');
+  const hotWrap = document.getElementById('hotTableWrap');
   const newOrderWrap = document.getElementById('newOrderWrap');
   const newUSWrap = document.getElementById('newUSWrap');
 
   const countReorderEl = document.getElementById('countReorder');
+  const countHotEl = document.getElementById('countHot');
   const countNewOrderEl = document.getElementById('countNewOrder');
   const countNewUSEl = document.getElementById('countNewUS');
 
@@ -823,6 +889,8 @@ function getDiscontinuedReason(sku) {
   let mainRowsAll = [];
   /** @type {{sku:string, asin:string, speed:number, order:number, us:number, avail:number, days:number}[]} */
   let reorderRowsAll = [];
+  /** @type {{sku:string, asin:(string|null), speed:(number|null), order:(number|null), us:(number|null), avail:(number|null), days:(number|null)}[]} */
+  let hotRowsAll = [];
   /** @type {{sku:string, order:number, us:(number|null)}[]} */
   let newOrderRowsAll = [];
   /** @type {{sku:string, us:number}[]} */
@@ -833,10 +901,17 @@ function getDiscontinuedReason(sku) {
   }
   function renderSkuCell(sku) {
     const isDiscontinued = isDiscontinuedSku(sku);
+    const isHot = isHotSku(sku);
     const label = escapeHtml(sku);
-    const tag = isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : '';
-    const className = isDiscontinued ? 'discontinued-text' : '';
-    return `<td class="${className}">${label}${tag}</td>`;
+    const tags = [
+      isHot ? ' <span class="hot-tag">熱銷品</span>' : '',
+      isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : ''
+    ].join('');
+    const className = [
+      isHot ? 'hot-text' : '',
+      isDiscontinued ? 'discontinued-text' : ''
+    ].filter(Boolean).join(' ');
+    return `<td class="${className}">${label}${tags}</td>`;
   }
   function normalizeNumber(s) {
     if (s === null || s === undefined) return null;
@@ -987,6 +1062,7 @@ function getDiscontinuedReason(sku) {
     );
 
     const h10SkuSet = new Set(h10Rows.map(r => r.sku));
+    const h10RowMap = new Map(h10Rows.map(r => [r.sku, r]));
 
     for (const r of h10Rows) {
       const o = orderMap.get(r.sku);
@@ -1014,6 +1090,24 @@ function getDiscontinuedReason(sku) {
       }
     }
 
+    const hotRows = hotSkuList.map(rawSku => {
+      const sku = normalizeSkuValue(rawSku);
+      const h10Row = h10RowMap.get(sku);
+      const orderVal = orderMap.get(sku);
+      const usVal = usMap.get(sku);
+      const row = {
+        sku,
+        asin: h10Row?.asin ?? null,
+        speed: h10Row?.speed ?? null,
+        order: (orderVal === undefined) ? null : orderVal,
+        us: (usVal === undefined) ? null : usVal,
+        avail: null,
+        days: null
+      };
+      computeDerived(row);
+      return row;
+    });
+
     const threshold = Math.max(1, Number(daysThresholdEl.value || 180));
     const reorder = h10Rows
       .filter(r => r.days !== null && r.days <= threshold && r.speed !== null && r.speed > 0)
@@ -1034,6 +1128,7 @@ function getDiscontinuedReason(sku) {
 
     mainRowsAll = h10Rows;
     reorderRowsAll = reorder;
+    hotRowsAll = hotRows;
     newOrderRowsAll = newOrder;
     newUSRowsAll = newUS;
     window.availMap = new Map(h10Rows.map(r => [r.sku, (r.avail ?? 0)]));
@@ -1047,6 +1142,7 @@ function getDiscontinuedReason(sku) {
   function renderAll() {
     renderReorder();
     renderMain();
+    renderHot();
     renderNewOrder();
     renderNewUS();
   }
@@ -1118,6 +1214,35 @@ function getDiscontinuedReason(sku) {
     }
   }
 
+  function addHotRowsToGenerator() {
+    const rows = applyFilters(hotRowsAll);
+    if (rows.length === 0) {
+      showTip('目前沒有可加入的熱銷品', 'error');
+      return;
+    }
+    const missing = [];
+    const skipped = [];
+    rows.forEach(row => {
+      if (isDiscontinuedSku(row.sku)) {
+        skipped.push(row.sku);
+        return;
+      }
+      const prod = getProductSpecByCode(row.sku);
+      if (!prod) {
+        missing.push(row.sku);
+        return;
+      }
+      const qty = (row.order !== null && Number.isFinite(row.order)) ? row.order : null;
+      addProduct(prod, qty);
+    });
+    if (missing.length) {
+      showTip(`以下 SKU 找不到品項資料：${missing.join(', ')}`, 'error');
+    }
+    if (skipped.length) {
+      showTip(`停產品項未加入訂單產生器：${skipped.join(', ')}`, 'error');
+    }
+  }
+
   function renderMain() {
     const rows = applyFilters(mainRowsAll);
     if (rows.length === 0) { mainWrap.innerHTML = ""; return; }
@@ -1141,6 +1266,40 @@ function getDiscontinuedReason(sku) {
     }).join("");
 
     mainWrap.innerHTML = `
+      <table>
+        <thead>
+          <tr>
+            <th>#</th><th>SKU</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可銷售天數</th>
+          </tr>
+        </thead>
+        <tbody>${body}</tbody>
+      </table>
+    `;
+  }
+
+  function renderHot() {
+    const rows = applyFilters(hotRowsAll);
+    countHotEl.textContent = String(rows.length);
+    if (rows.length === 0) { hotWrap.innerHTML = ""; return; }
+
+    const body = rows.map((r, idx) => {
+      const speedCell = (r.speed === null) ? `<td class="bad">(未抓到)</td>` : `<td class="ok">${escapeHtml(String(r.speed))}</td>`;
+      const orderCell = (r.order === null) ? `<td class="bad">(未對應)</td>` : `<td class="ok">${escapeHtml(String(r.order))}</td>`;
+      const usCell = (r.us === null) ? `<td class="bad">(未對應)</td>` : `<td class="ok">${escapeHtml(String(r.us))}</td>`;
+      const daysCell = (r.days === null) ? `<td class="bad">(不可算)</td>` : `<td class="ok">${escapeHtml(fmtDays(r.days))}</td>`;
+      return `
+        <tr>
+          <td>${idx + 1}</td>
+          ${renderSkuCell(r.sku)}
+          ${speedCell}
+          ${orderCell}
+          ${usCell}
+          ${daysCell}
+        </tr>
+      `;
+    }).join("");
+
+    hotWrap.innerHTML = `
       <table>
         <thead>
           <tr>
@@ -1314,6 +1473,10 @@ function getDiscontinuedReason(sku) {
 
   document.getElementById("btnAddReorderToGenerator").addEventListener("click", () => {
     addReorderRowsToGenerator();
+  });
+
+  document.getElementById("btnAddHotToGenerator").addEventListener("click", () => {
+    addHotRowsToGenerator();
   });
 
   document.getElementById("btnDownloadNewOrderCSV").addEventListener("click", () => {
@@ -1760,12 +1923,21 @@ const allProducts = [
       }
     }
 
-    function applyDiscontinuedRowState(row, code) {
+    function applySkuRowState(row, code) {
       if (!row) return;
       const discontinued = isDiscontinuedSku(code);
+      const hot = isHotSku(code);
       const skuCell = row.cells[1];
       if (skuCell) {
         skuCell.classList.toggle('discontinued-text', discontinued);
+        skuCell.classList.toggle('hot-text', hot);
+        const hotTag = skuCell.querySelector('.hot-tag');
+        if (hot && !hotTag) {
+          skuCell.insertAdjacentHTML('beforeend', ' <span class="hot-tag">熱銷品</span>');
+        }
+        if (!hot && hotTag) {
+          hotTag.remove();
+        }
         const tag = skuCell.querySelector('.discontinued-tag');
         if (discontinued && !tag) {
           skuCell.insertAdjacentHTML('beforeend', ' <span class="discontinued-tag">停產</span>');
@@ -1780,7 +1952,7 @@ const allProducts = [
       const tbody = document.querySelector('#productTable tbody');
       const existingRow = Array.from(tbody.querySelectorAll('tr')).find(r => r.dataset.product === prod.productCode);
       if(existingRow){
-        applyDiscontinuedRowState(existingRow, prod.productCode);
+        applySkuRowState(existingRow, prod.productCode);
         if (quantity !== null && Number.isFinite(quantity)) {
           const qtyInput = existingRow.querySelector('.edit-quantity-input');
           if (qtyInput) {
@@ -1825,7 +1997,7 @@ const allProducts = [
       </tr>`;
       tbody.insertAdjacentHTML('beforeend', rowHTML);
       const newRow = tbody.lastElementChild;
-      applyDiscontinuedRowState(newRow, prod.productCode);
+      applySkuRowState(newRow, prod.productCode);
       updateRowNumbers();
       if (quantity !== null && Number.isFinite(quantity)) {
         const qtyInput = newRow.querySelector('.edit-quantity-input');


### PR DESCRIPTION
### Motivation
- 讓使用者能快速辨識並操作一組指定的熱銷 SKU（類似現有的「停產」標記），提高下單效率。 

### Description
- 在 `index.html` 新增熱銷 SKU 清單 `hotSkuList`、`isHotSku` 判斷函式與對應的 CSS 樣式（`hot-text` / `hot-tag`），同時保留停產標記。 
- 在主介面於「主表（H10 產品）」與「新品（訂單有，但 H10 沒有）」之間插入「熱銷品專區」的 UI 區塊（包含數量計數與表格容器）。 
- 新增 Hot-row 資料產生流程與渲染函式 `renderHot()`，並把 hot 資料併入 `renderAll()` 更新流程。 
- 新增 `addHotRowsToGenerator()`，並把按鈕 `btnAddHotToGenerator` 綁定到該動作；同時將原本只處理停產的 row 狀態函式改為 `applySkuRowState()`，可同時顯示熱銷與停產標籤；所有變更都在 `index.html` 中實作。 

### Testing
- 啟動內建靜態 HTTP 伺服器以檢視變更（`python -m http.server`），伺服器成功啟動。 
- 嘗試使用 Playwright 擷取頁面截圖作為自動化檢視，但瀏覽器程序崩潰（SIGSEGV），截圖流程失敗。 
- 未執行單元測試或其他自動化驗證；已將變更加入版本控制（commit）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b000a7588325a17b5e07bf604d22)