### PR TITLE
Make SKUs clickable in sales calendar and remove inline add button

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,8 @@
     .salesDayCell.hasEvent .salesDayNum { background:#0b6bcb; color:#fff; }
     .salesDayCount { margin-top:2px; color:#0b6bcb; font-weight:600; }
     .salesDaySkus { margin-top:2px; color:#3f4e64; line-height:1.35; word-break: break-word; }
+    .salesDaySkuLink { color: #0b6bcb; font-weight: 700; text-decoration: none; cursor: pointer; }
+    .salesDaySkuLink:hover { text-decoration: underline; }
 
     .order-generator { margin-top: 36px; font-family: "Noto Sans TC", Arial, sans-serif; color: #273042; }
     .order-generator .container {
@@ -2672,7 +2674,7 @@ const allProducts = window.allProductsData || [];
         for (let day = 1; day <= daysInMonth; day += 1) {
           const skus = events.get(day) || [];
           const preview = skus.slice(0, 2).map(entry => `
-            <div>${entry.formatted}<button type="button" class="ganttSkuAction js-add-gantt-sku" data-sku="${escapeSalesText(entry.sku)}">加入訂單產生器</button></div>
+            <div><a href="#" class="salesDaySkuLink js-add-gantt-sku" data-sku="${escapeSalesText(entry.sku)}">${entry.formatted}</a></div>
           `).join('');
           const titleText = skus.map(entry => entry.sku).join('、');
           const extra = skus.length > 2 ? ` +${skus.length - 2}` : '';
@@ -2796,11 +2798,11 @@ const allProducts = window.allProductsData || [];
     }
     if (salesCalendarWrapEl) {
       salesCalendarWrapEl.addEventListener('click', (event) => {
-        const btn = event.target.closest('.js-add-gantt-sku');
-        if (!btn) return;
+        const skuLink = event.target.closest('.js-add-gantt-sku');
+        if (!skuLink) return;
         event.preventDefault();
         event.stopPropagation();
-        addSingleGanttSkuToGenerator(btn.dataset.sku || '');
+        addSingleGanttSkuToGenerator(skuLink.dataset.sku || '');
       });
     }
     const btnCalculateEl = document.getElementById('btnCalculate');


### PR DESCRIPTION
### Motivation
- 減少月曆檢視中的視覺雜訊，讓月曆版面更整潔並避免「加入訂單產生器」按鈕導致混亂。 
- 保留既有的加入流程與使用者回饋，改由點擊 SKU 本身觸發加入現有的 `addSingleGanttSkuToGenerator` 流程並顯示既有提示。 

### Description
- 在 `index.html` 中將月曆格內的原 inline 按鈕改為可點擊的 SKU 連結，使用類別 `salesDaySkuLink js-add-gantt-sku` 來標記互動元素。 
- 新增 CSS 樣式 `.salesDaySkuLink` 以提供藍色粗體與 hover 底線的點擊提示。 
- 將月曆容器的點擊處理改為尋找 `.js-add-gantt-sku` 的連結節點並呼叫 `addSingleGanttSkuToGenerator(...)`，保留既有檢核與提示邏輯。 

### Testing
- 已執行 `rg -n "salesDaySkuLink|js-add-gantt-sku|加入訂單產生器" index.html` 以驗證新連結與相關字串存在，執行成功。 
- 已檢查版本庫狀態並執行 `git -C /workspace/Supply status --short` 以確認檔案變更，執行成功。 
- 已提交變更使用 `git -C /workspace/Supply commit -m "Refine sales calendar SKU add interaction"`，提交成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde247bd048325bb4e40871dc1d2bf)