### PR TITLE
Fix order generator and utility buttons by removing global `allProducts` redeclaration

### DIFF
--- a/product-data.js
+++ b/product-data.js
@@ -1,5 +1,5 @@
 // 產品資料已獨立於 index.html，方便維護
-const allProducts = [
+window.allProductsData = [
   { productCode: "1GBRD019A0", productName: "Gootoe - Buffalo Bites Bone Shaped - 1.5lb (Pack of 3)", boxSize: "50*40*30", perCarton: 9, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
   { productCode: "1GBRD029A0", productName: "Gootoe - Buffalo Bites Stick (Large) - 1.5lb (Pack of 3)", boxSize: "50*40*30", perCarton: 8, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
   { productCode: "1AWDD010A0", productName: "A freschi Air-Dried Dog Food-Turkey Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
@@ -273,4 +273,3 @@ const allProducts = [
   { productCode: "ART01AM", productName: "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 36, country: "TW" },
   { productCode: "ART01J", productName: "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 21, country: "TW" }
 ];
-window.allProductsData = allProducts;


### PR DESCRIPTION
### Motivation
- The order-generator and the top-right “其他功能” buttons were not wired at runtime because a global `const allProducts` redeclaration in `product-data.js` conflicted with the same identifier in `index.html`, causing later scripts to not execute.

### Description
- Changed `product-data.js` to export the array as `window.allProductsData = [...]` instead of declaring `const allProducts` to avoid the identifier collision with `index.html`.
- Removed the redundant trailing assignment that re-wrote `window.allProductsData` from the now-removed local `allProducts` variable.
- No changes to `index.html` were required; the page now reads `const allProducts = window.allProductsData || [];` as before and will execute subsequent wiring code normally.

### Testing
- Ran a static JavaScript parse/evaluation check using a Node VM script (`node` + `vm`) to validate there are no redeclaration syntax errors, and it returned `parse-ok` (success).
- Started a local static server using `python3 -m http.server 8000` and confirmed the server process started (PID printed) as part of environment validation (success).
- Attempted headless UI smoke tests with Playwright to click `#otherFunctionsBtn` and add a product, but the browser runs were unstable in the CI container (Chromium timed out/crashed), so UI end-to-end verification was flaky and not completed (failed/flaky).
- Committed the fix (`product-data.js`) and created the PR; commit shown in repository (`cdc9242`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b51c30e2c88320ab7739b88251ba27)