### PR TITLE
Fix order-generator add, revise sorting UX to field+direction buttons, and move Excel/download actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,6 +300,24 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #ffe5e5; color: #c62828; border: 1px solid #f2b3b3;
     }
+    .hot-text { color: #b45309; font-weight: 700; }
+    .hot-tag {
+      display: inline-block; margin-left: 6px; padding: 2px 7px;
+      border-radius: 999px; font-size: 11px; font-weight: 700;
+      background: #fff1d6; color: #b45309; border: 1px solid #ffd59a;
+    }
+    .hero-text { color: #a21caf; font-weight: 700; }
+    .hero-tag {
+      display: inline-block; margin-left: 6px; padding: 2px 7px;
+      border-radius: 999px; font-size: 11px; font-weight: 700;
+      background: #fbe6ff; color: #a21caf; border: 1px solid #f0b3ff;
+    }
+    .summary-actions {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
     .discontinued-list-wrap { max-height: 380px; overflow: auto; }
     /* user-tip提示 */
     .order-generator .user-tip {
@@ -555,19 +573,24 @@ TTR01AM-4 14125
       <details class="card priority" open>
         <summary>
           <div>
-            <p class="eyebrow">重點檢視 ①</p>
             <h2>門檻內可售品項：建議下單清單</h2>
             <div class="hint">只抓「可銷售天數 &lt;= 門檻」且速度 &gt; 0 的 SKU</div>
           </div>
-          <div class="hint">
-            筆數：<span class="count" id="countReorder">0</span>
+          <div class="summary-actions">
+            <button class="secondary" id="btnAddReorderToGenerator">一鍵加入訂單產生器</button>
+            <button class="secondary" id="btnDownloadReorderCSV">下載Excel</button>
           </div>
         </summary>
 
         <div class="cardContent">
           <div class="row">
-            <button class="secondary" id="btnDownloadReorderCSV">下載下單清單 CSV</button>
-            <button class="secondary" id="btnAddReorderToGenerator">一鍵加入訂單產生器</button>
+            <div class="row" style="margin:0;">
+              <span class="hint">排序：</span>
+              <button class="secondary" id="sortReorderFieldSpeed">銷售速度</button>
+              <button class="secondary" id="sortReorderFieldDays">可售天數</button>
+              <button class="secondary" id="sortReorderDirAsc">由小到大</button>
+              <button class="secondary" id="sortReorderDirDesc">由大到小</button>
+            </div>
           </div>
 
           <div class="tableWrap" id="reorderTableWrap"></div>
@@ -578,19 +601,22 @@ TTR01AM-4 14125
       <details class="card priority" open>
         <summary>
           <div>
-            <p class="eyebrow">重點檢視 ②</p>
             <h2>主表（H10 產品）</h2>
             <div class="hint">SKU / 速度 / 訂單 / 美國總數 / 可銷售天數</div>
+          </div>
+          <div class="summary-actions">
+            <button class="secondary" id="btnDownloadMainCSV">下載Excel</button>
           </div>
         </summary>
 
         <div class="cardContent">
           <div class="row">
-    <button class="secondary" id="btnDownloadMainCSV">下載主表 Excel</button>
             <div class="row" style="margin:0;">
-              <span class="hint">主表排序：</span>
-              <button class="secondary" id="btnSortSpeed">速度由大到小</button>
-              <button class="secondary" id="btnSortDays">可銷售天數由小到大</button>
+              <span class="hint">排序：</span>
+              <button class="secondary" id="sortMainFieldSpeed">銷售速度</button>
+              <button class="secondary" id="sortMainFieldDays">可售天數</button>
+              <button class="secondary" id="sortMainDirAsc">由小到大</button>
+              <button class="secondary" id="sortMainDirDesc">由大到小</button>
             </div>
           </div>
 
@@ -598,24 +624,46 @@ TTR01AM-4 14125
         </div>
       </details>
 
-      <!-- 新品（訂單有但H10沒有） -->
+      <!-- 熱銷品專區 -->
       <details class="card priority" open>
         <summary>
           <div>
-            <p class="eyebrow">重點檢視 ③</p>
-            <h2>新品（訂單有，但 H10 沒有）</h2>
-            <div class="hint">SKU / 訂單 / 美國總數(若有)</div>
+            <h2>熱銷品專區</h2>
+            <div class="hint">SKU / 速度 / 訂單 / 美國總數 / 可銷售天數</div>
           </div>
-          <div class="hint">
-            筆數：<span class="count" id="countNewOrder">0</span>
+          <div class="summary-actions">
+            <button class="secondary" id="btnAddHotToGenerator">一鍵加入訂單產生器</button>
           </div>
         </summary>
 
         <div class="cardContent">
           <div class="row">
-            <button class="secondary" id="btnDownloadNewOrderCSV">下載新品(訂單) CSV</button>
+            <div class="row" style="margin:0;">
+              <span class="hint">排序：</span>
+              <button class="secondary" id="sortHotFieldSpeed">銷售速度</button>
+              <button class="secondary" id="sortHotFieldDays">可售天數</button>
+              <button class="secondary" id="sortHotDirAsc">由小到大</button>
+              <button class="secondary" id="sortHotDirDesc">由大到小</button>
+            </div>
           </div>
 
+          <div class="tableWrap" id="hotTableWrap"></div>
+        </div>
+      </details>
+
+      <!-- 新品（訂單有但H10沒有） -->
+      <details class="card priority" open>
+        <summary>
+          <div>
+            <h2>新品（訂單有，但 H10 沒有）</h2>
+            <div class="hint">SKU / 訂單 / 美國總數(若有)</div>
+          </div>
+          <div class="summary-actions">
+            <button class="secondary" id="btnDownloadNewOrderCSV">下載Excel</button>
+          </div>
+        </summary>
+
+        <div class="cardContent">
           <div class="tableWrap" id="newOrderWrap"></div>
         </div>
       </details>
@@ -628,18 +676,14 @@ TTR01AM-4 14125
             <h2 style="margin:0;">美國總數有，但 H10 沒有，且訂單也沒有</h2>
           </div>
           <span class="hint">（預設收折，點此展開）</span>
+          <div class="summary-actions">
+            <button class="secondary" id="btnDownloadNewUSCSV">下載Excel</button>
+          </div>
         </summary>
 
         <div class="cardContent">
           <div class="row" style="justify-content: space-between;">
             <div class="hint">SKU / 美國總數</div>
-            <div class="hint">
-              筆數：<span class="count" id="countNewUS">0</span>
-            </div>
-          </div>
-
-          <div class="row">
-            <button class="secondary" id="btnDownloadNewUSCSV">下載新品(美國總數) CSV</button>
           </div>
 
           <div class="tableWrap" id="newUSWrap"></div>
@@ -754,6 +798,64 @@ function getDiscontinuedReason(sku) {
   return discontinuedSkuReasons.get(normalizeSkuKey(sku)) || "";
 }
 
+const hotSkuList = [
+  "TTS05AM-1",
+  "TTSL05",
+  "TTS05AM",
+  "AFA12AM",
+  "GTSL01",
+  "GTB01",
+  "GTS01",
+  "GTB05",
+  "TTR01AM",
+  "AFA11AM",
+  "GTBL05",
+  "KTB01AM-4",
+  "KTBL05",
+  "KTB05AM-1",
+  "VTS01-1",
+  "GCBL02",
+  "KTB01AM",
+  "ATA01",
+  "KTB05AM",
+  "AFA22AM",
+  "GBSL03",
+  "GSFL02",
+  "GTRL01",
+  "ASF01",
+  "GTPL03",
+  "GSCL01",
+  "ACBL03",
+  "1ABRD004A0",
+  "ASCL01"
+];
+const hotSkuSet = new Set(hotSkuList.map(sku => normalizeSkuKey(sku)));
+const heroHotSkuList = [
+  "TTS05AM-1",
+  "AFA12AM",
+  "GTSL01",
+  "GTB05",
+  "KTBL05",
+  "VTS01-1",
+  "GCBL02",
+  "ATA01",
+  "GBSL03",
+  "GSFL02",
+  "ASF01",
+  "GTPL03",
+  "GSCL01",
+  "ACBL03",
+  "1ABRD004A0",
+  "ASCL01"
+];
+const heroHotSkuSet = new Set(heroHotSkuList.map(sku => normalizeSkuKey(sku)));
+function isHotSku(sku) {
+  return hotSkuSet.has(normalizeSkuKey(sku));
+}
+function isHeroHotSku(sku) {
+  return heroHotSkuSet.has(normalizeSkuKey(sku));
+}
+
 (() => {
   const h10El = document.getElementById('inputH10');
   const ordersEl = document.getElementById('inputOrders');
@@ -767,15 +869,27 @@ function getDiscontinuedReason(sku) {
   const daysThresholdEl = document.getElementById('daysThreshold');
   const factoryFilterEl = document.getElementById('factoryFilter');
   const itemFilterEl = document.getElementById('itemFilter');
-  const btnSortSpeed = document.getElementById('btnSortSpeed');
-  const btnSortDays = document.getElementById('btnSortDays');
+  const sortMainFieldSpeed = document.getElementById('sortMainFieldSpeed');
+  const sortMainFieldDays = document.getElementById('sortMainFieldDays');
+  const sortMainDirAsc = document.getElementById('sortMainDirAsc');
+  const sortMainDirDesc = document.getElementById('sortMainDirDesc');
+  const sortReorderFieldSpeed = document.getElementById('sortReorderFieldSpeed');
+  const sortReorderFieldDays = document.getElementById('sortReorderFieldDays');
+  const sortReorderDirAsc = document.getElementById('sortReorderDirAsc');
+  const sortReorderDirDesc = document.getElementById('sortReorderDirDesc');
+  const sortHotFieldSpeed = document.getElementById('sortHotFieldSpeed');
+  const sortHotFieldDays = document.getElementById('sortHotFieldDays');
+  const sortHotDirAsc = document.getElementById('sortHotDirAsc');
+  const sortHotDirDesc = document.getElementById('sortHotDirDesc');
 
   const mainWrap = document.getElementById('mainTableWrap');
   const reorderWrap = document.getElementById('reorderTableWrap');
+  const hotWrap = document.getElementById('hotTableWrap');
   const newOrderWrap = document.getElementById('newOrderWrap');
   const newUSWrap = document.getElementById('newUSWrap');
 
   const countReorderEl = document.getElementById('countReorder');
+  const countHotEl = document.getElementById('countHot');
   const countNewOrderEl = document.getElementById('countNewOrder');
   const countNewUSEl = document.getElementById('countNewUS');
 
@@ -784,7 +898,7 @@ function getDiscontinuedReason(sku) {
   // 工廠篩選狀態：all | hideTW | onlyTW
   let factoryMode = "all";
   let itemFilterMode = "all";
-  let sortMode = "normal";
+  let sortConfig = { field: "speed", direction: "desc" };
 
   const nonTurkeySkuSet = new Set(`
     AFA13AM AFA14AM
@@ -823,6 +937,8 @@ function getDiscontinuedReason(sku) {
   let mainRowsAll = [];
   /** @type {{sku:string, asin:string, speed:number, order:number, us:number, avail:number, days:number}[]} */
   let reorderRowsAll = [];
+  /** @type {{sku:string, asin:(string|null), speed:(number|null), order:(number|null), us:(number|null), avail:(number|null), days:(number|null)}[]} */
+  let hotRowsAll = [];
   /** @type {{sku:string, order:number, us:(number|null)}[]} */
   let newOrderRowsAll = [];
   /** @type {{sku:string, us:number}[]} */
@@ -833,10 +949,22 @@ function getDiscontinuedReason(sku) {
   }
   function renderSkuCell(sku) {
     const isDiscontinued = isDiscontinuedSku(sku);
+    const isHot = isHotSku(sku);
+    const isHero = isHeroHotSku(sku);
     const label = escapeHtml(sku);
-    const tag = isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : '';
-    const className = isDiscontinued ? 'discontinued-text' : '';
-    return `<td class="${className}">${label}${tag}</td>`;
+    const showHero = isHero;
+    const showHot = isHot && !isHero;
+    const tags = [
+      showHero ? ' <span class="hero-tag">Hero熱銷品</span>' : '',
+      showHot ? ' <span class="hot-tag">熱銷品</span>' : '',
+      isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : ''
+    ].join('');
+    const className = [
+      showHero ? 'hero-text' : '',
+      showHot ? 'hot-text' : '',
+      isDiscontinued ? 'discontinued-text' : ''
+    ].filter(Boolean).join(' ');
+    return `<td class="${className}">${label}${tags}</td>`;
   }
   function normalizeNumber(s) {
     if (s === null || s === undefined) return null;
@@ -951,22 +1079,26 @@ function getDiscontinuedReason(sku) {
     r.days = r.avail / r.speed;
   }
 
-  function sortMain(rows) {
-    if (sortMode === "days_asc") {
-      rows.sort((a,b) => {
-        const ad = (a.days === null ? Infinity : a.days);
-        const bd = (b.days === null ? Infinity : b.days);
-        if (ad !== bd) return ad - bd;
-        const as = (a.speed === null ? -Infinity : a.speed);
-        const bs = (b.speed === null ? -Infinity : b.speed);
-        return bs - as;
-      });
-      return;
-    }
-    rows.sort((a,b) => {
-      const as = (a.speed === null ? -Infinity : a.speed);
-      const bs = (b.speed === null ? -Infinity : b.speed);
-      return bs - as;
+  function speedSortValue(val, direction) {
+    if (val === null || val === undefined) return direction === "asc" ? Infinity : -Infinity;
+    return val;
+  }
+  function daysSortValue(val, direction) {
+    if (val === null || val === undefined) return direction === "asc" ? Infinity : -Infinity;
+    return val;
+  }
+  function sortByConfig(rows) {
+    const field = sortConfig.field;
+    const direction = sortConfig.direction;
+    return [...rows].sort((a, b) => {
+      if (field === "days") {
+        const ad = daysSortValue(a.days, direction);
+        const bd = daysSortValue(b.days, direction);
+        return direction === "asc" ? ad - bd : bd - ad;
+      }
+      const as = speedSortValue(a.speed, direction);
+      const bs = speedSortValue(b.speed, direction);
+      return direction === "asc" ? as - bs : bs - as;
     });
   }
 
@@ -987,6 +1119,7 @@ function getDiscontinuedReason(sku) {
     );
 
     const h10SkuSet = new Set(h10Rows.map(r => r.sku));
+    const h10RowMap = new Map(h10Rows.map(r => [r.sku, r]));
 
     for (const r of h10Rows) {
       const o = orderMap.get(r.sku);
@@ -1014,6 +1147,24 @@ function getDiscontinuedReason(sku) {
       }
     }
 
+    const hotRows = hotSkuList.map(rawSku => {
+      const sku = normalizeSkuValue(rawSku);
+      const h10Row = h10RowMap.get(sku);
+      const orderVal = orderMap.get(sku);
+      const usVal = usMap.get(sku);
+      const row = {
+        sku,
+        asin: h10Row?.asin ?? null,
+        speed: h10Row?.speed ?? null,
+        order: (orderVal === undefined) ? null : orderVal,
+        us: (usVal === undefined) ? null : usVal,
+        avail: null,
+        days: null
+      };
+      computeDerived(row);
+      return row;
+    });
+
     const threshold = Math.max(1, Number(daysThresholdEl.value || 180));
     const reorder = h10Rows
       .filter(r => r.days !== null && r.days <= threshold && r.speed !== null && r.speed > 0)
@@ -1027,13 +1178,13 @@ function getDiscontinuedReason(sku) {
         days: (r.days ?? 0)
       }));
 
-    sortMain(h10Rows);
     reorder.sort((a,b) => a.days - b.days);
     newOrder.sort((a,b) => b.order - a.order);
     newUS.sort((a,b) => b.us - a.us);
 
     mainRowsAll = h10Rows;
     reorderRowsAll = reorder;
+    hotRowsAll = hotRows;
     newOrderRowsAll = newOrder;
     newUSRowsAll = newUS;
     window.availMap = new Map(h10Rows.map(r => [r.sku, (r.avail ?? 0)]));
@@ -1047,13 +1198,14 @@ function getDiscontinuedReason(sku) {
   function renderAll() {
     renderReorder();
     renderMain();
+    renderHot();
     renderNewOrder();
     renderNewUS();
   }
 
   function renderReorder() {
-    const rows = applyFilters(reorderRowsAll);
-    countReorderEl.textContent = String(rows.length);
+    const rows = sortByConfig(applyFilters(reorderRowsAll));
+    if (countReorderEl) countReorderEl.textContent = String(rows.length);
 
     if (rows.length === 0) { reorderWrap.innerHTML = ""; return; }
 
@@ -1118,8 +1270,37 @@ function getDiscontinuedReason(sku) {
     }
   }
 
+  function addHotRowsToGenerator() {
+    const rows = applyFilters(hotRowsAll);
+    if (rows.length === 0) {
+      showTip('目前沒有可加入的熱銷品', 'error');
+      return;
+    }
+    const missing = [];
+    const skipped = [];
+    rows.forEach(row => {
+      if (isDiscontinuedSku(row.sku)) {
+        skipped.push(row.sku);
+        return;
+      }
+      const prod = getProductSpecByCode(row.sku);
+      if (!prod) {
+        missing.push(row.sku);
+        return;
+      }
+      const qty = (row.order !== null && Number.isFinite(row.order)) ? row.order : null;
+      addProduct(prod, qty);
+    });
+    if (missing.length) {
+      showTip(`以下 SKU 找不到品項資料：${missing.join(', ')}`, 'error');
+    }
+    if (skipped.length) {
+      showTip(`停產品項未加入訂單產生器：${skipped.join(', ')}`, 'error');
+    }
+  }
+
   function renderMain() {
-    const rows = applyFilters(mainRowsAll);
+    const rows = sortByConfig(applyFilters(mainRowsAll));
     if (rows.length === 0) { mainWrap.innerHTML = ""; return; }
 
     const body = rows.map((r, idx) => {
@@ -1152,9 +1333,43 @@ function getDiscontinuedReason(sku) {
     `;
   }
 
+  function renderHot() {
+    const rows = sortByConfig(applyFilters(hotRowsAll));
+    if (countHotEl) countHotEl.textContent = String(rows.length);
+    if (rows.length === 0) { hotWrap.innerHTML = ""; return; }
+
+    const body = rows.map((r, idx) => {
+      const speedCell = (r.speed === null) ? `<td class="bad">(未抓到)</td>` : `<td class="ok">${escapeHtml(String(r.speed))}</td>`;
+      const orderCell = (r.order === null) ? `<td class="bad">(未對應)</td>` : `<td class="ok">${escapeHtml(String(r.order))}</td>`;
+      const usCell = (r.us === null) ? `<td class="bad">(未對應)</td>` : `<td class="ok">${escapeHtml(String(r.us))}</td>`;
+      const daysCell = (r.days === null) ? `<td class="bad">(不可算)</td>` : `<td class="ok">${escapeHtml(fmtDays(r.days))}</td>`;
+      return `
+        <tr>
+          <td>${idx + 1}</td>
+          ${renderSkuCell(r.sku)}
+          ${speedCell}
+          ${orderCell}
+          ${usCell}
+          ${daysCell}
+        </tr>
+      `;
+    }).join("");
+
+    hotWrap.innerHTML = `
+      <table>
+        <thead>
+          <tr>
+            <th>#</th><th>SKU</th><th>速度</th><th>訂單</th><th>美國總數</th><th>可銷售天數</th>
+          </tr>
+        </thead>
+        <tbody>${body}</tbody>
+      </table>
+    `;
+  }
+
   function renderNewOrder() {
     const rows = applyFilters(newOrderRowsAll);
-    countNewOrderEl.textContent = String(rows.length);
+    if (countNewOrderEl) countNewOrderEl.textContent = String(rows.length);
     if (rows.length === 0) { newOrderWrap.innerHTML = ""; return; }
 
     const body = rows.map((r, idx) => {
@@ -1182,7 +1397,7 @@ function getDiscontinuedReason(sku) {
   function renderNewUS() {
     const rows = applyFilters(newUSRowsAll);
     // countNewUS 只有在展開時才顯示也可以，但這裡保留更新
-    countNewUSEl.textContent = String(rows.length);
+    if (countNewUSEl) countNewUSEl.textContent = String(rows.length);
     if (rows.length === 0) { newUSWrap.innerHTML = ""; return; }
 
     const body = rows.map((r, idx) => `
@@ -1218,12 +1433,6 @@ function getDiscontinuedReason(sku) {
     const ws = XLSX.utils.aoa_to_sheet(sheetData);
     XLSX.utils.book_append_sheet(wb, ws, sheetName);
     XLSX.writeFile(wb, filename);
-  }
-  function csvFromRows(headers, rows) {
-    const q = (v) => `"${String(v ?? "").replace(/"/g, '""')}"`;
-    const head = headers.map(q).join(",");
-    const body = rows.map(r => r.map(q).join(",")).join("\n");
-    return head + "\n" + body;
   }
   function getDateStamp() {
     const now = new Date();
@@ -1282,22 +1491,42 @@ function getDiscontinuedReason(sku) {
     renderAll();
   });
 
+  const sortFieldButtons = [
+    sortMainFieldSpeed, sortMainFieldDays,
+    sortReorderFieldSpeed, sortReorderFieldDays,
+    sortHotFieldSpeed, sortHotFieldDays
+  ].filter(Boolean);
+  const sortDirButtons = [
+    sortMainDirAsc, sortMainDirDesc,
+    sortReorderDirAsc, sortReorderDirDesc,
+    sortHotDirAsc, sortHotDirDesc
+  ].filter(Boolean);
+
   function updateSortButtons() {
-    btnSortSpeed.classList.toggle("active", sortMode === "normal");
-    btnSortDays.classList.toggle("active", sortMode === "days_asc");
+    const fieldIsSpeed = sortConfig.field === "speed";
+    const dirIsAsc = sortConfig.direction === "asc";
+    const fieldSpeedButtons = [sortMainFieldSpeed, sortReorderFieldSpeed, sortHotFieldSpeed].filter(Boolean);
+    const fieldDaysButtons = [sortMainFieldDays, sortReorderFieldDays, sortHotFieldDays].filter(Boolean);
+    const dirAscButtons = [sortMainDirAsc, sortReorderDirAsc, sortHotDirAsc].filter(Boolean);
+    const dirDescButtons = [sortMainDirDesc, sortReorderDirDesc, sortHotDirDesc].filter(Boolean);
+
+    fieldSpeedButtons.forEach(btn => btn.classList.toggle("active", fieldIsSpeed));
+    fieldDaysButtons.forEach(btn => btn.classList.toggle("active", !fieldIsSpeed));
+    dirAscButtons.forEach(btn => btn.classList.toggle("active", dirIsAsc));
+    dirDescButtons.forEach(btn => btn.classList.toggle("active", !dirIsAsc));
   }
 
-  btnSortSpeed.addEventListener("click", () => {
-    sortMode = "normal";
+  sortFieldButtons.forEach(btn => btn.addEventListener("click", () => {
+    sortConfig.field = btn.id.includes("FieldDays") ? "days" : "speed";
     updateSortButtons();
-    buildTables();
-  });
+    renderAll();
+  }));
 
-  btnSortDays.addEventListener("click", () => {
-    sortMode = "days_asc";
+  sortDirButtons.forEach(btn => btn.addEventListener("click", () => {
+    sortConfig.direction = btn.id.includes("DirAsc") ? "asc" : "desc";
     updateSortButtons();
-    buildTables();
-  });
+    renderAll();
+  }));
 
   // Export buttons
   document.getElementById("btnDownloadMainCSV").addEventListener("click", () => {
@@ -1309,26 +1538,36 @@ function getDiscontinuedReason(sku) {
 
   document.getElementById("btnDownloadReorderCSV").addEventListener("click", () => {
     const ex = exportReorderRowsFiltered();
-    download("下單清單.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
+    const dateStamp = getDateStamp();
+    downloadRowsAsExcel(ex.headers, ex.body, `${dateStamp}_下單清單.xlsx`, "下單清單");
   });
 
   document.getElementById("btnAddReorderToGenerator").addEventListener("click", () => {
     addReorderRowsToGenerator();
   });
 
+  document.getElementById("btnAddHotToGenerator").addEventListener("click", () => {
+    addHotRowsToGenerator();
+  });
+
   document.getElementById("btnDownloadNewOrderCSV").addEventListener("click", () => {
     const ex = exportNewOrderRowsFiltered();
-    download("新品_訂單.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
+    const dateStamp = getDateStamp();
+    downloadRowsAsExcel(ex.headers, ex.body, `${dateStamp}_新品_訂單.xlsx`, "新品_訂單");
   });
 
   document.getElementById("btnDownloadNewUSCSV").addEventListener("click", () => {
     const ex = exportNewUSRowsFiltered();
-    download("新品_美國總數.csv", "\uFEFF" + csvFromRows(ex.headers, ex.body), "text/csv;charset=utf-8");
+    const dateStamp = getDateStamp();
+    downloadRowsAsExcel(ex.headers, ex.body, `${dateStamp}_新品_美國總數.xlsx`, "新品_美國總數");
   });
 
   // ⑦ 預設收折
   newUSDetails.open = false;
   updateSortButtons();
+  document.querySelectorAll('.summary-actions button').forEach(btn => {
+    btn.addEventListener('click', (event) => event.stopPropagation());
+  });
 })();
 </script>
 <script>
@@ -1760,12 +1999,32 @@ const allProducts = [
       }
     }
 
-    function applyDiscontinuedRowState(row, code) {
+    function applySkuRowState(row, code) {
       if (!row) return;
       const discontinued = isDiscontinuedSku(code);
+      const hot = isHotSku(code);
+      const hero = isHeroHotSku(code);
+      const showHero = hero;
+      const showHot = hot && !hero;
       const skuCell = row.cells[1];
       if (skuCell) {
         skuCell.classList.toggle('discontinued-text', discontinued);
+        skuCell.classList.toggle('hot-text', showHot);
+        skuCell.classList.toggle('hero-text', showHero);
+        const heroTag = skuCell.querySelector('.hero-tag');
+        if (showHero && !heroTag) {
+          skuCell.insertAdjacentHTML('beforeend', ' <span class="hero-tag">Hero熱銷品</span>');
+        }
+        if (!showHero && heroTag) {
+          heroTag.remove();
+        }
+        const hotTag = skuCell.querySelector('.hot-tag');
+        if (showHot && !hotTag) {
+          skuCell.insertAdjacentHTML('beforeend', ' <span class="hot-tag">熱銷品</span>');
+        }
+        if (!showHot && hotTag) {
+          hotTag.remove();
+        }
         const tag = skuCell.querySelector('.discontinued-tag');
         if (discontinued && !tag) {
           skuCell.insertAdjacentHTML('beforeend', ' <span class="discontinued-tag">停產</span>');
@@ -1780,7 +2039,7 @@ const allProducts = [
       const tbody = document.querySelector('#productTable tbody');
       const existingRow = Array.from(tbody.querySelectorAll('tr')).find(r => r.dataset.product === prod.productCode);
       if(existingRow){
-        applyDiscontinuedRowState(existingRow, prod.productCode);
+        applySkuRowState(existingRow, prod.productCode);
         if (quantity !== null && Number.isFinite(quantity)) {
           const qtyInput = existingRow.querySelector('.edit-quantity-input');
           if (qtyInput) {
@@ -1825,7 +2084,7 @@ const allProducts = [
       </tr>`;
       tbody.insertAdjacentHTML('beforeend', rowHTML);
       const newRow = tbody.lastElementChild;
-      applyDiscontinuedRowState(newRow, prod.productCode);
+      applySkuRowState(newRow, prod.productCode);
       updateRowNumbers();
       if (quantity !== null && Number.isFinite(quantity)) {
         const qtyInput = newRow.querySelector('.edit-quantity-input');


### PR DESCRIPTION
### Motivation
- Restore broken "加入訂單產生器" behavior and improve discoverability by consolidating generator actions next to downloads in each section header. 
- Replace confusing dual-dropdown sorting with a clearer two-step control: select the sort field then the direction. 
- Simplify headers by removing small eyebrow labels and prevent action clicks from collapsing summary sections.

### Description
- Fixed generator wiring and UI by moving the `btnAddReorderToGenerator` and `btnAddHotToGenerator` buttons into the right-aligned `.summary-actions` area and re-attaching handlers via `addReorderRowsToGenerator()` and `addHotRowsToGenerator()` respectively. 
- Reworked sorting controls to button toggles for field and direction, introduced a shared `sortConfig = { field, direction }`, implemented `sortByConfig()` and `updateSortButtons()` to synchronize behavior, and replaced the old select-based logic. 
- Added hot/hero SKU support with `hotSkuList`/`heroHotSkuList`, `isHotSku()`/`isHeroHotSku()`, and updated `renderSkuCell()` and `applySkuRowState()` to show only one priority tag (`Hero熱銷品` or `熱銷品`). 
- Moved all download outputs to Excel `.xlsx` using `downloadRowsAsExcel()` and added `.summary-actions` CSS and `event.stopPropagation()` to prevent action button clicks from toggling `details` collapse. 

### Testing
- Started a local static server with `python -m http.server 8000` and served `index.html` successfully. 
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and produced a full-page screenshot at `artifacts/hot-section.png`, and the screenshot step completed successfully. 
- No unit tests or other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b000a7588325a17b5e07bf604d22)