### PR TITLE
Fix sales gantt/calendar rendering for 12-month forecast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,6 +1147,8 @@ function isHeroHotSku(sku) {
     });
   }
 
+  window.__isRenderingSalesGantt = false;
+
   function buildTables() {
     const rawH10 = h10El.value || "";
     const rawOrders = ordersEl.value || "";
@@ -1232,7 +1234,7 @@ function isHeroHotSku(sku) {
     if (window.refreshGeneratorSpeedMetrics) {
       window.refreshGeneratorSpeedMetrics();
     }
-    if (typeof renderSalesGantt === 'function') {
+    if (typeof renderSalesGantt === 'function' && !window.__isRenderingSalesGantt) {
       renderSalesGantt();
     }
   }
@@ -2775,18 +2777,25 @@ const allProducts = [
       });
 
       rows.forEach(r => {
-        const days = Number(r[mode]);
+        const sku = normalizeSalesSku(r?.sku || r?.productCode || '');
+        if (!sku) return;
+
+        const dayText = String(r?.[mode] ?? '').replace(/,/g, '').trim();
+        const days = Number(dayText);
         if (!Number.isFinite(days) || days < 0) return;
-        const outDate = new Date(today);
-        outDate.setDate(today.getDate() + Math.floor(days));
+
+        const outDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+        outDate.setDate(outDate.getDate() + Math.floor(days));
         const monthKey = `${outDate.getFullYear()}-${String(outDate.getMonth() + 1).padStart(2, '0')}`;
         const bucket = monthBuckets.find(m => m.key === monthKey);
         if (!bucket) return;
-        const dateText = `${outDate.getMonth() + 1}/${outDate.getDate()}`;
-        bucket.items.push({ sku: r.sku, dateText, outDate: new Date(outDate) });
+        const dateText = `${String(outDate.getMonth() + 1).padStart(2, '0')}/${String(outDate.getDate()).padStart(2, '0')}`;
+        bucket.items.push({ sku, dateText, outDate: new Date(outDate) });
       });
 
-      monthBuckets.forEach(m => m.items.sort((a,b) => a.sku.localeCompare(b.sku)));
+      monthBuckets.forEach(m => {
+        m.items.sort((a, b) => String(a?.sku || '').localeCompare(String(b?.sku || '')));
+      });
       return { monthBuckets, mode, factoryMode };
     }
 
@@ -2815,8 +2824,10 @@ const allProducts = [
         const events = new Map();
         m.items.forEach(item => {
           const day = item.outDate instanceof Date ? item.outDate.getDate() : Number(String(item.dateText).split('/')[1]);
+          if (!Number.isFinite(day) || day < 1 || day > daysInMonth) return;
           if (!events.has(day)) events.set(day, []);
-          events.get(day).push({ sku: item.sku, formatted: formatGanttSkuLabel(item.sku) });
+          const sku = normalizeSalesSku(item?.sku || '');
+          events.get(day).push({ sku, formatted: formatGanttSkuLabel(sku || 'N/A') });
         });
 
         const cells = [];
@@ -2850,6 +2861,8 @@ const allProducts = [
 
     function renderSalesGantt() {
       if (!salesGanttWrapEl) return;
+      window.__isRenderingSalesGantt = true;
+      try {
       const { monthBuckets, mode } = buildSalesGanttData();
       latestSalesGanttRows = monthBuckets;
       const modeLabel = mode === 'usDays' ? '美國可售天數甘特圖' : '含訂單可售天數甘特圖';
@@ -2877,6 +2890,9 @@ const allProducts = [
       if (salesGanttHintEl) {
         const viewLabel = viewType === 'calendar' ? '月曆檢視' : '甘特表格';
         salesGanttHintEl.textContent = `目前模式：${modeLabel} / ${viewLabel}。`;
+      }
+      } finally {
+        window.__isRenderingSalesGantt = false;
       }
     }
 


### PR DESCRIPTION
### Motivation
- The sales Gantt / calendar panel failed to render for the next 12 months due to fragile data parsing and an infinite re-entry between supply table rebuilds and gantt rendering. 

### Description
- Added a render guard `window.__isRenderingSalesGantt` and wrapped `renderSalesGantt()` in a `try/finally` so table rebuilds do not re-enter gantt rendering. 
- Hardened data preparation in `buildSalesGanttData()` by normalizing SKUs with `normalizeSalesSku`, safely parsing day text (strip commas/whitespace) and rejecting invalid day values. 
- Built `outDate` from explicit year/month/day and produce zero-padded `MM/DD` `dateText`, and made month-bucket sorting null-safe. 
- Improved calendar event generation by validating day range (1..daysInMonth) and normalizing SKU labels before calling `formatGanttSkuLabel` to avoid rendering errors on malformed data. 

### Testing
- Ran a static check on the extracted inline script with `node --check /tmp/supply_inline.js`, which succeeded. 
- Automated Playwright validation against the local server verified `monthCount=12`, calendar container is displayed (`calDisplay='block'`), and no page errors were emitted. 
- Manual local server smoke test served `index.html` and confirmed calendar HTML was populated and no runtime exceptions remained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ae125dcb48320a0202140863ad2c8)