### PR TITLE
Add one‑click "今日優先處理 → 訂單產生器" action

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,7 +726,7 @@
             <h2>今日優先處理</h2>
             <div class="hint">自動判斷斷貨、接貨缺口、營收風險與資料異常。</div>
           </div>
-          <div class="summary-actions"><button class="secondary" id="btnExportDecisionDashboard">下載Excel</button><span class="pill">Decision</span></div>
+          <div class="summary-actions"><button class="secondary" id="btnAddPriorityToGenerator">一鍵加入訂單產生器</button><button class="secondary" id="btnExportDecisionDashboard">下載Excel</button><span class="pill">Decision</span></div>
         </summary>
         <div class="cardContent">
           <div class="decisionGrid" id="decisionKpiGrid"></div>
@@ -2115,8 +2115,12 @@
     function applyPlannedQuantityToGenerator(prod, quantity, pallets = null) { const row = addProduct(prod, null); if (!row) return; if (Number.isFinite(pallets) && pallets > 0) { const input = row.querySelector('.edit-pallets-input'); input.value = pallets.toFixed(2); updateFields(input, prod.productCode); return; } if (Number.isFinite(quantity) && quantity > 0) { const input = row.querySelector('.edit-quantity-input'); input.value = quantity.toFixed(0); updateFields(input, prod.productCode); } }
     function addReorderRowsToGenerator() { const threshold = Math.max(1, Number(daysThresholdEl.value || 180)); const rows = applyFilters(mainRowsAll).filter(row => row.days !== null && row.days <= threshold && row.speed !== null && row.speed > 0); let missing = [], skipped = []; rows.forEach(row => { if (isDiscontinuedSku(row.sku)) { skipped.push(row.sku); return; } const prod = getProductSpecByCode(row.sku); if (!prod) { missing.push(row.sku); return; } applyPlannedQuantityToGenerator(prod, calculateReorderQuantity(row, threshold), calculateReorderPallets(row, prod, threshold)); }); if (missing.length) showTip(`找不到品項資料：${missing.join(', ')}`, 'error'); if (skipped.length) showTip(`停產品未加入：${skipped.join(', ')}`, 'error'); }
     function addHotRowsToGenerator() { let missing = [], skipped = []; applyFilters(hotRowsAll).forEach(row => { if (isDiscontinuedSku(row.sku)) { skipped.push(row.sku); return; } const prod = getProductSpecByCode(row.sku); if (!prod) { missing.push(row.sku); return; } addProduct(prod, row.order !== null && Number.isFinite(row.order) ? row.order : null); }); if (missing.length) showTip(`找不到品項資料：${missing.join(', ')}`, 'error'); if (skipped.length) showTip(`停產品未加入：${skipped.join(', ')}`, 'error'); }
+    function calculatePriorityQuantity(row, thresholdDays) { const speed = Number(row.speed || 0); if (!speed || !Number.isFinite(speed)) return 0; const currentDays = Number.isFinite(Number(row.usDays)) ? Number(row.usDays) : 0; return Math.ceil(Math.max(0, thresholdDays - currentDays) * speed); }
+    function calculatePriorityPallets(row, prod, thresholdDays) { const qty = calculatePriorityQuantity(row, thresholdDays), unitsPerPallet = getUnitsPerPallet(prod); return qty && unitsPerPallet ? Math.ceil((qty / unitsPerPallet) * 100) / 100 : null; }
+    function addPriorityRowsToGenerator() { if (!latestDecisionExport.priority.length) renderDecisionDashboard(); const threshold = Math.max(1, Number(daysThresholdEl.value || 180)); let missing = [], skipped = [], added = 0; latestDecisionExport.priority.forEach(row => { if (isDiscontinuedSku(row.sku)) { skipped.push(row.sku); return; } const prod = getProductSpecByCode(row.sku); if (!prod) { missing.push(row.sku); return; } applyPlannedQuantityToGenerator(prod, calculatePriorityQuantity(row, threshold), calculatePriorityPallets(row, prod, threshold)); added++; }); if (added) showTip(`已加入今日優先處理 ${added} 個品項`, 'success'); if (missing.length) showTip(`找不到品項資料：${missing.join(', ')}`, 'error'); if (skipped.length) showTip(`停產品未加入：${skipped.join(', ')}`, 'error'); }
     document.getElementById('btnAddReorderToGenerator').addEventListener('click', addReorderRowsToGenerator);
     document.getElementById('btnAddHotToGenerator').addEventListener('click', addHotRowsToGenerator);
+    document.getElementById('btnAddPriorityToGenerator').addEventListener('click', addPriorityRowsToGenerator);
 
     function exportGeneratorToExcel() {
       const wb = XLSX.utils.book_new();


### PR DESCRIPTION
### Motivation
- 在「今日優先處理」決策儀表板加入一鍵把優先清單加入訂單產生器的功能，以便快速從決策面把需要優先下單的品項匯入下單工具，減少手動操作。 
- 採用既有的門檻天數與美國可售天數計算邏輯來決定建議下單數量，與現有的「門檻內可售品項」與「熱銷品」一鍵加入機制保持一致。

### Description
- 修改 `index.html`：在「今日優先處理」標題列新增按鈕 `<button id="btnAddPriorityToGenerator">一鍵加入訂單產生器</button>`，並將其加入 UI 操作列。 
- 新增計算與匯入邏輯：新增 `calculatePriorityQuantity`、`calculatePriorityPallets` 與 `addPriorityRowsToGenerator` 三個函式，使用目前 `daysThreshold` 與每品項的 `usDays` / `speed` 計算建議數量與棧板數，再呼叫既有 `applyPlannedQuantityToGenerator` 將品項加入產生器。 
- 行為一致性：新功能會略過停產品並在找不到品項規格時顯示錯誤提示 (`showTip`)，並將按鈕綁定到 `addPriorityRowsToGenerator`，與現有 `addReorderRowsToGenerator`、`addHotRowsToGenerator` 並列。 
- 變更檔案：`index.html`（UI 與內嵌腳本新增/修改）。

### Testing
- 執行 `git diff --check` 並確認沒有語法/whitespace 問題（通過）。
- 抽出頁面內嵌腳本並執行 `node --check /tmp/supply-inline.js` 檢查 JavaScript 語法（通過）。
- 嘗試在 headless 環境截圖以驗證 UI 按鈕存在，但此步驟使用 Playwright 的自動化截圖失敗，原因是環境缺少 Playwright / 瀏覽器二進位（失敗/無法執行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a589817cb94832095e77a5f0c0b4f74)