### PR TITLE
移除「產生表格」按鈕，改為依選項自動顯示月曆/表格並調整下載按鈕位置

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,12 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #fbe6ff; color: #a21caf; border: 1px solid #f0b3ff;
     }
+
+    .sales-link { font-size: 12px; color: #0b6bcb; text-decoration: none; font-weight: 600; }
+    .sales-link:hover { text-decoration: underline; }
+    .gantt-item-discontinued { color: #c62828; font-weight: 700; }
+    .gantt-item-hero { color: #a21caf; font-weight: 700; }
+    .gantt-item-hot { color: #b45309; font-weight: 700; }
     .summary-actions {
       margin-left: auto;
       display: flex;
@@ -604,7 +610,7 @@ TTR01AM-4 14125
         <summary>
           <div>
             <h2>門檻內可售品項：建議下單清單</h2>
-            <div class="hint">只抓「美國可售天數 &lt;= 門檻」且速度 &gt; 0 的 SKU</div>
+            <div class="hint">只抓「含訂單可售天數 &lt;= 門檻」且速度 &gt; 0 的 SKU</div>
           </div>
           <div class="summary-actions">
             <button class="secondary" id="btnAddReorderToGenerator">一鍵加入訂單產生器</button>
@@ -731,7 +737,7 @@ TTR01AM-4 14125
           <h2>銷售額圓餅圖</h2>
           <div class="hint">貼上「SKU + 訂購產品銷售額」資料，系統會依工廠與品項分類產生圓餅圖。</div>
         </div>
-        <span class="pill">可收合</span>
+        <div class="summary-actions"><a class="sales-link" href="https://sellercentral.amazon.com/business-reports/ref=xx_sitemetric_dnav_xx#/report?id=102%3ADetailSalesTrafficBySKU&chartCols=&columns=0%2F1%2F2%2F3%2F8%2F9%2F14%2F15%2F20%2F21%2F26%2F27%2F28%2F29%2F30%2F31%2F32%2F33%2F34%2F35%2F36%2F37" target="_blank" rel="noopener noreferrer">後台資料</a><span class="pill">可收合</span></div>
       </summary>
       <div class="cardContent">
         <div class="row">
@@ -771,7 +777,10 @@ TTR01AM-4 14125
           <h2>銷售甘特圖 / 月曆（未來 12 個月）</h2>
           <div class="hint">獨立區塊顯示銷售甘特圖，支援表格與月曆檢視並可匯出 Excel。</div>
         </div>
-        <span class="pill">可收合</span>
+        <div class="summary-actions">
+          <button class="secondary" id="btnExportSalesGantt">下載Excel</button>
+          <span class="pill">可收合</span>
+        </div>
       </summary>
       <div class="cardContent">
         <div class="ganttCard" style="margin-top:0;">
@@ -779,21 +788,19 @@ TTR01AM-4 14125
             <label for="ganttDaysType">天數模式：</label>
             <select id="ganttDaysType">
               <option value="usDays">美國可售天數甘特圖</option>
-              <option value="days">含訂單可售天數甘特圖</option>
+              <option value="days" selected>含訂單可售天數甘特圖</option>
             </select>
             <label for="salesGanttFactory">工廠篩選：</label>
             <select id="salesGanttFactory">
               <option value="all">全部</option>
-              <option value="hideTW">越南廠（排除台灣廠）</option>
+              <option value="hideTW" selected>越南廠（排除台灣廠）</option>
               <option value="onlyTW">台灣廠</option>
             </select>
             <label for="salesGanttViewType">檢視模式：</label>
             <select id="salesGanttViewType">
-              <option value="table">甘特表格</option>
-              <option value="calendar">月曆檢視</option>
+              <option value="table">表格檢視</option>
+              <option value="calendar" selected>月曆檢視</option>
             </select>
-            <button id="btnBuildSalesGantt" class="secondary">產生甘特圖</button>
-            <button id="btnExportSalesGantt" class="secondary">匯出 Excel</button>
           </div>
           <div class="tableWrap" id="salesGanttWrap"></div>
           <div class="salesCalendarWrap" id="salesCalendarWrap" style="display:none;"></div>
@@ -1199,7 +1206,7 @@ function isHeroHotSku(sku) {
 
     const threshold = Math.max(1, Number(daysThresholdEl.value || 180));
     const reorder = h10Rows
-      .filter(r => r.usDays !== null && r.usDays <= threshold && r.speed !== null && r.speed > 0)
+       .filter(r => r.days !== null && r.days <= threshold && r.speed !== null && r.speed > 0)
       .map(r => ({
         sku: r.sku,
         asin: r.asin,
@@ -1211,7 +1218,7 @@ function isHeroHotSku(sku) {
         days: (r.days ?? 0)
       }));
 
-    reorder.sort((a,b) => a.usDays - b.usDays);
+    reorder.sort((a,b) => a.days - b.days);
     newOrder.sort((a,b) => b.order - a.order);
 
     mainRowsAll = h10Rows;
@@ -1266,7 +1273,7 @@ function isHeroHotSku(sku) {
 
   function calculateReorderQuantity(row, thresholdDays) {
     const speed = Number(row.speed || 0);
-    const currentDays = Number(row.usDays || 0);
+    const currentDays = Number(row.days || 0);
     if (!speed || !Number.isFinite(speed)) return 0;
     const gapDays = Math.max(0, thresholdDays - currentDays);
     return Math.ceil(gapDays * speed);
@@ -2566,7 +2573,6 @@ const allProducts = [
     const ganttDaysTypeEl = document.getElementById('ganttDaysType');
     const salesGanttFactoryEl = document.getElementById('salesGanttFactory');
     const salesGanttViewTypeEl = document.getElementById('salesGanttViewType');
-    const btnBuildSalesGantt = document.getElementById('btnBuildSalesGantt');
     const btnExportSalesGantt = document.getElementById('btnExportSalesGantt');
     const salesGanttWrapEl = document.getElementById('salesGanttWrap');
     const salesCalendarWrapEl = document.getElementById('salesCalendarWrap');
@@ -2757,6 +2763,19 @@ const allProducts = [
       return { monthBuckets, mode, factoryMode };
     }
 
+
+    function getGanttSkuClassName(sku) {
+      if (isDiscontinuedSku(sku)) return 'gantt-item-discontinued';
+      if (isHeroHotSku(sku)) return 'gantt-item-hero';
+      if (isHotSku(sku)) return 'gantt-item-hot';
+      return '';
+    }
+
+    function formatGanttSkuLabel(sku) {
+      const cls = getGanttSkuClassName(sku);
+      return cls ? `<span class="${cls}">${escapeHtml(String(sku))}</span>` : escapeHtml(String(sku));
+    }
+
     function renderSalesCalendar(monthBuckets) {
       if (!salesCalendarWrapEl) return;
       const weekLabels = ['日', '一', '二', '三', '四', '五', '六'];
@@ -2770,7 +2789,7 @@ const allProducts = [
         m.items.forEach(item => {
           const day = item.outDate instanceof Date ? item.outDate.getDate() : Number(String(item.dateText).split('/')[1]);
           if (!events.has(day)) events.set(day, []);
-          events.get(day).push(item.sku);
+          events.get(day).push({ sku: item.sku, formatted: formatGanttSkuLabel(item.sku) });
         });
 
         const cells = [];
@@ -2779,13 +2798,14 @@ const allProducts = [
         }
         for (let day = 1; day <= daysInMonth; day += 1) {
           const skus = events.get(day) || [];
-          const preview = skus.slice(0, 2).join('、');
+          const preview = skus.slice(0, 2).map(entry => entry.formatted).join('、');
+          const titleText = skus.map(entry => entry.sku).join('、');
           const extra = skus.length > 2 ? ` +${skus.length - 2}` : '';
           cells.push(`
             <div class="salesDayCell ${skus.length ? 'hasEvent' : ''}">
               <div class="salesDayNum">${day}</div>
               ${skus.length ? `<div class="salesDayCount">${skus.length} 項</div>` : ''}
-              ${skus.length ? `<div class="salesDaySkus" title="${skus.join('、')}">${preview}${extra}</div>` : ''}
+              ${skus.length ? `<div class="salesDaySkus" title="${escapeHtml(titleText)}">${preview}${extra}</div>` : ''}
             </div>
           `);
         }
@@ -2809,7 +2829,7 @@ const allProducts = [
       const viewType = salesGanttViewTypeEl?.value || 'table';
       const body = monthBuckets.map(m => {
         const skuList = m.items.length
-          ? `<ul class="ganttSkuList">${m.items.map(i => `<li>${i.sku}（${i.dateText} 缺貨）</li>`).join('')}</ul>`
+          ? `<ul class="ganttSkuList">${m.items.map(i => `<li>${formatGanttSkuLabel(i.sku)}（${i.dateText} 缺貨）</li>`).join('')}</ul>`
           : '—';
         return `<tr><td>${m.label}</td><td class="count">${m.items.length}</td><td>${skuList}</td></tr>`;
       }).join('');
@@ -2866,9 +2886,6 @@ const allProducts = [
     if (btnBuildSalesCharts) {
       btnBuildSalesCharts.addEventListener('click', buildSalesCharts);
     }
-    if (btnBuildSalesGantt) {
-      btnBuildSalesGantt.addEventListener('click', renderSalesGantt);
-    }
     if (btnExportSalesGantt) {
       btnExportSalesGantt.addEventListener('click', exportSalesGanttExcel);
     }
@@ -2881,6 +2898,10 @@ const allProducts = [
     if (salesGanttViewTypeEl) {
       salesGanttViewTypeEl.addEventListener('change', renderSalesGantt);
     }
+    if (salesInputEl) {
+      salesInputEl.addEventListener('input', renderSalesGantt);
+    }
+    renderSalesGantt();
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- 使用者不想再點「產生表格」才看到結果，期望依現有選項自動顯示對應檢視（表格或月曆）。
- 希望匯出 Excel 的按鈕與其他區塊風格一致，放在卡片右上並改名為 `下載Excel`。
- 需要預設在頁面載入時就顯示月曆，避免區塊一開始為空白導致看不到月曆。

### Description
- 在 `index.html` 中移除甘特區的 `產生表格`（`btnBuildSalesGantt`）按鈕，並移除對應的事件綁定。 
- 將匯出按鈕移到卡片 `summary` 右側並改名為 `下載Excel`，與其他區塊保持一致。 
- 改為在選單變更或 `salesInput` 輸入時自動呼叫 `renderSalesGantt()`，並在頁面初始化時執行一次 `renderSalesGantt()`，因此會即時顯示目前所選的月曆或表格。 
- 新增甘特 SKU 樣式與輔助函式 `getGanttSkuClassName` 與 `formatGanttSkuLabel`，並在日曆/表格輸出中使用以改善 SKU 樣式與 tooltip 的 escape 處理。 

### Testing
- 執行靜態/檔案檢視與內容核對（比對修改段落與 `index.html` 片段），檢查 UI 控制列與相關 script 已更新且存在。 (成功)
- 啟動本地靜態伺服器 `python3 -m http.server` 以提供頁面供互動測試，伺服器可正常啟動。 (成功)
- 嘗試使用 Playwright 自動化檢視以截圖並驗證 DOM 行為，但在本環境啟動 Chromium 時發生 SIGSEGV，導致瀏覽器互動驗證失敗且無法產出截圖；因此互動端驗證暫未自動通過（屬環境限制）。 (失敗 — 環境原因)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698acf565ce48320a7182ca200fba53f)