### PR TITLE
修正月曆區塊按「產生表格」未顯示結果並優化甘特圖顯示

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,12 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #fbe6ff; color: #a21caf; border: 1px solid #f0b3ff;
     }
+
+    .sales-link { font-size: 12px; color: #0b6bcb; text-decoration: none; font-weight: 600; }
+    .sales-link:hover { text-decoration: underline; }
+    .gantt-item-discontinued { color: #c62828; font-weight: 700; }
+    .gantt-item-hero { color: #a21caf; font-weight: 700; }
+    .gantt-item-hot { color: #b45309; font-weight: 700; }
     .summary-actions {
       margin-left: auto;
       display: flex;
@@ -604,7 +610,7 @@ TTR01AM-4 14125
         <summary>
           <div>
             <h2>門檻內可售品項：建議下單清單</h2>
-            <div class="hint">只抓「美國可售天數 &lt;= 門檻」且速度 &gt; 0 的 SKU</div>
+            <div class="hint">只抓「含訂單可售天數 &lt;= 門檻」且速度 &gt; 0 的 SKU</div>
           </div>
           <div class="summary-actions">
             <button class="secondary" id="btnAddReorderToGenerator">一鍵加入訂單產生器</button>
@@ -731,7 +737,7 @@ TTR01AM-4 14125
           <h2>銷售額圓餅圖</h2>
           <div class="hint">貼上「SKU + 訂購產品銷售額」資料，系統會依工廠與品項分類產生圓餅圖。</div>
         </div>
-        <span class="pill">可收合</span>
+        <div class="summary-actions"><a class="sales-link" href="https://sellercentral.amazon.com/business-reports/ref=xx_sitemetric_dnav_xx#/report?id=102%3ADetailSalesTrafficBySKU&chartCols=&columns=0%2F1%2F2%2F3%2F8%2F9%2F14%2F15%2F20%2F21%2F26%2F27%2F28%2F29%2F30%2F31%2F32%2F33%2F34%2F35%2F36%2F37" target="_blank" rel="noopener noreferrer">後台資料</a><span class="pill">可收合</span></div>
       </summary>
       <div class="cardContent">
         <div class="row">
@@ -779,20 +785,20 @@ TTR01AM-4 14125
             <label for="ganttDaysType">天數模式：</label>
             <select id="ganttDaysType">
               <option value="usDays">美國可售天數甘特圖</option>
-              <option value="days">含訂單可售天數甘特圖</option>
+              <option value="days" selected>含訂單可售天數甘特圖</option>
             </select>
             <label for="salesGanttFactory">工廠篩選：</label>
             <select id="salesGanttFactory">
               <option value="all">全部</option>
-              <option value="hideTW">越南廠（排除台灣廠）</option>
+              <option value="hideTW" selected>越南廠（排除台灣廠）</option>
               <option value="onlyTW">台灣廠</option>
             </select>
             <label for="salesGanttViewType">檢視模式：</label>
             <select id="salesGanttViewType">
-              <option value="table">甘特表格</option>
-              <option value="calendar">月曆檢視</option>
+              <option value="table">表格檢視</option>
+              <option value="calendar" selected>月曆檢視</option>
             </select>
-            <button id="btnBuildSalesGantt" class="secondary">產生甘特圖</button>
+            <button id="btnBuildSalesGantt">產生表格</button>
             <button id="btnExportSalesGantt" class="secondary">匯出 Excel</button>
           </div>
           <div class="tableWrap" id="salesGanttWrap"></div>
@@ -1199,7 +1205,7 @@ function isHeroHotSku(sku) {
 
     const threshold = Math.max(1, Number(daysThresholdEl.value || 180));
     const reorder = h10Rows
-      .filter(r => r.usDays !== null && r.usDays <= threshold && r.speed !== null && r.speed > 0)
+       .filter(r => r.days !== null && r.days <= threshold && r.speed !== null && r.speed > 0)
       .map(r => ({
         sku: r.sku,
         asin: r.asin,
@@ -1211,7 +1217,7 @@ function isHeroHotSku(sku) {
         days: (r.days ?? 0)
       }));
 
-    reorder.sort((a,b) => a.usDays - b.usDays);
+    reorder.sort((a,b) => a.days - b.days);
     newOrder.sort((a,b) => b.order - a.order);
 
     mainRowsAll = h10Rows;
@@ -1266,7 +1272,7 @@ function isHeroHotSku(sku) {
 
   function calculateReorderQuantity(row, thresholdDays) {
     const speed = Number(row.speed || 0);
-    const currentDays = Number(row.usDays || 0);
+    const currentDays = Number(row.days || 0);
     if (!speed || !Number.isFinite(speed)) return 0;
     const gapDays = Math.max(0, thresholdDays - currentDays);
     return Math.ceil(gapDays * speed);
@@ -2757,6 +2763,19 @@ const allProducts = [
       return { monthBuckets, mode, factoryMode };
     }
 
+
+    function getGanttSkuClassName(sku) {
+      if (isDiscontinuedSku(sku)) return 'gantt-item-discontinued';
+      if (isHeroHotSku(sku)) return 'gantt-item-hero';
+      if (isHotSku(sku)) return 'gantt-item-hot';
+      return '';
+    }
+
+    function formatGanttSkuLabel(sku) {
+      const cls = getGanttSkuClassName(sku);
+      return cls ? `<span class="${cls}">${escapeHtml(String(sku))}</span>` : escapeHtml(String(sku));
+    }
+
     function renderSalesCalendar(monthBuckets) {
       if (!salesCalendarWrapEl) return;
       const weekLabels = ['日', '一', '二', '三', '四', '五', '六'];
@@ -2770,7 +2789,7 @@ const allProducts = [
         m.items.forEach(item => {
           const day = item.outDate instanceof Date ? item.outDate.getDate() : Number(String(item.dateText).split('/')[1]);
           if (!events.has(day)) events.set(day, []);
-          events.get(day).push(item.sku);
+          events.get(day).push({ sku: item.sku, formatted: formatGanttSkuLabel(item.sku) });
         });
 
         const cells = [];
@@ -2779,13 +2798,14 @@ const allProducts = [
         }
         for (let day = 1; day <= daysInMonth; day += 1) {
           const skus = events.get(day) || [];
-          const preview = skus.slice(0, 2).join('、');
+          const preview = skus.slice(0, 2).map(entry => entry.formatted).join('、');
+          const titleText = skus.map(entry => entry.sku).join('、');
           const extra = skus.length > 2 ? ` +${skus.length - 2}` : '';
           cells.push(`
             <div class="salesDayCell ${skus.length ? 'hasEvent' : ''}">
               <div class="salesDayNum">${day}</div>
               ${skus.length ? `<div class="salesDayCount">${skus.length} 項</div>` : ''}
-              ${skus.length ? `<div class="salesDaySkus" title="${skus.join('、')}">${preview}${extra}</div>` : ''}
+              ${skus.length ? `<div class="salesDaySkus" title="${escapeHtml(titleText)}">${preview}${extra}</div>` : ''}
             </div>
           `);
         }
@@ -2809,7 +2829,7 @@ const allProducts = [
       const viewType = salesGanttViewTypeEl?.value || 'table';
       const body = monthBuckets.map(m => {
         const skuList = m.items.length
-          ? `<ul class="ganttSkuList">${m.items.map(i => `<li>${i.sku}（${i.dateText} 缺貨）</li>`).join('')}</ul>`
+          ? `<ul class="ganttSkuList">${m.items.map(i => `<li>${formatGanttSkuLabel(i.sku)}（${i.dateText} 缺貨）</li>`).join('')}</ul>`
           : '—';
         return `<tr><td>${m.label}</td><td class="count">${m.items.length}</td><td>${skuList}</td></tr>`;
       }).join('');
@@ -2867,7 +2887,10 @@ const allProducts = [
       btnBuildSalesCharts.addEventListener('click', buildSalesCharts);
     }
     if (btnBuildSalesGantt) {
-      btnBuildSalesGantt.addEventListener('click', renderSalesGantt);
+      btnBuildSalesGantt.addEventListener('click', () => {
+        if (salesGanttViewTypeEl) salesGanttViewTypeEl.value = 'table';
+        renderSalesGantt();
+      });
     }
     if (btnExportSalesGantt) {
       btnExportSalesGantt.addEventListener('click', exportSalesGanttExcel);


### PR DESCRIPTION
### Motivation
- 使用者在「銷售甘特圖 / 月曆」預設為月曆檢視時按下 `產生表格` 不會切回表格檢視，導致看不到表格結果。
- 同時需要改善甘特圖／月曆中的 SKU 顯示樣式與部分以天數為基準的篩選/計算邏輯以符合 UI 文案與行為預期。

### Description
- 將 `#btnBuildSalesGantt` 的 click 行為改為先將 `#salesGanttViewType` 強制設為 `table` 再呼叫 `renderSalesGantt()`，確保按鈕會顯示表格檢視。
- 更新 UI 文案與預設選項：將按鈕文字改為 `產生表格`，並針對 `ganttDaysType`、`salesGanttFactory`、`salesGanttViewType` 設定更合理的預設值與提示文字，並新增外部連結按鈕。
- 加入甘特圖 SKU 樣式支援與輸出格式化：新增 CSS 類別與輔助函式 `getGanttSkuClassName` 與 `formatGanttSkuLabel`，並在 `renderSalesCalendar` 與 `renderSalesGantt` 中把 SKU 加入樣式並安全地 escape title。 
- 調整以天數為基礎的篩選/排序與補貨計算：將原先使用 `usDays` 的篩選、排序與 `calculateReorderQuantity` 中的 `currentDays` 都改為使用 `days`，並同步更新表格顯示欄位與排序邏輯。 

### Testing
- 已執行 `git status --short` 與 `nl -ba index.html | sed -n '2884,2910p'` 以確認變更片段存在並核對行數，且已成功 `git commit` 變更。 
- 啟動靜態伺服器 `python3 -m http.server 4173 --directory /workspace/Supply` 並嘗試以 Playwright 自動化點擊驗證按鈕行為，但 Playwright 在本環境啟動 Chromium 時發生 SIGSEGV，導致瀏覽器端互動驗證失敗。 
- 因 Playwright 驗證失敗，互動行為尚未在瀏覽器環境中自動化通過，但所有靜態程式碼修改及跨函式引用已經檢視並提交。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698acf565ce48320a7182ca200fba53f)