### PR TITLE
Add equivalent SKU aggregation and order-code toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,18 @@
       border-radius: 999px; font-size: 11px; font-weight: 700;
       background: #fbe6ff; color: #a21caf; border: 1px solid #f0b3ff;
     }
+    .equivalent-tag {
+      display: inline-block; margin-left: 6px; padding: 2px 7px;
+      border-radius: 999px; font-size: 11px; font-weight: 700;
+      background: #ecfdf5; color: #047857; border: 1px solid #86efac;
+    }
+    .order-code-cell { min-width: 150px; }
+    .order-code-label { display: inline-block; font-weight: 700; margin-right: 6px; }
+    .equiv-toggle {
+      margin-top: 5px; padding: 4px 8px; font-size: 11px; border-radius: 999px;
+      border: 1px solid #86efac; background: #ecfdf5; color: #047857; box-shadow: none;
+    }
+    .equiv-toggle:hover { background: #d1fae5; box-shadow: none; transform: none; }
 
     .sales-link { font-size: 12px; color: #0b6bcb; text-decoration: none; font-weight: 600; }
     .sales-link:hover { text-decoration: underline; }
@@ -436,7 +448,7 @@
                   <thead>
                     <tr>
                       <th>序號</th>
-                      <th>品號</th>
+                      <th>品號 / 下單品號</th>
                       <th>包數</th>
                       <th>袋數/盒數</th>
                       <th>目標數量</th>
@@ -875,6 +887,42 @@ const discontinuedSkuSet = new Set(discontinuedSkuReasons.keys());
 function normalizeSkuKey(sku) {
   return String(sku ?? "").trim().toUpperCase();
 }
+
+const equivalentSkuPairs = [
+  ["GTP05", "7GTPD053AB"],
+  ["GTRL03", "7GTRD037AB"],
+  ["GTPL03", "7GTPD037AB"],
+  ["GTP01", "7GTPD013AB"],
+  ["GTR01", "7GTRD013AB"],
+  ["TTS05AM-1", "7ATSD010AB"],
+  ["TTS05AM", "7ATSD019AB"],
+  ["ATS01", "7ATSD011AB"],
+  ["ATR01", "7ATRD013AB"],
+  ["TTSL05", "7ATSD017AB"]
+];
+const equivalentSkuAliasToCanonical = new Map();
+const equivalentSkuCanonicalToGroup = new Map();
+equivalentSkuPairs.forEach(pair => {
+  const group = pair.map(normalizeSkuKey);
+  const canonical = group[0];
+  equivalentSkuCanonicalToGroup.set(canonical, group);
+  group.forEach(alias => equivalentSkuAliasToCanonical.set(alias, canonical));
+});
+function getCanonicalSku(sku) {
+  const key = normalizeSkuKey(sku);
+  return equivalentSkuAliasToCanonical.get(key) || key;
+}
+function getEquivalentSkuGroup(sku) {
+  return equivalentSkuCanonicalToGroup.get(getCanonicalSku(sku)) || null;
+}
+function hasEquivalentSku(sku) {
+  const group = getEquivalentSkuGroup(sku);
+  return Boolean(group && group.length > 1);
+}
+function getEquivalentSkuLabel(sku) {
+  const group = getEquivalentSkuGroup(sku);
+  return group ? group.join(' = ') : '';
+}
 function isDiscontinuedSku(sku) {
   return discontinuedSkuSet.has(normalizeSkuKey(sku));
 }
@@ -1046,7 +1094,8 @@ function isHeroHotSku(sku) {
     const tags = [
       showHero ? ' <span class="hero-tag">Hero熱銷品</span>' : '',
       showHot ? ' <span class="hot-tag">熱銷品</span>' : '',
-      isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : ''
+      isDiscontinued ? ' <span class="discontinued-tag">停產</span>' : '',
+      hasEquivalentSku(sku) ? ` <span class="equivalent-tag" title="${escapeHtml(getEquivalentSkuLabel(sku))}">相同品</span>` : ''
     ].join('');
     const className = [
       showHero ? 'hero-text' : '',
@@ -1157,6 +1206,36 @@ function isHeroHotSku(sku) {
     return map;
   }
 
+  function aggregateSkuNumberMapByEquivalent(map) {
+    const aggregated = new Map();
+    for (const [sku, qty] of map.entries()) {
+      const canonicalSku = getCanonicalSku(sku);
+      aggregated.set(canonicalSku, (aggregated.get(canonicalSku) ?? 0) + qty);
+    }
+    return aggregated;
+  }
+
+  function aggregateH10RowsByEquivalent(rows) {
+    const rowMap = new Map();
+    for (const row of rows) {
+      const canonicalSku = getCanonicalSku(row.sku);
+      const existing = rowMap.get(canonicalSku);
+      if (!existing) {
+        rowMap.set(canonicalSku, { ...row, sku: canonicalSku });
+        continue;
+      }
+      if (row.asin && !String(existing.asin || '').split(' / ').includes(row.asin)) {
+        existing.asin = existing.asin ? `${existing.asin} / ${row.asin}` : row.asin;
+      }
+      if (row.speed !== null && Number.isFinite(row.speed)) {
+        existing.speed = (existing.speed !== null && Number.isFinite(existing.speed))
+          ? existing.speed + row.speed
+          : row.speed;
+      }
+    }
+    return Array.from(rowMap.values());
+  }
+
   function mergeSkuNumberMaps(...maps) {
     const merged = new Map();
     for (const map of maps) {
@@ -1214,10 +1293,11 @@ function isHeroHotSku(sku) {
 
     let h10Rows = parseH10ToRows(rawH10);
     if (chkDedupe.checked) h10Rows = dedupeH10(h10Rows);
+    h10Rows = aggregateH10RowsByEquivalent(h10Rows);
 
-    const orderMap = parseSkuNumberMap(rawOrders);
-    const usAmzMap = parseSkuNumberMap(rawUSAmz);
-    const usJspMap = parseSkuNumberMap(rawUSJsp);
+    const orderMap = aggregateSkuNumberMapByEquivalent(parseSkuNumberMap(rawOrders));
+    const usAmzMap = aggregateSkuNumberMapByEquivalent(parseSkuNumberMap(rawUSAmz));
+    const usJspMap = aggregateSkuNumberMapByEquivalent(parseSkuNumberMap(rawUSJsp));
     const usMap = mergeSkuNumberMaps(usAmzMap, usJspMap);
     window.orderSpeedMap = new Map(
       h10Rows
@@ -1260,7 +1340,7 @@ function isHeroHotSku(sku) {
     }
 
     const hotRows = hotSkuList.map(rawSku => {
-      const sku = normalizeSkuValue(rawSku);
+      const sku = getCanonicalSku(rawSku);
       const h10Row = h10RowMap.get(sku);
       const orderVal = orderMap.get(sku);
       const usAmzVal = usAmzMap.get(sku);
@@ -1888,6 +1968,13 @@ const allProducts = window.allProductsData || [];
         if (!showHero && heroTag) {
           heroTag.remove();
         }
+        const equivalentTag = skuCell.querySelector('.equivalent-tag');
+        if (hasEquivalentSku(code) && !equivalentTag) {
+          skuCell.insertAdjacentHTML('beforeend', ` <span class="equivalent-tag" title="${escapeHtml(getEquivalentSkuLabel(code))}">相同品</span>`);
+        }
+        if (!hasEquivalentSku(code) && equivalentTag) {
+          equivalentTag.remove();
+        }
         const hotTag = skuCell.querySelector('.hot-tag');
         if (showHot && !hotTag) {
           skuCell.insertAdjacentHTML('beforeend', ' <span class="hot-tag">熱銷品</span>');
@@ -1903,6 +1990,39 @@ const allProducts = window.allProductsData || [];
           tag.remove();
         }
       }
+    }
+
+    function renderEquivalentOrderToggle(code) {
+      const group = getEquivalentSkuGroup(code);
+      if (!group || group.length < 2) return '';
+      const nextCode = group[1];
+      return `<button type="button" class="equiv-toggle" onclick="toggleEquivalentOrderCode(this)" title="相同品可切換下單品號">切換下單：${escapeHtml(nextCode)}</button>`;
+    }
+
+    function setRowOrderCode(row, code) {
+      if (!row) return;
+      row.dataset.orderCode = code;
+      const label = row.querySelector('.order-code-label');
+      if (label) label.textContent = code;
+      const btn = row.querySelector('.equiv-toggle');
+      const group = getEquivalentSkuGroup(row.dataset.product || code);
+      if (btn && group && group.length > 1) {
+        const nextCode = code === group[0] ? group[1] : group[0];
+        btn.textContent = `切換下單：${nextCode}`;
+        btn.title = `目前下單 ${code}；點擊切換成 ${nextCode}`;
+      }
+    }
+
+    function toggleEquivalentOrderCode(btn) {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const group = getEquivalentSkuGroup(row.dataset.product);
+      if (!group || group.length < 2) return;
+      const current = row.dataset.orderCode || group[0];
+      const idx = group.indexOf(current);
+      const nextCode = group[(idx + 1) % group.length] || group[0];
+      setRowOrderCode(row, nextCode);
+      showTip(`下單品號已切換為 ${nextCode}`, 'success');
     }
 
     function addProduct(prod, quantity = null){
@@ -1932,9 +2052,9 @@ const allProducts = window.allProductsData || [];
       }
       const targetPlaceholder = hasPack ? '目標袋數' : (hasBox ? '目標盒數' : '目標包數');
       const rowHTML = `
-      <tr data-product="${prod.productCode}">
+      <tr data-product="${prod.productCode}" data-order-code="${prod.productCode}">
         <td>${rowIndex}</td>
-        <td>${prod.productCode}</td>
+        <td class="order-code-cell"><span class="order-code-label">${prod.productCode}</span>${renderEquivalentOrderToggle(prod.productCode)}</td>
         <td><input type="number" class="edit-quantity-input" placeholder="包數" oninput="updateFields(this,'${prod.productCode}')"></td>
         <td>${packOrBoxInput}</td>
         <td><input type="number" class="target-input" placeholder="${targetPlaceholder}" oninput="checkTarget(this)"></td>
@@ -2214,11 +2334,12 @@ const allProducts = window.allProductsData || [];
     function exportToExcel() {
       const wb = XLSX.utils.book_new();
       const getRowProductCode = (row) => {
-        const fromDataset = row?.dataset?.product?.trim();
-        if (fromDataset) return fromDataset;
-        const rawCellText = row?.cells?.[1]?.childNodes?.[0]?.textContent || row?.cells?.[1]?.textContent || '';
+        const selectedCode = row?.dataset?.orderCode?.trim();
+        if (selectedCode) return selectedCode;
+        const rawCellText = row?.querySelector('.order-code-label')?.textContent || row?.cells?.[1]?.childNodes?.[0]?.textContent || row?.cells?.[1]?.textContent || '';
         return rawCellText.trim();
       };
+      const getRowSpecCode = (row) => row?.dataset?.product?.trim() || getRowProductCode(row);
       const orderSheetData = [];
       const orderHeader = ["序號","品號","名稱","每箱","包裝類型","箱數","單位","棧板數","單位","紙箱尺寸(cm)"];
       orderSheetData.push(orderHeader);
@@ -2226,7 +2347,7 @@ const allProducts = window.allProductsData || [];
       rows.forEach(row => {
         const idx = row.cells[0].textContent;
         const code = getRowProductCode(row);
-        const prod = getProductSpecByCode(code);
+        const prod = getProductSpecByCode(getRowSpecCode(row));
         const name = prod?.productName || '';
         const eachCarton = prod?.perCarton || 1;
         let pkgType = '單包';
@@ -2247,7 +2368,7 @@ const allProducts = window.allProductsData || [];
       rows.forEach(row => {
         const idx = row.cells[0].textContent;
         const code = getRowProductCode(row);
-        const prod = getProductSpecByCode(code);
+        const prod = getProductSpecByCode(getRowSpecCode(row));
         const name = prod?.productName || '';
         const quantity = parseFloat(row.querySelector('.edit-quantity-input')?.value) || 0;
         let packOrBoxVal = '—';


### PR DESCRIPTION
### Motivation

- 部分品號有廠商/原品兩組不同代碼（例如 `GTP05` = `7GTPD053AB`），需要在庫存與下單計算時視為同一品以便看出真實可用量和是否要下單。 
- 讓下單產生器能選擇要以哪一個品號匯出訂單，但計算仍使用對應商品規格以保留箱/棧板/包裝邏輯。 

### Description

- 新增等價 SKU 對照表 `equivalentSkuPairs` 並實作正規化/群組函式 `getCanonicalSku`, `getEquivalentSkuGroup`, `hasEquivalentSku`。 
- 實作合併/聚合函式 `aggregateH10RowsByEquivalent` 與 `aggregateSkuNumberMapByEquivalent`，在 `buildTables` 中對 H10 行、訂單、AMZ 與 JSP 數量先做群組加總（以 canonical SKU 為單位）。
- UI/UX：新增 `equivalent-tag` 標籤於表格顯示相同品，並將訂單產生器的「品號欄」改為 `品號 / 下單品號`，在加入產品列新增 `切換下單` 按鈕（`equiv-toggle`），可在等價群組裡切換要匯出的下單品號；按鈕行為由 `toggleEquivalentOrderCode` / `setRowOrderCode` 負責。 
- 匯出行為調整：匯出 Excel 使用目前選擇的下單品號（row 的 `data-order-code`），但仍用原始產品規格（透過 `getRowSpecCode` 對應到 `allProducts`）計算箱數、棧板數與名稱，熱銷/下單清單等邏輯也改為以 canonical SKU 處理。 

### Testing

- 已對打包的行內腳本做靜態檢查：`node --check /tmp/supply-inline.js`（通過）。
- 已對 `product-data.js` 做靜態檢查：`node --check product-data.js`（通過）。
- 已執行代碼檢查：`git diff --check`（通過）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2bc5202d788320b7cb23d9c562079c)