### PR TITLE
Change hot-selling (熱銷品) color to blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,11 +322,11 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #ffe5e5; color: #c62828; border: 1px solid #f2b3b3;
     }
-    .hot-text { color: #b45309; font-weight: 700; }
+    .hot-text { color: #1d4ed8; font-weight: 700; }
     .hot-tag {
       display: inline-block; margin-left: 6px; padding: 2px 7px;
       border-radius: 999px; font-size: 11px; font-weight: 700;
-      background: #fff1d6; color: #b45309; border: 1px solid #ffd59a;
+      background: #dbeafe; color: #1d4ed8; border: 1px solid #93c5fd;
     }
     .hero-text { color: #a21caf; font-weight: 700; }
     .hero-tag {
@@ -339,7 +339,7 @@
     .sales-link:hover { text-decoration: underline; }
     .gantt-item-discontinued { color: #c62828; font-weight: 700; }
     .gantt-item-hero { color: #a21caf; font-weight: 700; }
-    .gantt-item-hot { color: #b45309; font-weight: 700; }
+    .gantt-item-hot { color: #1d4ed8; font-weight: 700; }
     .summary-actions {
       margin-left: auto;
       display: flex;


### PR DESCRIPTION
### Motivation
- Users were confusing hot-selling items with discontinued items due to similar warm colors, so hot-selling highlights were changed to a distinct blue for clearer visual distinction.

### Description
- Updated CSS in `index.html` to set `.hot-text` and `.gantt-item-hot` color to `#1d4ed8` and adjusted `.hot-tag` background to `#dbeafe` with border `#93c5fd` for consistent blue styling.

### Testing
- Verified the CSS diff in `index.html` reflects the new blue palette for ` .hot-text`, `.hot-tag`, and `.gantt-item-hot`; no automated unit tests exist for these UI color changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde10ad90483258e5b352fdd0f3840)