### PR TITLE
Simplify workspaces and add coverage HP bars

### DIFF
--- a/Boss/index.html
+++ b/Boss/index.html
@@ -6,6 +6,7 @@
   <title>訂單分析器 V2</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 64 64%27%3E%3Ctext x=%278%27 y=%2746%27 font-size=%2742%27%3E📦%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <link rel="stylesheet" href="../shared/coverage-indicator.css">
   <style>
     :root { font-family: "Noto Sans TC", system-ui, -apple-system, "Segoe UI", Arial, sans-serif; color: #0f1d2b; }
     * { box-sizing: border-box; }
@@ -157,34 +158,48 @@
     .order-generator th, .order-generator td { padding: 12px 8px; border-bottom: 1px solid #e3e8f0; font-size: 13px; }
     .order-generator th { background: #eaf1fc; color: #375a7f; font-weight: 700; border-bottom: 2px solid #b7d2f6; }
     .order-generator tr:hover td { background: #f0f5fe; }
-    .order-generator .action-button, .order-generator .remove-button, .order-generator .lock-button, .order-generator .drag-handle { background: #e0e7f3; color: #5c6f8f; padding: 5px 9px; margin: 2px 1px; border: none; border-radius: 6px; cursor: pointer; font-size: 15px; font-weight: bold; transition: background 0.2s; box-shadow: none; }
-    .order-generator .remove-button { background: #fa7878; color: #fff; }
-    .order-generator .lock-button { background: #ffd76b; color: #925700; }
-    .order-generator .drag-handle { cursor: grab; background:#dbeafe; color:#2563eb; touch-action:none; }
+    .order-generator .action-button, .order-generator .remove-button, .order-generator .lock-button, .order-generator .drag-handle { display:inline-grid; place-items:center; inline-size:28px; block-size:28px; padding:0; margin:0; border:0; border-radius:7px; background:transparent; color:#64748b; cursor:pointer; font-size:12px; font-weight:800; transition:background .15s ease,color .15s ease; box-shadow:none; }
+    .order-generator .action-button:hover, .order-generator .remove-button:hover, .order-generator .lock-button:hover, .order-generator .drag-handle:hover { transform:none; box-shadow:none; }
+    .order-generator .remove-button { color:#dc2626; }
+    .order-generator .remove-button:hover { background:#fee2e2; color:#b91c1c; }
+    .order-generator .lock-button { color:#92600a; }
+    .order-generator .lock-button:hover { background:#fef3c7; color:#854d0e; }
+    .order-generator .drag-handle { cursor:grab; color:#2563eb; touch-action:none; }
+    .order-generator .drag-handle:hover { background:#dbeafe; color:#1d4ed8; }
     .order-generator .drag-handle:active { cursor:grabbing; }
     .order-generator tr.generator-dragging { opacity:.45; pointer-events:none; }
-    .order-generator .generatorActions { white-space:nowrap; }
+    .order-generator .generatorActions { width:1%; padding-inline:4px; white-space:nowrap; }
+    .generatorActionGroup { display:inline-flex; align-items:center; gap:3px; inline-size:90px; }
+    .order-generator .generatorActionGroup > button:focus-visible, .order-generator .miniBtn:focus-visible { outline:2px solid #2563eb; outline-offset:2px; }
+    .order-generator .miniBtn { display:inline-grid; place-items:center; inline-size:26px; block-size:26px; margin-left:4px; padding:0; border-radius:7px; font-size:11px; }
     .generatorQuantityGroup { display:flex; flex-direction:column; gap:6px; min-width:84px; max-width:112px; }
     .generatorQuantityGroup.single { min-width:82px; }
     .generatorQuantityField { display:flex; flex-direction:column; gap:3px; color:#64748b; font-size:10px; font-weight:800; }
     .generatorQuantityField input { min-width:0; width:100%; }
-    .palletStepControl { display:grid; grid-template-columns:minmax(72px,1fr) 28px; gap:4px; align-items:stretch; min-width:104px; }
-    .palletStepButtons { display:grid; grid-template-rows:1fr 1fr; gap:3px; }
-    .palletStepButton { display:grid; place-items:center; min-width:28px; min-height:24px; padding:0; border:1px solid #cbd5e1; border-radius:7px; background:#fff; color:#334155; box-shadow:none; font-size:12px; line-height:1; cursor:pointer; }
-    .palletStepButton:hover { background:#eff6ff; color:#1d4ed8; }
+    .palletStepControl { position:relative; display:block; width:88px; min-width:88px; height:34px; }
+    .palletStepButtons { position:absolute; inset:1px 1px 1px auto; z-index:1; display:grid; grid-template-rows:1fr 1fr; width:20px; overflow:hidden; border-left:1px solid #cbd5e1; border-radius:0 7px 7px 0; }
+    .palletStepButton { display:grid; place-items:center; width:20px; min-width:0; min-height:0; padding:0; margin:0; border:0; border-radius:0; background:#f8fafc; color:#475569; box-shadow:none; font-size:8px; line-height:1; cursor:pointer; }
+    .palletStepButton + .palletStepButton { border-top:1px solid #cbd5e1; }
+    .palletStepButton:hover { background:#eff6ff; color:#1d4ed8; transform:none; box-shadow:none; }
+    .palletStepButton:focus-visible { outline:0; box-shadow:inset 0 0 0 2px #2563eb; }
     .palletStepButton:disabled { cursor:not-allowed; opacity:.45; }
-    .edit-pallets-input { appearance:textfield; -moz-appearance:textfield; }
+    .palletStepControl:focus-within .edit-pallets-input { border-color:#2563eb; box-shadow:0 0 0 2px rgba(37,99,235,.2); }
+    .edit-pallets-input { width:100%; height:100%; padding:6px 23px 6px 8px; border-radius:8px; appearance:textfield; -moz-appearance:textfield; }
     .edit-pallets-input::-webkit-inner-spin-button, .edit-pallets-input::-webkit-outer-spin-button { appearance:none; margin:0; }
     .pallet-guidance { display:block; max-width:128px; margin-top:4px; color:#92400e; font-size:10px; font-weight:750; line-height:1.3; }
     .pallet-guidance[hidden] { display:none; }
-    .generatorCoverageStatus { font-size:.78rem; font-weight:850; white-space:nowrap; }
-    .generatorCoverageStatus.low { color:#b45309; }
-    .generatorCoverageStatus.healthy { color:#15803d; }
-    .generatorCoverageStatus.excess { color:#b91c1c; }
-    .generatorCoverageStatus.neutral { color:#64748b; }
+    .coverageHealthCell, .estimated-days, .arrival-days { min-width:148px; }
     .order-generator tr.locked td, .order-generator tr.locked:hover td { background:#dcfce7 !important; color:#166534; border-bottom-color:#86efac; }
     .order-generator tr.locked input { background:#f0fdf4; color:#166534; border-color:#86efac; font-weight:800; }
-    .order-generator tr.locked .lock-button { background:#16a34a; color:#fff; }
+    .order-generator tr.locked .lock-button { background:#dcfce7; color:#15803d; }
+    @media (pointer:coarse) {
+      .palletStepControl { width:96px; min-width:96px; height:48px; }
+      .palletStepButtons { inset:0 0 0 auto; width:28px; }
+      .palletStepButton { width:28px; font-size:10px; }
+      .edit-pallets-input { padding-right:31px; }
+      .order-generator .generatorActionGroup { gap:3px; inline-size:126px; }
+      .order-generator .generatorActionGroup > button, .order-generator .miniBtn { inline-size:40px; block-size:40px; }
+    }
     .generatorColumnBar { display:flex; align-items:center; flex-wrap:wrap; gap:7px; margin:0 0 10px; padding:9px 11px; border:1px solid #e2e8f0; border-radius:14px; background:#f8fafc; }
     .generatorColumnBar > span { color:#64748b; font-size:12px; font-weight:800; margin-right:2px; }
     .generatorColumnToggle { display:inline-flex; align-items:center; gap:5px; padding:6px 9px; border-radius:999px; background:#e2e8f0; color:#64748b; font-size:11px; font-weight:800; cursor:pointer; user-select:none; }
@@ -1080,7 +1095,7 @@
                   <tbody></tbody>
                 </table>
               </div>
-              <div class="hint" style="text-align:right;margin-top:10px;">含舊訂單可售天數會包含 JAM/FY 的預計補貨；新訂單到港後總可售天數會先扣前置期銷售，納入已下單舊單，並排除「還沒下單／STOP」。低於目標天數會提醒，達標到 365 天為綠色，只有超過 365 天才標紅；建議會優先使用整板，只有下一整板會從低於目標跳到超過 365 天時，才依最小箱數顯示零散板。按住拖曳圖示可調整順序，草稿會自動保存。</div>
+              <div class="hint" style="text-align:right;margin-top:10px;">含舊訂單可售天數會包含 JAM/FY 的預計補貨；新訂單到港後總可售天數會先扣前置期銷售，納入已下單舊單，並排除「還沒下單／STOP」。血條固定為：低於 180 天黃色、180–365 天綠色、超過 365 天紅色；上方到港後目標仍只影響建議量。建議會優先使用整板，只有下一整板會從低於目標跳到超過 365 天時，才依最小箱數顯示零散板。按住拖曳圖示可調整順序，草稿會自動保存。</div>
               <div class="totals-container">
                 <div class="total"><i class="fa-solid fa-boxes-stacked"></i> 總包數: <span id="totalQuantity">0</span> | 總箱數: <span id="totalCartons">0</span> | 總棧板數: <span id="totalPallets">0</span></div>
                 <div class="box-counts" id="boxCounts"></div>
@@ -1405,6 +1420,7 @@
   <script type="module" src="../shared/workspace-snapshot.js"></script>
   <script type="module" src="../shared/workspace-navigation.js"></script>
   <script type="module" src="../shared/workspace-ui.js"></script>
+  <script type="module" src="../shared/coverage-indicator.js"></script>
   <script>
     const IS_BOSS_PORTAL = true;
     const BOSS_API_BASE = 'https://supply-boss.brave-prawn-0848.chatgpt.site';
@@ -2422,7 +2438,8 @@
     }
     function renderInventoryCell(value, missingText = "(未對應)") { return (value === null || value === undefined) ? `<td class="bad">${escapeHtml(missingText)}</td>` : `<td class="ok">${escapeHtml(fmtQty(value))}</td>`; }
     function renderNumericCell(value, badText = "(未對應)") { return (value === null || value === undefined) ? `<td class="bad">${escapeHtml(badText)}</td>` : `<td class="ok">${escapeHtml(fmtQty(value))}</td>`; }
-    function renderCoverageDaysCell(value, targetDays = getReorderTargetDays()) { if (!Number.isFinite(value)) return '<td class="bad">(不可算)</td>'; const band = getGeneratorCoverageBand(value, targetDays); const cls = band === 'excess' ? 'bad' : (band === 'low' ? 'warn' : 'ok'); const note = band === 'excess' ? '<br><span class="generatorCoverageStatus excess">超過 365 天</span>' : ''; return `<td class="${cls}">${fmtDays(value)}${note}</td>`; }
+    function renderCoverageMeterHtml(coverageDays, assessment = 'ready') { const api = window.SupplyCoverageIndicator; if (!api?.renderCoverageMeter) return Number.isFinite(coverageDays) ? escapeHtml(fmtDays(coverageDays)) : '—'; return api.renderCoverageMeter({ coverageDays:Number.isFinite(coverageDays) ? coverageDays : null, assessment }); }
+    function renderCoverageDaysCell(value) { const assessment = Number.isFinite(value) ? 'ready' : 'unavailable'; return `<td class="coverageHealthCell">${renderCoverageMeterHtml(value, assessment)}</td>`; }
     function getSharedBookCoverageDays(row) { const plan = getLeadTimePlan(row, 365); return Number.isFinite(plan?.bookCoverageDays) ? plan.bookCoverageDays : row?.days; }
     function renderAmazonUnitCell(value, rawValue, sku, missingText = "(未對應)") {
       if (value === null || value === undefined) return `<td class="bad">${escapeHtml(missingText)}</td>`;
@@ -2980,9 +2997,9 @@
     }
 
     function captureActiveWorkspace() {
-      const ids = window.SupplyWorkspaceNavigation?.WORKSPACE_IDS || [];
       const activeWorkspace = workspaceUiController?.getActiveWorkspace();
-      return ids.includes(activeWorkspace) ? activeWorkspace : (ids.includes(restoredWorkspacePreference) ? restoredWorkspacePreference : 'today');
+      const canonicalize = window.SupplyWorkspaceNavigation?.canonicalWorkspaceId;
+      return canonicalize?.(activeWorkspace) || canonicalize?.(restoredWorkspacePreference) || 'data';
     }
 
     function captureGeneratorColumns() {
@@ -3093,8 +3110,7 @@
       activatePanel('.decisionTab[data-panel]', '.decisionPanel', otherText.decisionPanel);
       activatePanel('.toolTab[data-panel]', '.toolPanel', otherText.toolPanel);
       updateSortButtons();
-      const ids = window.SupplyWorkspaceNavigation?.WORKSPACE_IDS || [];
-      restoredWorkspacePreference = ids.includes(preferences.activeWorkspace) ? preferences.activeWorkspace : null;
+      restoredWorkspacePreference = window.SupplyWorkspaceNavigation?.canonicalWorkspaceId?.(preferences.activeWorkspace) || null;
     }
 
     function getWorkspaceStorageMessage(result, action = 'save') {
@@ -3407,7 +3423,7 @@
       }
       velocityHistoryFailureSignature = '';
       restoredWorkspacePreference = null;
-      workspaceUiController?.activate('today', { historyMode:'replace' });
+      workspaceUiController?.activate('data', { historyMode:'replace' });
       updateSortButtons();
       buildTables();
       updateTotals();
@@ -4401,7 +4417,7 @@
     function syncVisibleGeneratorRowsToDraft() { if (!generatorDraft) return false; const rows = Array.from(document.querySelectorAll('#productTable tbody tr')); for (const row of rows) { const serialized = serializeGeneratorRow(row); const existing = generatorDraft.rowsByProductSku?.[normalizeSkuKey(serialized.productSku)]; const command = existing ? { type:'patch-row', productSku:serialized.productSku, patch:{ quantities:serialized.quantities, pallet:serialized.pallet, locked:serialized.locked } } : { type:'upsert-row', row:serialized }; if (!applyGeneratorDraftCommand(command)) return false; } return Boolean(applyGeneratorDraftCommand({ type:'reorder-group', group:currentOrderGroup, productSkus:rows.map(row => row.dataset.product) })); }
     function persistGeneratorDraft(options = null) { const announce = options?.announce !== false; const api = getOrderDraftStateApi(); if (!api || !generatorDraft || generatorDraftLoadBlocked) { if (announce) setGeneratorDraftStatus('訂單草稿目前無法安全保存；請先處理上方載入錯誤。', 'error'); return false; } const result = api.saveOrderDraft({ storage:localStorage, draft:generatorDraft, context:getGeneratorDraftContext() }); if (!result?.ok) { setGeneratorDraftStatus(getGeneratorDraftErrorMessage(result, '訂單草稿保存失敗，請勿關閉頁面。'), 'error'); return false; } if (announce) { const count = Object.keys(generatorDraft.rowsByProductSku || {}).length; setGeneratorDraftStatus(`已自動保存 ${count} 個品項 · ${new Date().toLocaleTimeString('zh-TW', {hour:'2-digit', minute:'2-digit'})}`); } updateWorkflowUi(); return true; }
     function saveGeneratorDraft() { if (isRestoringDraft) return true; if (!syncVisibleGeneratorRowsToDraft()) return false; return persistGeneratorDraft(); }
-    function hydrateGeneratorRow(row, draftRow, prod) { const quantities = draftRow?.quantities || {}, pallet = draftRow?.pallet || {}; const put = (selector, value) => { const input = row.querySelector(selector); if (input) input.value = value ?? ''; }; row.dataset.orderCode = draftRow.orderSku || draftRow.productSku; row.dataset.palletMode = pallet.mode || ''; row.dataset.exactPalletValue = String(pallet.value ?? '').trim(); const label = row.querySelector('.order-code-label'); if (label) label.textContent = row.dataset.orderCode; put('.edit-quantity-input', quantities.quantity ?? quantities.packages); put('.edit-pack-input, .edit-box-input', quantities.units ?? quantities.secondary); put('.target-input', quantities.target); put('.edit-cartons-input', quantities.cartons); put('.edit-pallets-input', row.dataset.exactPalletValue === '' ? '' : formatPalletValue(pallet.value)); if (String(quantities.orderDraft ?? '').trim() && Number.isFinite(Number(quantities.orderDraft))) row.dataset.orderDraftQuantity = String(Math.max(0, Number(quantities.orderDraft))); row.dataset.authoritativeField = pallet.authoritativeField || ''; const targetInput = row.querySelector('.target-input'); if (targetInput) checkTarget(targetInput); if (draftRow.locked) { row.classList.add('locked'); row.querySelectorAll('input').forEach(control => { control.disabled = true; }); const icon = row.querySelector('.lock-button'); if (icon) icon.innerHTML = '<i class="fa-solid fa-lock-open"></i>'; } const currentCatalogIssue = getProductPalletCatalogIssue(prod); const restoredWarningCode = currentCatalogIssue?.code || (pallet.warningCode === 'INVALID_PALLET_CATALOG' ? '' : (pallet.warningCode || '')); setGeneratorPalletState(row, { warningCode:restoredWarningCode, strategy:pallet.strategy || '', message:currentCatalogIssue ? '' : (pallet.guidance || '') }); updateEstimatedDays(row, prod); }
+    function hydrateGeneratorRow(row, draftRow, prod) { const quantities = draftRow?.quantities || {}, pallet = draftRow?.pallet || {}; const put = (selector, value) => { const input = row.querySelector(selector); if (input) input.value = value ?? ''; }; row.dataset.orderCode = draftRow.orderSku || draftRow.productSku; row.dataset.palletMode = pallet.mode || ''; row.dataset.exactPalletValue = String(pallet.value ?? '').trim(); const label = row.querySelector('.order-code-label'); if (label) label.textContent = row.dataset.orderCode; put('.edit-quantity-input', quantities.quantity ?? quantities.packages); put('.edit-pack-input, .edit-box-input', quantities.units ?? quantities.secondary); put('.target-input', quantities.target); put('.edit-cartons-input', quantities.cartons); put('.edit-pallets-input', row.dataset.exactPalletValue === '' ? '' : formatPalletValue(pallet.value)); if (String(quantities.orderDraft ?? '').trim() && Number.isFinite(Number(quantities.orderDraft))) row.dataset.orderDraftQuantity = String(Math.max(0, Number(quantities.orderDraft))); row.dataset.authoritativeField = pallet.authoritativeField || ''; const targetInput = row.querySelector('.target-input'); if (targetInput) checkTarget(targetInput); if (draftRow.locked) { row.classList.add('locked'); row.querySelectorAll('input').forEach(control => { control.disabled = true; }); } syncGeneratorLockButton(row); const currentCatalogIssue = getProductPalletCatalogIssue(prod); const restoredWarningCode = currentCatalogIssue?.code || (pallet.warningCode === 'INVALID_PALLET_CATALOG' ? '' : (pallet.warningCode || '')); setGeneratorPalletState(row, { warningCode:restoredWarningCode, strategy:pallet.strategy || '', message:currentCatalogIssue ? '' : (pallet.guidance || '') }); updateEstimatedDays(row, prod); }
     function renderGeneratorRepairRows() { const box = document.getElementById('generatorRepairRows'); if (!box) return; const rows = (generatorDraft?.repairOrder || []).map(productSku => generatorDraft.rowsByProductSku?.[productSku]).filter(Boolean); box.hidden = rows.length === 0; box.innerHTML = rows.length ? `<b>需要修復，暫停匯出</b><br>${rows.map(row => { const quantities = Object.entries(row.quantities || {}).filter(([, value]) => String(value ?? '').trim() !== '').map(([key, value]) => `${key}: ${value}`).join(' · ') || '未保存數量'; const issues = (row.issues || []).map(issue => issue.code).join('、') || '身份資料不完整'; return `<div class="generatorRepairRow" data-repair-product="${escapeHtml(row.productSku)}"><span>Product SKU：${escapeHtml(row.productSku)} · Order SKU：${escapeHtml(row.orderSku)} · ${escapeHtml(quantities)} · 棧板：${escapeHtml(String(row.pallet?.value ?? ''))} · ${escapeHtml(issues)}</span> <button type="button" class="secondary generatorRepairDelete">刪除此筆</button></div>`; }).join('')}` : ''; box.querySelectorAll('.generatorRepairDelete').forEach(button => { button.addEventListener('click', () => removeGeneratorRepairRow(button)); }); }
     function removeGeneratorRepairRow(button) { const productSku = button?.closest('.generatorRepairRow')?.dataset.repairProduct; if (!productSku) return; const result = applyGeneratorDraftCommand({ type:'remove-row', productSku }); if (!result) return; persistGeneratorDraft(); renderActiveOrderGroup(); setGeneratorDraftStatus(`已刪除需要修復的 ${productSku}，可重新檢查匯出。`); }
     window.removeGeneratorRepairRow = removeGeneratorRepairRow;
@@ -4418,6 +4434,7 @@
     function getProductPalletCatalogIssue(prod) { if (!window.SupplyPlanningLegacy) return { code:'INVALID_PALLET_CATALOG' }; return window.SupplyPlanningLegacy.getPalletCatalogIssue({ unitsPerPallet:getUnitsPerPallet(prod), executableOrderIncrement:getOrderIncrementInAmazonUnits(prod?.productCode) }); }
     function formatPalletDays(prod) { const planningVelocity = getPlanningVelocityForProduct(prod.productCode); if (!planningVelocity || planningVelocity <= 0) return '—'; const days = getUnitsPerPallet(prod) / planningVelocity; return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—'; }
     function formatEstimatedDays(prod) { const code = getCanonicalSku(prod.productCode); const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code); if (!sourceRow) return '—'; const days = getLeadTimePlan(sourceRow, 365).bookCoverageDays; return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—'; }
+    function renderGeneratorBookCoverage(prod) { const code = getCanonicalSku(prod.productCode); const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code); if (!sourceRow) return renderCoverageMeterHtml(null, 'unavailable'); const plan = getLeadTimePlan(sourceRow, 365); return renderCoverageMeterHtml(plan.bookCoverageDays, plan.canRecommend === false ? 'unavailable' : 'ready'); }
     function getPostArrivalCoverageDays(prod, quantity, units) {
       const code = getCanonicalSku(prod.productCode);
       const planningVelocity = getPlanningVelocityForProduct(code);
@@ -4428,32 +4445,19 @@
       const days = getLeadTimePlan(sourceRow, 365, Math.max(0, newOrderUnits)).continuousPostOrderCoverageDays;
       return Number.isFinite(days) ? days : null;
     }
-    function getGeneratorCoverageBand(days, targetDays = 180) {
-      if (!window.SupplyPlanningLegacy) return 'neutral';
-      return window.SupplyPlanningLegacy.classifyCoverageDays({ coverageDays:days, targetDays:Math.min(365, Math.max(1, Number(targetDays) || 180)), maximumCoverageDays:365 });
-    }
-    function formatPostArrivalDays(prod, quantity, units) {
-      const days = getPostArrivalCoverageDays(prod, quantity, units);
-      return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—';
-    }
     function renderGeneratorArrivalCoverage(prod, quantity, units) {
       const days = getPostArrivalCoverageDays(prod, quantity, units);
-      const coverage = formatPostArrivalDays(prod, quantity, units);
       const code = getCanonicalSku(prod.productCode);
       const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code);
-      if (!sourceRow || !Number.isFinite(days)) return escapeHtml(coverage);
+      if (!sourceRow || !Number.isFinite(days)) return renderCoverageMeterHtml(null, 'unavailable');
       const plan = getLeadTimePlan(sourceRow, 365);
-      if (plan.canRecommend === false) return `${escapeHtml(coverage)}<br><span class="generatorCoverageStatus neutral">資料未完整，不判色</span>`;
-      const target = getReorderTargetDays();
-      const band = getGeneratorCoverageBand(days, target);
-      const label = band === 'excess' ? '超過 365 天' : (band === 'low' ? `低於目標 ${target} 天` : `健康範圍 ${target}–365 天`);
-      return `${escapeHtml(coverage)}<br><span class="generatorCoverageStatus ${band}">${escapeHtml(label)}</span>`;
+      return renderCoverageMeterHtml(days, plan.canRecommend === false ? 'unavailable' : 'ready');
     }
     window.refreshGeneratorSpeedMetrics = function() { document.querySelectorAll('#productTable tbody tr').forEach(row => { const prod = getProductSpecByCode(row.dataset.product); if (!prod) return; row.querySelector('.pallet-days').textContent = formatPalletDays(prod); updateEstimatedDays(row, prod); }); };
     function searchProduct() { const raw = document.getElementById('searchInput').value.trim(); const val = normalizeSkuKey(raw); const nameVal = raw.toLocaleLowerCase('zh-Hant'); const res = document.getElementById('searchResults'); res.innerHTML = ''; if (!val) { res.style.display = 'none'; return; } const matched = getFilteredProducts().filter(p => normalizeSkuKey(p.productCode).includes(val) || String(p.productName || '').toLocaleLowerCase('zh-Hant').includes(nameVal)).slice(0, 40); if (matched.length) { res.style.display = 'block'; matched.forEach(prod => { const item = document.createElement('div'); item.className = 'search-result-item'; item.textContent = `${prod.productCode} - ${prod.productName}`; item.onclick = () => { addProduct(prod); document.getElementById('searchInput').value = ''; res.innerHTML = ''; res.style.display = 'none'; }; res.appendChild(item); }); } else res.style.display = 'none'; }
     window.searchProduct = searchProduct;
     function checkPackageType(prod) { const hasPack = typeof prod.perPack !== 'undefined' && prod.perPack > 0; const hasBox = typeof prod.perBox !== 'undefined' && prod.perBox > 0 && !hasPack; return { hasPack, hasBox }; }
-    function renderEquivalentOrderToggle(code, orderCode = code) { const group = getEquivalentSkuGroup(code); if (!group || group.length < 2) return ''; const currentIndex = group.indexOf(normalizeSkuKey(orderCode)); const nextCode = group[(currentIndex + 1) % group.length] || group[0]; return `<button type="button" class="miniBtn" onclick="toggleEquivalentOrderCode(this)">切換下單：${escapeHtml(nextCode)}</button>`; }
+    function renderEquivalentOrderToggle(code, orderCode = code) { const group = getEquivalentSkuGroup(code); if (!group || group.length < 2) return ''; const currentIndex = group.indexOf(normalizeSkuKey(orderCode)); const nextCode = group[(currentIndex + 1) % group.length] || group[0]; const safeNextCode = escapeHtml(nextCode); return `<button type="button" class="miniBtn" onclick="toggleEquivalentOrderCode(this)" aria-label="切換下單品號為 ${safeNextCode}" title="切換為 ${safeNextCode}" data-next-order-sku="${safeNextCode}"><i class="fa-solid fa-repeat" aria-hidden="true"></i></button>`; }
     function toggleEquivalentOrderCode(btn) { const row = btn.closest('tr'), group = getEquivalentSkuGroup(row?.dataset.product); if (!row || !group) return; saveGeneratorDraft(); const current = normalizeSkuKey(row.dataset.orderCode || group[0]); const nextOrderSku = group[(group.indexOf(current) + 1) % group.length] || group[0]; const result = applyGeneratorDraftCommand({ type:'switch-order-sku', productSku:row.dataset.product, orderSku:nextOrderSku }); if (!result) return; persistGeneratorDraft(); setActiveOrderGroup(result.row.orderGroup); renderActiveOrderGroup(); showTip(`已切換下單品號 ${result.row.orderSku}，並移至${getOrderGroupLabel(result.row.orderGroup)}。`, 'success'); }
     window.toggleEquivalentOrderCode = toggleEquivalentOrderCode;
     function createGeneratorDraftRow(prod, { quantity = null, recommendation = null } = {}) { const { hasPack, hasBox } = checkPackageType(prod); let values = { quantity:0, units:0, cartons:0, pallets:0 }; let authoritativeField = ''; let palletMode = 'derived'; if (recommendation) { const recommendedQuantity = Number(recommendation.quantity); const recommendedPallets = Number(recommendation.pallets); const applyBy = recommendation.applyBy || 'none'; if (applyBy === 'pallets' && recommendedPallets > 0) { values.pallets = recommendedPallets; authoritativeField = 'pallets'; values = recalcValues('pallets', { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } else if (applyBy === 'quantity' && recommendedQuantity > 0) { authoritativeField = (hasPack || hasBox) ? 'units' : 'quantity'; values[authoritativeField] = recommendedQuantity; values = recalcValues(authoritativeField, { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } palletMode = recommendation.strategy || (authoritativeField === 'pallets' ? 'whole-pallet' : 'unit-guidance'); } else if (quantity !== null && Number.isFinite(quantity)) { values.quantity = Math.max(0, quantity); authoritativeField = 'quantity'; values = recalcValues('quantity', { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } const warningCode = recommendation?.warning?.code || recommendation?.warning || ''; return { productSku:normalizeSkuKey(prod.productCode), orderSku:normalizeSkuKey(prod.productCode), quantities:{ packages:authoritativeField ? values.quantity : '', secondary:authoritativeField ? values.units : '', target:'', cartons:authoritativeField ? values.cartons : '', orderDraft:authoritativeField ? getOrderDraftQuantityFromValues(prod, values.quantity, values.units) : '' }, pallet:{ value:authoritativeField ? values.pallets : '', mode:palletMode, authoritativeField, warningCode, strategy:recommendation?.strategy || '', guidance:getPalletRecommendationWarning(warningCode) }, locked:false }; }
@@ -4488,7 +4492,7 @@
       const quantityInputs = `<div class="generatorQuantityGroup${unitInput ? '' : ' single'}"><label class="generatorQuantityField"><span>包</span><input type="number" class="edit-quantity-input" placeholder="包數" oninput="updateFields(this,'${code}')"></label>${unitInput ? `<label class="generatorQuantityField"><span>${unitLabel}</span>${unitInput}</label>` : ''}</div>`;
       const targetPlaceholder = hasPack ? '目標袋數' : (hasBox ? '目標盒數' : '目標包數');
       const orderCode = draftRow.orderSku || code;
-      const rowHTML = `<tr data-product="${escapeHtml(code)}" data-order-code="${escapeHtml(orderCode)}"><td></td><td><span class="order-code-label">${escapeHtml(orderCode)}</span>${renderEquivalentOrderToggle(code, orderCode)}</td><td>${quantityInputs}</td><td data-generator-col="target"><input type="number" class="target-input" placeholder="${targetPlaceholder}" oninput="checkTarget(this)"></td><td data-generator-col="cartons"><input type="number" class="edit-cartons-input" placeholder="箱數" oninput="updateFields(this,'${code}')"></td><td><div class="palletStepControl"><input type="number" class="edit-pallets-input" step="any" min="0" placeholder="棧板數" oninput="updateFields(this,'${code}')" onchange="normalizeGeneratorPallets(this,'${code}')" onkeydown="handleGeneratorPalletKey(event)"><span class="palletStepButtons"><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,1)" aria-label="增加 1 棧板">▲</button><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,-1)" aria-label="減少 1 棧板">▼</button></span></div><span class="pallet-guidance" hidden></span></td><td class="box-size-cell" data-generator-col="box">${escapeHtml(prod.boxSize || '')} cm</td><td class="pallet-days">${formatPalletDays(prod)}</td><td class="estimated-days" data-generator-col="estimated">${formatEstimatedDays(prod, 0, 0)}</td><td class="arrival-days" data-generator-col="arrival">${renderGeneratorArrivalCoverage(prod, 0, 0)}</td><td class="generatorActions"><button type="button" class="drag-handle" aria-label="按住拖曳排序" title="按住拖曳排序"><i class="fa-solid fa-grip-vertical"></i></button><button type="button" class="lock-button" onclick="toggleLock(this)" aria-label="鎖定這列"><i class="fa-solid fa-lock"></i></button><button type="button" class="remove-button" onclick="removeRow(this)" aria-label="刪除這列"><i class="fa-solid fa-trash"></i></button></td></tr>`;
+      const rowHTML = `<tr data-product="${escapeHtml(code)}" data-order-code="${escapeHtml(orderCode)}"><td></td><td><span class="order-code-label">${escapeHtml(orderCode)}</span>${renderEquivalentOrderToggle(code, orderCode)}</td><td>${quantityInputs}</td><td data-generator-col="target"><input type="number" class="target-input" placeholder="${targetPlaceholder}" oninput="checkTarget(this)"></td><td data-generator-col="cartons"><input type="number" class="edit-cartons-input" placeholder="箱數" oninput="updateFields(this,'${code}')"></td><td><div class="palletStepControl"><input type="number" class="edit-pallets-input" step="any" min="0" aria-label="${escapeHtml(code)} 棧板數" placeholder="棧板數" oninput="updateFields(this,'${code}')" onchange="normalizeGeneratorPallets(this,'${code}')" onkeydown="handleGeneratorPalletKey(event)"><span class="palletStepButtons"><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,1)" aria-label="增加 1 棧板" title="增加 1 棧板">▲</button><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,-1)" aria-label="減少 1 棧板" title="減少 1 棧板">▼</button></span></div><span class="pallet-guidance" hidden></span></td><td class="box-size-cell" data-generator-col="box">${escapeHtml(prod.boxSize || '')} cm</td><td class="pallet-days">${formatPalletDays(prod)}</td><td class="estimated-days" data-generator-col="estimated">${renderGeneratorBookCoverage(prod)}</td><td class="arrival-days" data-generator-col="arrival">${renderGeneratorArrivalCoverage(prod, 0, 0)}</td><td class="generatorActions"><span class="generatorActionGroup"><button type="button" class="drag-handle" aria-label="按住拖曳排序" title="按住拖曳排序"><i class="fa-solid fa-grip-vertical" aria-hidden="true"></i></button><button type="button" class="lock-button" onclick="toggleLock(this)" aria-label="鎖定這列" aria-pressed="false" title="鎖定這列"><i class="fa-solid fa-lock" aria-hidden="true"></i></button><button type="button" class="remove-button" onclick="removeRow(this)" aria-label="刪除這列" title="刪除這列"><i class="fa-solid fa-trash" aria-hidden="true"></i></button></span></td></tr>`;
       tbody.insertAdjacentHTML('beforeend', rowHTML);
       const row = tbody.lastElementChild;
       hydrateGeneratorRow(row, draftRow, prod);
@@ -4525,11 +4529,12 @@
     function getRowExactMetrics(row) { const prod = getProductSpecByCode(row?.dataset.product); if (!prod) return { quantity:0, cartons:0, pallets:0 }; const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const { hasPack, hasBox } = checkPackageType(prod); const factor = hasPack ? Number(prod.perPack) : (hasBox ? Number(prod.perBox) : 1); const quantity = orderDraftQuantity * (Number.isFinite(factor) && factor > 0 ? factor : 1); const perCarton = Number(prod.perCarton); const cartons = Number.isFinite(perCarton) && perCarton > 0 ? (hasBox ? orderDraftQuantity : quantity) / perCarton : 0; const unitsPerPallet = getUnitsPerPallet(prod); const pallets = unitsPerPallet > 0 ? orderDraftQuantity / unitsPerPallet : 0; return { quantity, cartons, pallets, orderDraftQuantity }; }
     function updateFields(input, productCode, state = {}) { const row = input.closest('tr'), prod = getProductSpecByCode(productCode); if (!prod) return; const catalogIssue = getProductPalletCatalogIssue(prod); const changedField = getChangedField(input); const authoritativeField = state.authoritativeField || changedField; row.dataset.authoritativeField = authoritativeField; row.dataset.palletMode = state.mode || (authoritativeField === 'pallets' ? 'manual' : 'derived'); if (changedField === 'pallets' && catalogIssue) { setGeneratorPalletState(row, { warningCode:catalogIssue.code }); updateTotals(); saveGeneratorDraft(); return; } let { quantity, units, cartons, pallets } = getCurrentValues(row); ({ quantity, units, cartons, pallets } = recalcValues(changedField, { quantity, units, cartons, pallets, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) })); row.dataset.exactPalletValue = Number.isFinite(pallets) && pallets >= 0 ? String(pallets) : ''; if (changedField !== 'quantity') row.querySelector('.edit-quantity-input').value = formatDraftNumber(quantity); const unitInput = row.querySelector('.edit-pack-input') || row.querySelector('.edit-box-input'); if (unitInput && changedField !== 'units') unitInput.value = formatDraftNumber(units); if (changedField !== 'cartons') row.querySelector('.edit-cartons-input').value = formatDraftNumber(cartons); if (!catalogIssue && changedField !== 'pallets') row.querySelector('.edit-pallets-input').value = formatPalletValue(pallets); const exactOrderDraftQuantity = Number(state.exactOrderDraftQuantity); row.dataset.orderDraftQuantity = String(Number.isFinite(exactOrderDraftQuantity) && exactOrderDraftQuantity >= 0 ? exactOrderDraftQuantity : getOrderDraftQuantityFromValues(prod, quantity, units)); setGeneratorPalletState(row, { warningCode:catalogIssue?.code || '' }); updateEstimatedDays(row, prod); updateTotals(); saveGeneratorDraft(); }
     window.updateFields = updateFields;
-    function updateEstimatedDays(row, prod) { const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const quantity = checkPackageType(prod).hasPack || checkPackageType(prod).hasBox ? 0 : orderDraftQuantity; const units = quantity > 0 ? 0 : orderDraftQuantity; const estimated = row.querySelector('.estimated-days'); const arrival = row.querySelector('.arrival-days'); if (estimated) estimated.textContent = formatEstimatedDays(prod); if (arrival) arrival.innerHTML = renderGeneratorArrivalCoverage(prod, quantity, units); }
+    function updateEstimatedDays(row, prod) { const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const quantity = checkPackageType(prod).hasPack || checkPackageType(prod).hasBox ? 0 : orderDraftQuantity; const units = quantity > 0 ? 0 : orderDraftQuantity; const estimated = row.querySelector('.estimated-days'); const arrival = row.querySelector('.arrival-days'); if (estimated) estimated.innerHTML = renderGeneratorBookCoverage(prod); if (arrival) arrival.innerHTML = renderGeneratorArrivalCoverage(prod, quantity, units); }
     function checkTarget(targetInput) { const row = targetInput.closest('tr'); const unitInput = row.querySelector('.edit-pack-input') || row.querySelector('.edit-box-input'); const currentVal = unitInput ? (parseFloat(unitInput.value) || 0) : (parseFloat(row.querySelector('.edit-quantity-input').value) || 0); const tVal = parseFloat(targetInput.value) || 0; if (tVal > 0 && currentVal >= tVal) { targetInput.style.backgroundColor = '#23c87d'; targetInput.style.color = '#fff'; } else if (tVal > 0) { targetInput.style.backgroundColor = '#fa5353'; targetInput.style.color = '#fff'; } else { targetInput.style.backgroundColor = ''; targetInput.style.color = ''; } saveGeneratorDraft(); }
     window.checkTarget = checkTarget;
     function setGeneratorPalletState(row, { warningCode = '', strategy = '', message = '' } = {}) { if (!row) return; const code = warningCode?.code || warningCode || ''; row.dataset.palletWarningCode = code; row.dataset.palletStrategy = strategy || ''; const invalid = code === 'INVALID_PALLET_CATALOG'; const locked = row.classList.contains('locked'); const palletInput = row.querySelector('.edit-pallets-input'); if (palletInput) { if (invalid) palletInput.value = ''; palletInput.disabled = locked || invalid; } row.querySelectorAll('.palletStepButton').forEach(control => { control.disabled = locked || invalid; }); const guidance = row.querySelector('.pallet-guidance'); const guidanceText = message || getPalletRecommendationWarning(code) || (strategy === 'fractional-exception' ? '整板會超過 365 天；已依最小箱數預填零散棧板。' : ''); if (guidance) { guidance.textContent = guidanceText; guidance.hidden = !guidanceText; } }
-    function toggleLock(btn) { const row = btn.closest('tr'); const isLocked = row.classList.contains('locked'); row.classList.toggle('locked', !isLocked); row.querySelectorAll('input').forEach(control => { control.disabled = !isLocked; }); setGeneratorPalletState(row, { warningCode:row.dataset.palletWarningCode || '', strategy:row.dataset.palletStrategy || '', message:row.querySelector('.pallet-guidance')?.textContent || '' }); btn.innerHTML = isLocked ? '<i class="fa-solid fa-lock"></i>' : '<i class="fa-solid fa-lock-open"></i>'; saveGeneratorDraft(); }
+    function syncGeneratorLockButton(row) { const button = row?.querySelector('.lock-button'); if (!button) return; const locked = row.classList.contains('locked'); const label = locked ? '解除鎖定這列' : '鎖定這列'; button.innerHTML = locked ? '<i class="fa-solid fa-lock-open" aria-hidden="true"></i>' : '<i class="fa-solid fa-lock" aria-hidden="true"></i>'; button.setAttribute('aria-label', label); button.setAttribute('title', label); button.setAttribute('aria-pressed', String(locked)); }
+    function toggleLock(btn) { const row = btn.closest('tr'); const isLocked = row.classList.contains('locked'); row.classList.toggle('locked', !isLocked); row.querySelectorAll('input').forEach(control => { control.disabled = !isLocked; }); setGeneratorPalletState(row, { warningCode:row.dataset.palletWarningCode || '', strategy:row.dataset.palletStrategy || '', message:row.querySelector('.pallet-guidance')?.textContent || '' }); syncGeneratorLockButton(row); saveGeneratorDraft(); }
     function removeRow(btn) { const row = btn.closest('tr'); if (!row) return; const result = applyGeneratorDraftCommand({ type:'remove-row', productSku:row.dataset.product }); if (!result) return; persistGeneratorDraft(); renderActiveOrderGroup(); }
     window.toggleLock = toggleLock; window.removeRow = removeRow;
     function updateRowNumbers() { document.querySelectorAll('#productTable tbody tr').forEach((r, i) => { r.cells[0].textContent = i + 1; }); }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>訂單分析器 V2</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 64 64%27%3E%3Ctext x=%278%27 y=%2746%27 font-size=%2742%27%3E📦%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <link rel="stylesheet" href="./shared/coverage-indicator.css">
   <style>
     :root { font-family: "Noto Sans TC", system-ui, -apple-system, "Segoe UI", Arial, sans-serif; color: #0f1d2b; }
     * { box-sizing: border-box; }
@@ -157,34 +158,48 @@
     .order-generator th, .order-generator td { padding: 12px 8px; border-bottom: 1px solid #e3e8f0; font-size: 13px; }
     .order-generator th { background: #eaf1fc; color: #375a7f; font-weight: 700; border-bottom: 2px solid #b7d2f6; }
     .order-generator tr:hover td { background: #f0f5fe; }
-    .order-generator .action-button, .order-generator .remove-button, .order-generator .lock-button, .order-generator .drag-handle { background: #e0e7f3; color: #5c6f8f; padding: 5px 9px; margin: 2px 1px; border: none; border-radius: 6px; cursor: pointer; font-size: 15px; font-weight: bold; transition: background 0.2s; box-shadow: none; }
-    .order-generator .remove-button { background: #fa7878; color: #fff; }
-    .order-generator .lock-button { background: #ffd76b; color: #925700; }
-    .order-generator .drag-handle { cursor: grab; background:#dbeafe; color:#2563eb; touch-action:none; }
+    .order-generator .action-button, .order-generator .remove-button, .order-generator .lock-button, .order-generator .drag-handle { display:inline-grid; place-items:center; inline-size:28px; block-size:28px; padding:0; margin:0; border:0; border-radius:7px; background:transparent; color:#64748b; cursor:pointer; font-size:12px; font-weight:800; transition:background .15s ease,color .15s ease; box-shadow:none; }
+    .order-generator .action-button:hover, .order-generator .remove-button:hover, .order-generator .lock-button:hover, .order-generator .drag-handle:hover { transform:none; box-shadow:none; }
+    .order-generator .remove-button { color:#dc2626; }
+    .order-generator .remove-button:hover { background:#fee2e2; color:#b91c1c; }
+    .order-generator .lock-button { color:#92600a; }
+    .order-generator .lock-button:hover { background:#fef3c7; color:#854d0e; }
+    .order-generator .drag-handle { cursor:grab; color:#2563eb; touch-action:none; }
+    .order-generator .drag-handle:hover { background:#dbeafe; color:#1d4ed8; }
     .order-generator .drag-handle:active { cursor:grabbing; }
     .order-generator tr.generator-dragging { opacity:.45; pointer-events:none; }
-    .order-generator .generatorActions { white-space:nowrap; }
+    .order-generator .generatorActions { width:1%; padding-inline:4px; white-space:nowrap; }
+    .generatorActionGroup { display:inline-flex; align-items:center; gap:3px; inline-size:90px; }
+    .order-generator .generatorActionGroup > button:focus-visible, .order-generator .miniBtn:focus-visible { outline:2px solid #2563eb; outline-offset:2px; }
+    .order-generator .miniBtn { display:inline-grid; place-items:center; inline-size:26px; block-size:26px; margin-left:4px; padding:0; border-radius:7px; font-size:11px; }
     .generatorQuantityGroup { display:flex; flex-direction:column; gap:6px; min-width:84px; max-width:112px; }
     .generatorQuantityGroup.single { min-width:82px; }
     .generatorQuantityField { display:flex; flex-direction:column; gap:3px; color:#64748b; font-size:10px; font-weight:800; }
     .generatorQuantityField input { min-width:0; width:100%; }
-    .palletStepControl { display:grid; grid-template-columns:minmax(72px,1fr) 28px; gap:4px; align-items:stretch; min-width:104px; }
-    .palletStepButtons { display:grid; grid-template-rows:1fr 1fr; gap:3px; }
-    .palletStepButton { display:grid; place-items:center; min-width:28px; min-height:24px; padding:0; border:1px solid #cbd5e1; border-radius:7px; background:#fff; color:#334155; box-shadow:none; font-size:12px; line-height:1; cursor:pointer; }
-    .palletStepButton:hover { background:#eff6ff; color:#1d4ed8; }
+    .palletStepControl { position:relative; display:block; width:88px; min-width:88px; height:34px; }
+    .palletStepButtons { position:absolute; inset:1px 1px 1px auto; z-index:1; display:grid; grid-template-rows:1fr 1fr; width:20px; overflow:hidden; border-left:1px solid #cbd5e1; border-radius:0 7px 7px 0; }
+    .palletStepButton { display:grid; place-items:center; width:20px; min-width:0; min-height:0; padding:0; margin:0; border:0; border-radius:0; background:#f8fafc; color:#475569; box-shadow:none; font-size:8px; line-height:1; cursor:pointer; }
+    .palletStepButton + .palletStepButton { border-top:1px solid #cbd5e1; }
+    .palletStepButton:hover { background:#eff6ff; color:#1d4ed8; transform:none; box-shadow:none; }
+    .palletStepButton:focus-visible { outline:0; box-shadow:inset 0 0 0 2px #2563eb; }
     .palletStepButton:disabled { cursor:not-allowed; opacity:.45; }
-    .edit-pallets-input { appearance:textfield; -moz-appearance:textfield; }
+    .palletStepControl:focus-within .edit-pallets-input { border-color:#2563eb; box-shadow:0 0 0 2px rgba(37,99,235,.2); }
+    .edit-pallets-input { width:100%; height:100%; padding:6px 23px 6px 8px; border-radius:8px; appearance:textfield; -moz-appearance:textfield; }
     .edit-pallets-input::-webkit-inner-spin-button, .edit-pallets-input::-webkit-outer-spin-button { appearance:none; margin:0; }
     .pallet-guidance { display:block; max-width:128px; margin-top:4px; color:#92400e; font-size:10px; font-weight:750; line-height:1.3; }
     .pallet-guidance[hidden] { display:none; }
-    .generatorCoverageStatus { font-size:.78rem; font-weight:850; white-space:nowrap; }
-    .generatorCoverageStatus.low { color:#b45309; }
-    .generatorCoverageStatus.healthy { color:#15803d; }
-    .generatorCoverageStatus.excess { color:#b91c1c; }
-    .generatorCoverageStatus.neutral { color:#64748b; }
+    .coverageHealthCell, .estimated-days, .arrival-days { min-width:148px; }
     .order-generator tr.locked td, .order-generator tr.locked:hover td { background:#dcfce7 !important; color:#166534; border-bottom-color:#86efac; }
     .order-generator tr.locked input { background:#f0fdf4; color:#166534; border-color:#86efac; font-weight:800; }
-    .order-generator tr.locked .lock-button { background:#16a34a; color:#fff; }
+    .order-generator tr.locked .lock-button { background:#dcfce7; color:#15803d; }
+    @media (pointer:coarse) {
+      .palletStepControl { width:96px; min-width:96px; height:48px; }
+      .palletStepButtons { inset:0 0 0 auto; width:28px; }
+      .palletStepButton { width:28px; font-size:10px; }
+      .edit-pallets-input { padding-right:31px; }
+      .order-generator .generatorActionGroup { gap:3px; inline-size:126px; }
+      .order-generator .generatorActionGroup > button, .order-generator .miniBtn { inline-size:40px; block-size:40px; }
+    }
     .generatorColumnBar { display:flex; align-items:center; flex-wrap:wrap; gap:7px; margin:0 0 10px; padding:9px 11px; border:1px solid #e2e8f0; border-radius:14px; background:#f8fafc; }
     .generatorColumnBar > span { color:#64748b; font-size:12px; font-weight:800; margin-right:2px; }
     .generatorColumnToggle { display:inline-flex; align-items:center; gap:5px; padding:6px 9px; border-radius:999px; background:#e2e8f0; color:#64748b; font-size:11px; font-weight:800; cursor:pointer; user-select:none; }
@@ -990,7 +1005,7 @@
                   <tbody></tbody>
                 </table>
               </div>
-              <div class="hint" style="text-align:right;margin-top:10px;">含舊訂單可售天數會包含 JAM/FY 的預計補貨；新訂單到港後總可售天數會先扣前置期銷售，納入已下單舊單，並排除「還沒下單／STOP」。低於目標天數會提醒，達標到 365 天為綠色，只有超過 365 天才標紅；建議會優先使用整板，只有下一整板會從低於目標跳到超過 365 天時，才依最小箱數顯示零散板。按住拖曳圖示可調整順序，草稿會自動保存。</div>
+              <div class="hint" style="text-align:right;margin-top:10px;">含舊訂單可售天數會包含 JAM/FY 的預計補貨；新訂單到港後總可售天數會先扣前置期銷售，納入已下單舊單，並排除「還沒下單／STOP」。血條固定為：低於 180 天黃色、180–365 天綠色、超過 365 天紅色；上方到港後目標仍只影響建議量。建議會優先使用整板，只有下一整板會從低於目標跳到超過 365 天時，才依最小箱數顯示零散板。按住拖曳圖示可調整順序，草稿會自動保存。</div>
               <div class="totals-container">
                 <div class="total"><i class="fa-solid fa-boxes-stacked"></i> 總包數: <span id="totalQuantity">0</span> | 總箱數: <span id="totalCartons">0</span> | 總棧板數: <span id="totalPallets">0</span></div>
                 <div class="box-counts" id="boxCounts"></div>
@@ -1315,6 +1330,7 @@
   <script type="module" src="./shared/workspace-snapshot.js"></script>
   <script type="module" src="./shared/workspace-navigation.js"></script>
   <script type="module" src="./shared/workspace-ui.js"></script>
+  <script type="module" src="./shared/coverage-indicator.js"></script>
   <script>
     const IS_BOSS_PORTAL = window.__SUPPLY_BOSS_PORTAL__ === true;
     if (IS_BOSS_PORTAL) document.body.classList.add('bossPortal');
@@ -2319,7 +2335,8 @@
     }
     function renderInventoryCell(value, missingText = "(未對應)") { return (value === null || value === undefined) ? `<td class="bad">${escapeHtml(missingText)}</td>` : `<td class="ok">${escapeHtml(fmtQty(value))}</td>`; }
     function renderNumericCell(value, badText = "(未對應)") { return (value === null || value === undefined) ? `<td class="bad">${escapeHtml(badText)}</td>` : `<td class="ok">${escapeHtml(fmtQty(value))}</td>`; }
-    function renderCoverageDaysCell(value, targetDays = getReorderTargetDays()) { if (!Number.isFinite(value)) return '<td class="bad">(不可算)</td>'; const band = getGeneratorCoverageBand(value, targetDays); const cls = band === 'excess' ? 'bad' : (band === 'low' ? 'warn' : 'ok'); const note = band === 'excess' ? '<br><span class="generatorCoverageStatus excess">超過 365 天</span>' : ''; return `<td class="${cls}">${fmtDays(value)}${note}</td>`; }
+    function renderCoverageMeterHtml(coverageDays, assessment = 'ready') { const api = window.SupplyCoverageIndicator; if (!api?.renderCoverageMeter) return Number.isFinite(coverageDays) ? escapeHtml(fmtDays(coverageDays)) : '—'; return api.renderCoverageMeter({ coverageDays:Number.isFinite(coverageDays) ? coverageDays : null, assessment }); }
+    function renderCoverageDaysCell(value) { const assessment = Number.isFinite(value) ? 'ready' : 'unavailable'; return `<td class="coverageHealthCell">${renderCoverageMeterHtml(value, assessment)}</td>`; }
     function getSharedBookCoverageDays(row) { const plan = getLeadTimePlan(row, 365); return Number.isFinite(plan?.bookCoverageDays) ? plan.bookCoverageDays : row?.days; }
     function renderAmazonUnitCell(value, rawValue, sku, missingText = "(未對應)") {
       if (value === null || value === undefined) return `<td class="bad">${escapeHtml(missingText)}</td>`;
@@ -2877,9 +2894,9 @@
     }
 
     function captureActiveWorkspace() {
-      const ids = window.SupplyWorkspaceNavigation?.WORKSPACE_IDS || [];
       const activeWorkspace = workspaceUiController?.getActiveWorkspace();
-      return ids.includes(activeWorkspace) ? activeWorkspace : (ids.includes(restoredWorkspacePreference) ? restoredWorkspacePreference : 'today');
+      const canonicalize = window.SupplyWorkspaceNavigation?.canonicalWorkspaceId;
+      return canonicalize?.(activeWorkspace) || canonicalize?.(restoredWorkspacePreference) || 'data';
     }
 
     function captureGeneratorColumns() {
@@ -2990,8 +3007,7 @@
       activatePanel('.decisionTab[data-panel]', '.decisionPanel', otherText.decisionPanel);
       activatePanel('.toolTab[data-panel]', '.toolPanel', otherText.toolPanel);
       updateSortButtons();
-      const ids = window.SupplyWorkspaceNavigation?.WORKSPACE_IDS || [];
-      restoredWorkspacePreference = ids.includes(preferences.activeWorkspace) ? preferences.activeWorkspace : null;
+      restoredWorkspacePreference = window.SupplyWorkspaceNavigation?.canonicalWorkspaceId?.(preferences.activeWorkspace) || null;
     }
 
     function getWorkspaceStorageMessage(result, action = 'save') {
@@ -3304,7 +3320,7 @@
       }
       velocityHistoryFailureSignature = '';
       restoredWorkspacePreference = null;
-      workspaceUiController?.activate('today', { historyMode:'replace' });
+      workspaceUiController?.activate('data', { historyMode:'replace' });
       updateSortButtons();
       buildTables();
       updateTotals();
@@ -3776,7 +3792,7 @@
     function syncVisibleGeneratorRowsToDraft() { if (!generatorDraft) return false; const rows = Array.from(document.querySelectorAll('#productTable tbody tr')); for (const row of rows) { const serialized = serializeGeneratorRow(row); const existing = generatorDraft.rowsByProductSku?.[normalizeSkuKey(serialized.productSku)]; const command = existing ? { type:'patch-row', productSku:serialized.productSku, patch:{ quantities:serialized.quantities, pallet:serialized.pallet, locked:serialized.locked } } : { type:'upsert-row', row:serialized }; if (!applyGeneratorDraftCommand(command)) return false; } return Boolean(applyGeneratorDraftCommand({ type:'reorder-group', group:currentOrderGroup, productSkus:rows.map(row => row.dataset.product) })); }
     function persistGeneratorDraft(options = null) { const announce = options?.announce !== false; const api = getOrderDraftStateApi(); if (!api || !generatorDraft || generatorDraftLoadBlocked) { if (announce) setGeneratorDraftStatus('訂單草稿目前無法安全保存；請先處理上方載入錯誤。', 'error'); return false; } const result = api.saveOrderDraft({ storage:localStorage, draft:generatorDraft, context:getGeneratorDraftContext() }); if (!result?.ok) { setGeneratorDraftStatus(getGeneratorDraftErrorMessage(result, '訂單草稿保存失敗，請勿關閉頁面。'), 'error'); return false; } if (announce) { const count = Object.keys(generatorDraft.rowsByProductSku || {}).length; setGeneratorDraftStatus(`已自動保存 ${count} 個品項 · ${new Date().toLocaleTimeString('zh-TW', {hour:'2-digit', minute:'2-digit'})}`); } updateWorkflowUi(); return true; }
     function saveGeneratorDraft() { if (isRestoringDraft) return true; if (!syncVisibleGeneratorRowsToDraft()) return false; return persistGeneratorDraft(); }
-    function hydrateGeneratorRow(row, draftRow, prod) { const quantities = draftRow?.quantities || {}, pallet = draftRow?.pallet || {}; const put = (selector, value) => { const input = row.querySelector(selector); if (input) input.value = value ?? ''; }; row.dataset.orderCode = draftRow.orderSku || draftRow.productSku; row.dataset.palletMode = pallet.mode || ''; row.dataset.exactPalletValue = String(pallet.value ?? '').trim(); const label = row.querySelector('.order-code-label'); if (label) label.textContent = row.dataset.orderCode; put('.edit-quantity-input', quantities.quantity ?? quantities.packages); put('.edit-pack-input, .edit-box-input', quantities.units ?? quantities.secondary); put('.target-input', quantities.target); put('.edit-cartons-input', quantities.cartons); put('.edit-pallets-input', row.dataset.exactPalletValue === '' ? '' : formatPalletValue(pallet.value)); if (String(quantities.orderDraft ?? '').trim() && Number.isFinite(Number(quantities.orderDraft))) row.dataset.orderDraftQuantity = String(Math.max(0, Number(quantities.orderDraft))); row.dataset.authoritativeField = pallet.authoritativeField || ''; const targetInput = row.querySelector('.target-input'); if (targetInput) checkTarget(targetInput); if (draftRow.locked) { row.classList.add('locked'); row.querySelectorAll('input').forEach(control => { control.disabled = true; }); const icon = row.querySelector('.lock-button'); if (icon) icon.innerHTML = '<i class="fa-solid fa-lock-open"></i>'; } const currentCatalogIssue = getProductPalletCatalogIssue(prod); const restoredWarningCode = currentCatalogIssue?.code || (pallet.warningCode === 'INVALID_PALLET_CATALOG' ? '' : (pallet.warningCode || '')); setGeneratorPalletState(row, { warningCode:restoredWarningCode, strategy:pallet.strategy || '', message:currentCatalogIssue ? '' : (pallet.guidance || '') }); updateEstimatedDays(row, prod); }
+    function hydrateGeneratorRow(row, draftRow, prod) { const quantities = draftRow?.quantities || {}, pallet = draftRow?.pallet || {}; const put = (selector, value) => { const input = row.querySelector(selector); if (input) input.value = value ?? ''; }; row.dataset.orderCode = draftRow.orderSku || draftRow.productSku; row.dataset.palletMode = pallet.mode || ''; row.dataset.exactPalletValue = String(pallet.value ?? '').trim(); const label = row.querySelector('.order-code-label'); if (label) label.textContent = row.dataset.orderCode; put('.edit-quantity-input', quantities.quantity ?? quantities.packages); put('.edit-pack-input, .edit-box-input', quantities.units ?? quantities.secondary); put('.target-input', quantities.target); put('.edit-cartons-input', quantities.cartons); put('.edit-pallets-input', row.dataset.exactPalletValue === '' ? '' : formatPalletValue(pallet.value)); if (String(quantities.orderDraft ?? '').trim() && Number.isFinite(Number(quantities.orderDraft))) row.dataset.orderDraftQuantity = String(Math.max(0, Number(quantities.orderDraft))); row.dataset.authoritativeField = pallet.authoritativeField || ''; const targetInput = row.querySelector('.target-input'); if (targetInput) checkTarget(targetInput); if (draftRow.locked) { row.classList.add('locked'); row.querySelectorAll('input').forEach(control => { control.disabled = true; }); } syncGeneratorLockButton(row); const currentCatalogIssue = getProductPalletCatalogIssue(prod); const restoredWarningCode = currentCatalogIssue?.code || (pallet.warningCode === 'INVALID_PALLET_CATALOG' ? '' : (pallet.warningCode || '')); setGeneratorPalletState(row, { warningCode:restoredWarningCode, strategy:pallet.strategy || '', message:currentCatalogIssue ? '' : (pallet.guidance || '') }); updateEstimatedDays(row, prod); }
     function renderGeneratorRepairRows() { const box = document.getElementById('generatorRepairRows'); if (!box) return; const rows = (generatorDraft?.repairOrder || []).map(productSku => generatorDraft.rowsByProductSku?.[productSku]).filter(Boolean); box.hidden = rows.length === 0; box.innerHTML = rows.length ? `<b>需要修復，暫停匯出</b><br>${rows.map(row => { const quantities = Object.entries(row.quantities || {}).filter(([, value]) => String(value ?? '').trim() !== '').map(([key, value]) => `${key}: ${value}`).join(' · ') || '未保存數量'; const issues = (row.issues || []).map(issue => issue.code).join('、') || '身份資料不完整'; return `<div class="generatorRepairRow" data-repair-product="${escapeHtml(row.productSku)}"><span>Product SKU：${escapeHtml(row.productSku)} · Order SKU：${escapeHtml(row.orderSku)} · ${escapeHtml(quantities)} · 棧板：${escapeHtml(String(row.pallet?.value ?? ''))} · ${escapeHtml(issues)}</span> <button type="button" class="secondary generatorRepairDelete">刪除此筆</button></div>`; }).join('')}` : ''; box.querySelectorAll('.generatorRepairDelete').forEach(button => { button.addEventListener('click', () => removeGeneratorRepairRow(button)); }); }
     function removeGeneratorRepairRow(button) { const productSku = button?.closest('.generatorRepairRow')?.dataset.repairProduct; if (!productSku) return; const result = applyGeneratorDraftCommand({ type:'remove-row', productSku }); if (!result) return; persistGeneratorDraft(); renderActiveOrderGroup(); setGeneratorDraftStatus(`已刪除需要修復的 ${productSku}，可重新檢查匯出。`); }
     window.removeGeneratorRepairRow = removeGeneratorRepairRow;
@@ -3793,6 +3809,7 @@
     function getProductPalletCatalogIssue(prod) { if (!window.SupplyPlanningLegacy) return { code:'INVALID_PALLET_CATALOG' }; return window.SupplyPlanningLegacy.getPalletCatalogIssue({ unitsPerPallet:getUnitsPerPallet(prod), executableOrderIncrement:getOrderIncrementInAmazonUnits(prod?.productCode) }); }
     function formatPalletDays(prod) { const planningVelocity = getPlanningVelocityForProduct(prod.productCode); if (!planningVelocity || planningVelocity <= 0) return '—'; const days = getUnitsPerPallet(prod) / planningVelocity; return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—'; }
     function formatEstimatedDays(prod) { const code = getCanonicalSku(prod.productCode); const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code); if (!sourceRow) return '—'; const days = getLeadTimePlan(sourceRow, 365).bookCoverageDays; return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—'; }
+    function renderGeneratorBookCoverage(prod) { const code = getCanonicalSku(prod.productCode); const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code); if (!sourceRow) return renderCoverageMeterHtml(null, 'unavailable'); const plan = getLeadTimePlan(sourceRow, 365); return renderCoverageMeterHtml(plan.bookCoverageDays, plan.canRecommend === false ? 'unavailable' : 'ready'); }
     function getPostArrivalCoverageDays(prod, quantity, units) {
       const code = getCanonicalSku(prod.productCode);
       const planningVelocity = getPlanningVelocityForProduct(code);
@@ -3803,32 +3820,19 @@
       const days = getLeadTimePlan(sourceRow, 365, Math.max(0, newOrderUnits)).continuousPostOrderCoverageDays;
       return Number.isFinite(days) ? days : null;
     }
-    function getGeneratorCoverageBand(days, targetDays = 180) {
-      if (!window.SupplyPlanningLegacy) return 'neutral';
-      return window.SupplyPlanningLegacy.classifyCoverageDays({ coverageDays:days, targetDays:Math.min(365, Math.max(1, Number(targetDays) || 180)), maximumCoverageDays:365 });
-    }
-    function formatPostArrivalDays(prod, quantity, units) {
-      const days = getPostArrivalCoverageDays(prod, quantity, units);
-      return Number.isFinite(days) ? `${days.toFixed(1)} 天` : '—';
-    }
     function renderGeneratorArrivalCoverage(prod, quantity, units) {
       const days = getPostArrivalCoverageDays(prod, quantity, units);
-      const coverage = formatPostArrivalDays(prod, quantity, units);
       const code = getCanonicalSku(prod.productCode);
       const sourceRow = mainRowsAll.find(row => getCanonicalSku(row.sku) === code);
-      if (!sourceRow || !Number.isFinite(days)) return escapeHtml(coverage);
+      if (!sourceRow || !Number.isFinite(days)) return renderCoverageMeterHtml(null, 'unavailable');
       const plan = getLeadTimePlan(sourceRow, 365);
-      if (plan.canRecommend === false) return `${escapeHtml(coverage)}<br><span class="generatorCoverageStatus neutral">資料未完整，不判色</span>`;
-      const target = getReorderTargetDays();
-      const band = getGeneratorCoverageBand(days, target);
-      const label = band === 'excess' ? '超過 365 天' : (band === 'low' ? `低於目標 ${target} 天` : `健康範圍 ${target}–365 天`);
-      return `${escapeHtml(coverage)}<br><span class="generatorCoverageStatus ${band}">${escapeHtml(label)}</span>`;
+      return renderCoverageMeterHtml(days, plan.canRecommend === false ? 'unavailable' : 'ready');
     }
     window.refreshGeneratorSpeedMetrics = function() { document.querySelectorAll('#productTable tbody tr').forEach(row => { const prod = getProductSpecByCode(row.dataset.product); if (!prod) return; row.querySelector('.pallet-days').textContent = formatPalletDays(prod); updateEstimatedDays(row, prod); }); };
     function searchProduct() { const raw = document.getElementById('searchInput').value.trim(); const val = normalizeSkuKey(raw); const nameVal = raw.toLocaleLowerCase('zh-Hant'); const res = document.getElementById('searchResults'); res.innerHTML = ''; if (!val) { res.style.display = 'none'; return; } const matched = getFilteredProducts().filter(p => normalizeSkuKey(p.productCode).includes(val) || String(p.productName || '').toLocaleLowerCase('zh-Hant').includes(nameVal)).slice(0, 40); if (matched.length) { res.style.display = 'block'; matched.forEach(prod => { const item = document.createElement('div'); item.className = 'search-result-item'; item.textContent = `${prod.productCode} - ${prod.productName}`; item.onclick = () => { addProduct(prod); document.getElementById('searchInput').value = ''; res.innerHTML = ''; res.style.display = 'none'; }; res.appendChild(item); }); } else res.style.display = 'none'; }
     window.searchProduct = searchProduct;
     function checkPackageType(prod) { const hasPack = typeof prod.perPack !== 'undefined' && prod.perPack > 0; const hasBox = typeof prod.perBox !== 'undefined' && prod.perBox > 0 && !hasPack; return { hasPack, hasBox }; }
-    function renderEquivalentOrderToggle(code, orderCode = code) { const group = getEquivalentSkuGroup(code); if (!group || group.length < 2) return ''; const currentIndex = group.indexOf(normalizeSkuKey(orderCode)); const nextCode = group[(currentIndex + 1) % group.length] || group[0]; return `<button type="button" class="miniBtn" onclick="toggleEquivalentOrderCode(this)">切換下單：${escapeHtml(nextCode)}</button>`; }
+    function renderEquivalentOrderToggle(code, orderCode = code) { const group = getEquivalentSkuGroup(code); if (!group || group.length < 2) return ''; const currentIndex = group.indexOf(normalizeSkuKey(orderCode)); const nextCode = group[(currentIndex + 1) % group.length] || group[0]; const safeNextCode = escapeHtml(nextCode); return `<button type="button" class="miniBtn" onclick="toggleEquivalentOrderCode(this)" aria-label="切換下單品號為 ${safeNextCode}" title="切換為 ${safeNextCode}" data-next-order-sku="${safeNextCode}"><i class="fa-solid fa-repeat" aria-hidden="true"></i></button>`; }
     function toggleEquivalentOrderCode(btn) { const row = btn.closest('tr'), group = getEquivalentSkuGroup(row?.dataset.product); if (!row || !group) return; saveGeneratorDraft(); const current = normalizeSkuKey(row.dataset.orderCode || group[0]); const nextOrderSku = group[(group.indexOf(current) + 1) % group.length] || group[0]; const result = applyGeneratorDraftCommand({ type:'switch-order-sku', productSku:row.dataset.product, orderSku:nextOrderSku }); if (!result) return; persistGeneratorDraft(); setActiveOrderGroup(result.row.orderGroup); renderActiveOrderGroup(); showTip(`已切換下單品號 ${result.row.orderSku}，並移至${getOrderGroupLabel(result.row.orderGroup)}。`, 'success'); }
     window.toggleEquivalentOrderCode = toggleEquivalentOrderCode;
     function createGeneratorDraftRow(prod, { quantity = null, recommendation = null } = {}) { const { hasPack, hasBox } = checkPackageType(prod); let values = { quantity:0, units:0, cartons:0, pallets:0 }; let authoritativeField = ''; let palletMode = 'derived'; if (recommendation) { const recommendedQuantity = Number(recommendation.quantity); const recommendedPallets = Number(recommendation.pallets); const applyBy = recommendation.applyBy || 'none'; if (applyBy === 'pallets' && recommendedPallets > 0) { values.pallets = recommendedPallets; authoritativeField = 'pallets'; values = recalcValues('pallets', { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } else if (applyBy === 'quantity' && recommendedQuantity > 0) { authoritativeField = (hasPack || hasBox) ? 'units' : 'quantity'; values[authoritativeField] = recommendedQuantity; values = recalcValues(authoritativeField, { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } palletMode = recommendation.strategy || (authoritativeField === 'pallets' ? 'whole-pallet' : 'unit-guidance'); } else if (quantity !== null && Number.isFinite(quantity)) { values.quantity = Math.max(0, quantity); authoritativeField = 'quantity'; values = recalcValues('quantity', { ...values, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) }); } const warningCode = recommendation?.warning?.code || recommendation?.warning || ''; return { productSku:normalizeSkuKey(prod.productCode), orderSku:normalizeSkuKey(prod.productCode), quantities:{ packages:authoritativeField ? values.quantity : '', secondary:authoritativeField ? values.units : '', target:'', cartons:authoritativeField ? values.cartons : '', orderDraft:authoritativeField ? getOrderDraftQuantityFromValues(prod, values.quantity, values.units) : '' }, pallet:{ value:authoritativeField ? values.pallets : '', mode:palletMode, authoritativeField, warningCode, strategy:recommendation?.strategy || '', guidance:getPalletRecommendationWarning(warningCode) }, locked:false }; }
@@ -3863,7 +3867,7 @@
       const quantityInputs = `<div class="generatorQuantityGroup${unitInput ? '' : ' single'}"><label class="generatorQuantityField"><span>包</span><input type="number" class="edit-quantity-input" placeholder="包數" oninput="updateFields(this,'${code}')"></label>${unitInput ? `<label class="generatorQuantityField"><span>${unitLabel}</span>${unitInput}</label>` : ''}</div>`;
       const targetPlaceholder = hasPack ? '目標袋數' : (hasBox ? '目標盒數' : '目標包數');
       const orderCode = draftRow.orderSku || code;
-      const rowHTML = `<tr data-product="${escapeHtml(code)}" data-order-code="${escapeHtml(orderCode)}"><td></td><td><span class="order-code-label">${escapeHtml(orderCode)}</span>${renderEquivalentOrderToggle(code, orderCode)}</td><td>${quantityInputs}</td><td data-generator-col="target"><input type="number" class="target-input" placeholder="${targetPlaceholder}" oninput="checkTarget(this)"></td><td data-generator-col="cartons"><input type="number" class="edit-cartons-input" placeholder="箱數" oninput="updateFields(this,'${code}')"></td><td><div class="palletStepControl"><input type="number" class="edit-pallets-input" step="any" min="0" placeholder="棧板數" oninput="updateFields(this,'${code}')" onchange="normalizeGeneratorPallets(this,'${code}')" onkeydown="handleGeneratorPalletKey(event)"><span class="palletStepButtons"><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,1)" aria-label="增加 1 棧板">▲</button><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,-1)" aria-label="減少 1 棧板">▼</button></span></div><span class="pallet-guidance" hidden></span></td><td class="box-size-cell" data-generator-col="box">${escapeHtml(prod.boxSize || '')} cm</td><td class="pallet-days">${formatPalletDays(prod)}</td><td class="estimated-days" data-generator-col="estimated">${formatEstimatedDays(prod, 0, 0)}</td><td class="arrival-days" data-generator-col="arrival">${renderGeneratorArrivalCoverage(prod, 0, 0)}</td><td class="generatorActions"><button type="button" class="drag-handle" aria-label="按住拖曳排序" title="按住拖曳排序"><i class="fa-solid fa-grip-vertical"></i></button><button type="button" class="lock-button" onclick="toggleLock(this)" aria-label="鎖定這列"><i class="fa-solid fa-lock"></i></button><button type="button" class="remove-button" onclick="removeRow(this)" aria-label="刪除這列"><i class="fa-solid fa-trash"></i></button></td></tr>`;
+      const rowHTML = `<tr data-product="${escapeHtml(code)}" data-order-code="${escapeHtml(orderCode)}"><td></td><td><span class="order-code-label">${escapeHtml(orderCode)}</span>${renderEquivalentOrderToggle(code, orderCode)}</td><td>${quantityInputs}</td><td data-generator-col="target"><input type="number" class="target-input" placeholder="${targetPlaceholder}" oninput="checkTarget(this)"></td><td data-generator-col="cartons"><input type="number" class="edit-cartons-input" placeholder="箱數" oninput="updateFields(this,'${code}')"></td><td><div class="palletStepControl"><input type="number" class="edit-pallets-input" step="any" min="0" aria-label="${escapeHtml(code)} 棧板數" placeholder="棧板數" oninput="updateFields(this,'${code}')" onchange="normalizeGeneratorPallets(this,'${code}')" onkeydown="handleGeneratorPalletKey(event)"><span class="palletStepButtons"><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,1)" aria-label="增加 1 棧板" title="增加 1 棧板">▲</button><button type="button" class="palletStepButton" onclick="stepGeneratorPallets(this,-1)" aria-label="減少 1 棧板" title="減少 1 棧板">▼</button></span></div><span class="pallet-guidance" hidden></span></td><td class="box-size-cell" data-generator-col="box">${escapeHtml(prod.boxSize || '')} cm</td><td class="pallet-days">${formatPalletDays(prod)}</td><td class="estimated-days" data-generator-col="estimated">${renderGeneratorBookCoverage(prod)}</td><td class="arrival-days" data-generator-col="arrival">${renderGeneratorArrivalCoverage(prod, 0, 0)}</td><td class="generatorActions"><span class="generatorActionGroup"><button type="button" class="drag-handle" aria-label="按住拖曳排序" title="按住拖曳排序"><i class="fa-solid fa-grip-vertical" aria-hidden="true"></i></button><button type="button" class="lock-button" onclick="toggleLock(this)" aria-label="鎖定這列" aria-pressed="false" title="鎖定這列"><i class="fa-solid fa-lock" aria-hidden="true"></i></button><button type="button" class="remove-button" onclick="removeRow(this)" aria-label="刪除這列" title="刪除這列"><i class="fa-solid fa-trash" aria-hidden="true"></i></button></span></td></tr>`;
       tbody.insertAdjacentHTML('beforeend', rowHTML);
       const row = tbody.lastElementChild;
       hydrateGeneratorRow(row, draftRow, prod);
@@ -3900,11 +3904,12 @@
     function getRowExactMetrics(row) { const prod = getProductSpecByCode(row?.dataset.product); if (!prod) return { quantity:0, cartons:0, pallets:0 }; const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const { hasPack, hasBox } = checkPackageType(prod); const factor = hasPack ? Number(prod.perPack) : (hasBox ? Number(prod.perBox) : 1); const quantity = orderDraftQuantity * (Number.isFinite(factor) && factor > 0 ? factor : 1); const perCarton = Number(prod.perCarton); const cartons = Number.isFinite(perCarton) && perCarton > 0 ? (hasBox ? orderDraftQuantity : quantity) / perCarton : 0; const unitsPerPallet = getUnitsPerPallet(prod); const pallets = unitsPerPallet > 0 ? orderDraftQuantity / unitsPerPallet : 0; return { quantity, cartons, pallets, orderDraftQuantity }; }
     function updateFields(input, productCode, state = {}) { const row = input.closest('tr'), prod = getProductSpecByCode(productCode); if (!prod) return; const catalogIssue = getProductPalletCatalogIssue(prod); const changedField = getChangedField(input); const authoritativeField = state.authoritativeField || changedField; row.dataset.authoritativeField = authoritativeField; row.dataset.palletMode = state.mode || (authoritativeField === 'pallets' ? 'manual' : 'derived'); if (changedField === 'pallets' && catalogIssue) { setGeneratorPalletState(row, { warningCode:catalogIssue.code }); updateTotals(); saveGeneratorDraft(); return; } let { quantity, units, cartons, pallets } = getCurrentValues(row); ({ quantity, units, cartons, pallets } = recalcValues(changedField, { quantity, units, cartons, pallets, perPack:Number(prod.perPack || 0), perBox:Number(prod.perBox || 0), perCarton:Number(prod.perCarton), perPallet:Number(prod.perPallet) })); row.dataset.exactPalletValue = Number.isFinite(pallets) && pallets >= 0 ? String(pallets) : ''; if (changedField !== 'quantity') row.querySelector('.edit-quantity-input').value = formatDraftNumber(quantity); const unitInput = row.querySelector('.edit-pack-input') || row.querySelector('.edit-box-input'); if (unitInput && changedField !== 'units') unitInput.value = formatDraftNumber(units); if (changedField !== 'cartons') row.querySelector('.edit-cartons-input').value = formatDraftNumber(cartons); if (!catalogIssue && changedField !== 'pallets') row.querySelector('.edit-pallets-input').value = formatPalletValue(pallets); const exactOrderDraftQuantity = Number(state.exactOrderDraftQuantity); row.dataset.orderDraftQuantity = String(Number.isFinite(exactOrderDraftQuantity) && exactOrderDraftQuantity >= 0 ? exactOrderDraftQuantity : getOrderDraftQuantityFromValues(prod, quantity, units)); setGeneratorPalletState(row, { warningCode:catalogIssue?.code || '' }); updateEstimatedDays(row, prod); updateTotals(); saveGeneratorDraft(); }
     window.updateFields = updateFields;
-    function updateEstimatedDays(row, prod) { const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const quantity = checkPackageType(prod).hasPack || checkPackageType(prod).hasBox ? 0 : orderDraftQuantity; const units = quantity > 0 ? 0 : orderDraftQuantity; const estimated = row.querySelector('.estimated-days'); const arrival = row.querySelector('.arrival-days'); if (estimated) estimated.textContent = formatEstimatedDays(prod); if (arrival) arrival.innerHTML = renderGeneratorArrivalCoverage(prod, quantity, units); }
+    function updateEstimatedDays(row, prod) { const orderDraftQuantity = getRowOrderDraftQuantity(row, prod); const quantity = checkPackageType(prod).hasPack || checkPackageType(prod).hasBox ? 0 : orderDraftQuantity; const units = quantity > 0 ? 0 : orderDraftQuantity; const estimated = row.querySelector('.estimated-days'); const arrival = row.querySelector('.arrival-days'); if (estimated) estimated.innerHTML = renderGeneratorBookCoverage(prod); if (arrival) arrival.innerHTML = renderGeneratorArrivalCoverage(prod, quantity, units); }
     function checkTarget(targetInput) { const row = targetInput.closest('tr'); const unitInput = row.querySelector('.edit-pack-input') || row.querySelector('.edit-box-input'); const currentVal = unitInput ? (parseFloat(unitInput.value) || 0) : (parseFloat(row.querySelector('.edit-quantity-input').value) || 0); const tVal = parseFloat(targetInput.value) || 0; if (tVal > 0 && currentVal >= tVal) { targetInput.style.backgroundColor = '#23c87d'; targetInput.style.color = '#fff'; } else if (tVal > 0) { targetInput.style.backgroundColor = '#fa5353'; targetInput.style.color = '#fff'; } else { targetInput.style.backgroundColor = ''; targetInput.style.color = ''; } saveGeneratorDraft(); }
     window.checkTarget = checkTarget;
     function setGeneratorPalletState(row, { warningCode = '', strategy = '', message = '' } = {}) { if (!row) return; const code = warningCode?.code || warningCode || ''; row.dataset.palletWarningCode = code; row.dataset.palletStrategy = strategy || ''; const invalid = code === 'INVALID_PALLET_CATALOG'; const locked = row.classList.contains('locked'); const palletInput = row.querySelector('.edit-pallets-input'); if (palletInput) { if (invalid) palletInput.value = ''; palletInput.disabled = locked || invalid; } row.querySelectorAll('.palletStepButton').forEach(control => { control.disabled = locked || invalid; }); const guidance = row.querySelector('.pallet-guidance'); const guidanceText = message || getPalletRecommendationWarning(code) || (strategy === 'fractional-exception' ? '整板會超過 365 天；已依最小箱數預填零散棧板。' : ''); if (guidance) { guidance.textContent = guidanceText; guidance.hidden = !guidanceText; } }
-    function toggleLock(btn) { const row = btn.closest('tr'); const isLocked = row.classList.contains('locked'); row.classList.toggle('locked', !isLocked); row.querySelectorAll('input').forEach(control => { control.disabled = !isLocked; }); setGeneratorPalletState(row, { warningCode:row.dataset.palletWarningCode || '', strategy:row.dataset.palletStrategy || '', message:row.querySelector('.pallet-guidance')?.textContent || '' }); btn.innerHTML = isLocked ? '<i class="fa-solid fa-lock"></i>' : '<i class="fa-solid fa-lock-open"></i>'; saveGeneratorDraft(); }
+    function syncGeneratorLockButton(row) { const button = row?.querySelector('.lock-button'); if (!button) return; const locked = row.classList.contains('locked'); const label = locked ? '解除鎖定這列' : '鎖定這列'; button.innerHTML = locked ? '<i class="fa-solid fa-lock-open" aria-hidden="true"></i>' : '<i class="fa-solid fa-lock" aria-hidden="true"></i>'; button.setAttribute('aria-label', label); button.setAttribute('title', label); button.setAttribute('aria-pressed', String(locked)); }
+    function toggleLock(btn) { const row = btn.closest('tr'); const isLocked = row.classList.contains('locked'); row.classList.toggle('locked', !isLocked); row.querySelectorAll('input').forEach(control => { control.disabled = !isLocked; }); setGeneratorPalletState(row, { warningCode:row.dataset.palletWarningCode || '', strategy:row.dataset.palletStrategy || '', message:row.querySelector('.pallet-guidance')?.textContent || '' }); syncGeneratorLockButton(row); saveGeneratorDraft(); }
     function removeRow(btn) { const row = btn.closest('tr'); if (!row) return; const result = applyGeneratorDraftCommand({ type:'remove-row', productSku:row.dataset.product }); if (!result) return; persistGeneratorDraft(); renderActiveOrderGroup(); }
     window.toggleLock = toggleLock; window.removeRow = removeRow;
     function updateRowNumbers() { document.querySelectorAll('#productTable tbody tr').forEach((r, i) => { r.cells[0].textContent = i + 1; }); }

--- a/scripts/site-contract.mjs
+++ b/scripts/site-contract.mjs
@@ -5,6 +5,8 @@ export const runtimeFiles = Object.freeze([
   'Boss/index.html',
   'index.html',
   'product-data.js',
+  'shared/coverage-indicator.css',
+  'shared/coverage-indicator.js',
   'shared/legacy-planning-adapter.js',
   'shared/order-draft-quantity.js',
   'shared/order-draft-state.js',

--- a/scripts/verify-live-browser.mjs
+++ b/scripts/verify-live-browser.mjs
@@ -47,6 +47,7 @@ export function buildLiveBrowserUrls({ baseUrl, expectedRevision, attempt = 1 } 
   return Object.freeze({
     releaseUrl:cacheBustedUrl(resolvedBaseUrl, 'release.json', revision, boundedAttempt),
     legacyPublicUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#decisionDashboard'),
+    legacyTodayUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#today'),
     legacyCanonicalUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#recommendations'),
     canonicalPublicUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#recommendations'),
     bossUrl:cacheBustedUrl(resolvedBaseUrl, 'Boss/', revision, boundedAttempt, '#today'),
@@ -65,13 +66,6 @@ async function requireVisible(page, selector, label, timeout) {
   if (!await locator.isVisible()) throw new Error(`${label} is not visible`);
 }
 
-async function requireHidden(page, selector, label, timeout) {
-  const locator = page.locator(selector);
-  await requireCount(locator, 1, label);
-  await locator.waitFor({ state:'hidden', timeout });
-  if (!await locator.isHidden()) throw new Error(`${label} is not hidden`);
-}
-
 async function requireWorkspaceReady(page, timeout) {
   const ready = page.locator('html[data-workspace-ui-ready="true"]');
   await requireCount(ready, 1, 'workspace UI ready marker');
@@ -88,6 +82,7 @@ function requireExactUrl(page, expectedUrl, label) {
 async function assertRecommendationsWorkspace(page, expectedUrl, assertionTimeoutMs) {
   await requireWorkspaceReady(page, assertionTimeoutMs);
   requireExactUrl(page, expectedUrl, 'Recommendations workspace');
+  await requireCount(page.locator('.workspaceNavTab'), 4, 'workspace navigation tabs');
   await requireVisible(
     page,
     '.workspaceNavTab[data-workspace="recommendations"][aria-selected="true"]',
@@ -100,10 +95,10 @@ async function assertRecommendationsWorkspace(page, expectedUrl, assertionTimeou
     'Recommendations panel',
     assertionTimeoutMs,
   );
-  await requireHidden(
+  await requireVisible(
     page,
-    '#todayWorkspaceSummary[data-workspace-panel="today"]',
-    'Today panel',
+    '#todayWorkspaceSummary[data-workspace-panel="recommendations"]',
+    'Merged Today summary',
     assertionTimeoutMs,
   );
   await requireCount(page.locator('.appSidebar'), 0, 'legacy app sidebar');
@@ -141,6 +136,13 @@ async function verifyBrowserAttempt({ browserType, urls, expectedRevision, navig
         timeout:navigationTimeoutMs,
       });
       await assertRecommendationsWorkspace(legacyPage, urls.legacyCanonicalUrl, assertionTimeoutMs);
+
+      const legacyTodayPage = await context.newPage();
+      await legacyTodayPage.goto(urls.legacyTodayUrl, {
+        waitUntil:'domcontentloaded',
+        timeout:navigationTimeoutMs,
+      });
+      await assertRecommendationsWorkspace(legacyTodayPage, urls.legacyCanonicalUrl, assertionTimeoutMs);
 
       const canonicalPage = await context.newPage();
       await canonicalPage.goto(urls.canonicalPublicUrl, {

--- a/shared/coverage-indicator.css
+++ b/shared/coverage-indicator.css
@@ -1,0 +1,73 @@
+.coverageMeter {
+  --coverage-fill: 0%;
+  --coverage-target: 49.3151%;
+  display: grid;
+  gap: 4px;
+  min-width: 132px;
+  max-width: 190px;
+  color: #334155;
+}
+
+.coverageMeter__summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  line-height: 1.2;
+}
+
+.coverageMeter__value {
+  color: #0f172a;
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.coverageMeter__status {
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-align: right;
+}
+
+.coverageMeter__track {
+  position: relative;
+  height: 11px;
+  overflow: hidden;
+  border: 1px solid #94a3b8;
+  border-radius: 999px;
+  background: #e2e8f0;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.18);
+}
+
+.coverageMeter__fill {
+  display: block;
+  width: var(--coverage-fill);
+  height: 100%;
+  border-radius: inherit;
+  background: #94a3b8;
+  transition: width 180ms ease;
+}
+
+.coverageMeter__targetMarker {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  left: var(--coverage-target);
+  width: 2px;
+  background: rgba(15, 23, 42, 0.48);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.58);
+}
+
+.coverageMeter--low .coverageMeter__fill { background: #facc15; }
+.coverageMeter--low .coverageMeter__status { color: #854d0e; }
+.coverageMeter--healthy .coverageMeter__fill { background: #22c55e; }
+.coverageMeter--healthy .coverageMeter__status { color: #166534; }
+.coverageMeter--excess .coverageMeter__fill {
+  background: repeating-linear-gradient(135deg, #ef4444 0 7px, #dc2626 7px 14px);
+}
+.coverageMeter--excess .coverageMeter__status { color: #991b1b; }
+.coverageMeter--neutral .coverageMeter__status { color: #64748b; }
+
+@media (prefers-reduced-motion: reduce) {
+  .coverageMeter__fill { transition: none; }
+}

--- a/shared/coverage-indicator.js
+++ b/shared/coverage-indicator.js
@@ -1,0 +1,77 @@
+import { classifyCoverageDays } from './supply-planner.js';
+
+const TARGET_DAYS = 180;
+const MAXIMUM_DAYS = 365;
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function formatDays(value) {
+  return `${(Math.round(value * 10) / 10).toFixed(1)} 天`;
+}
+
+function formatAttributeNumber(value) {
+  return Number(value.toFixed(4)).toString();
+}
+
+function statusTextForBand(band, hasValue) {
+  if (!hasValue) return '無資料';
+  if (band === 'low') return `低於 ${TARGET_DAYS} 天`;
+  if (band === 'healthy') return `健康範圍 ${TARGET_DAYS}–${MAXIMUM_DAYS} 天`;
+  if (band === 'excess') return `超過 ${MAXIMUM_DAYS} 天`;
+  return '資料未完整，不判色';
+}
+
+export function buildCoverageMeterModel({ coverageDays, assessment = 'ready' } = {}) {
+  const hasValue = Number.isFinite(coverageDays);
+  const normalizedAssessment = assessment === 'unavailable' ? 'unavailable' : 'ready';
+  const band = hasValue && normalizedAssessment === 'ready'
+    ? classifyCoverageDays({
+        coverageDays,
+        targetDays:TARGET_DAYS,
+        maximumCoverageDays:MAXIMUM_DAYS,
+      })
+    : 'neutral';
+  const fillPercent = hasValue
+    ? clamp((coverageDays / MAXIMUM_DAYS) * 100, 0, 100)
+    : 0;
+  const meterValue = hasValue ? clamp(coverageDays, 0, MAXIMUM_DAYS) : null;
+  const valueText = hasValue ? formatDays(coverageDays) : '—';
+  const statusText = statusTextForBand(band, hasValue);
+
+  return Object.freeze({
+    assessment:normalizedAssessment,
+    band,
+    coverageDays:hasValue ? coverageDays : null,
+    fillPercent,
+    hasValue,
+    maximumDays:MAXIMUM_DAYS,
+    meterValue,
+    statusText,
+    targetDays:TARGET_DAYS,
+    valueText,
+  });
+}
+
+function renderTrack(model) {
+  const fill = `<span class="coverageMeter__fill" style="--coverage-fill:${formatAttributeNumber(model.fillPercent)}%"></span><span class="coverageMeter__targetMarker" aria-hidden="true"></span>`;
+  if (!model.hasValue) {
+    return `<div class="coverageMeter__track" aria-hidden="true">${fill}</div>`;
+  }
+  const ariaValueText = `${model.valueText}，${model.statusText}`;
+  return `<div class="coverageMeter__track" role="meter" aria-label="可售天數" aria-valuemin="0" aria-valuemax="${MAXIMUM_DAYS}" aria-valuenow="${formatAttributeNumber(model.meterValue)}" aria-valuetext="${ariaValueText}">${fill}</div>`;
+}
+
+export function renderCoverageMeter(options = {}) {
+  const model = buildCoverageMeterModel(options);
+  const noDataAria = model.hasValue ? '' : ' role="group" aria-label="可售天數：無資料"';
+  return `<div class="coverageMeter coverageMeter--${model.band}" data-band="${model.band}" data-assessment="${model.assessment}"${noDataAria}><div class="coverageMeter__summary"><strong class="coverageMeter__value">${model.valueText}</strong><span class="coverageMeter__status">${model.statusText}</span></div>${renderTrack(model)}</div>`;
+}
+
+const browserInterface = Object.freeze({
+  buildCoverageMeterModel,
+  renderCoverageMeter,
+});
+
+if (typeof window !== 'undefined') window.SupplyCoverageIndicator = browserInterface;

--- a/shared/workspace-navigation.js
+++ b/shared/workspace-navigation.js
@@ -1,12 +1,17 @@
 export const WORKSPACE_IDS = Object.freeze([
-  'today',
   'data',
   'recommendations',
   'orders',
   'analysis',
 ]);
 
+const DEFAULT_WORKSPACE = 'data';
+const LEGACY_WORKSPACE_IDS = Object.freeze({
+  today:'recommendations',
+});
+
 export const LEGACY_WORKSPACE_HASHES = Object.freeze({
+  '#today':'recommendations',
   '#decisionDashboard':'recommendations',
   '#uploadCard':'data',
   '#reorderCard':'recommendations',
@@ -53,17 +58,18 @@ function workspaceFromHash(value) {
   return HASH_TO_WORKSPACE.get(hash.toLowerCase()) || null;
 }
 
-function canonicalWorkspace(value) {
+export function canonicalWorkspaceId(value) {
   const workspace = String(value ?? '').trim().toLowerCase();
-  return WORKSPACE_SET.has(workspace) ? workspace : null;
+  if (WORKSPACE_SET.has(workspace)) return workspace;
+  return Object.hasOwn(LEGACY_WORKSPACE_IDS, workspace) ? LEGACY_WORKSPACE_IDS[workspace] : null;
 }
 
 export function resolveInitialWorkspace({ url, hash, preference } = {}) {
-  return workspaceFromHash(url ?? hash) || canonicalWorkspace(preference) || 'today';
+  return workspaceFromHash(url ?? hash) || canonicalWorkspaceId(preference) || DEFAULT_WORKSPACE;
 }
 
 export function workspaceHash(workspace) {
-  return `#${canonicalWorkspace(workspace) || 'today'}`;
+  return `#${canonicalWorkspaceId(workspace) || DEFAULT_WORKSPACE}`;
 }
 
 function normalizeRows(value, field, issues) {
@@ -199,10 +205,10 @@ function nextAction({ readiness, priorityCount, highestPriorityVelocityRisk, gro
   }
   if (highestPriorityVelocityRisk) {
     const suffix = highestPriorityVelocityRisk.productSku ? ` ${highestPriorityVelocityRisk.productSku}` : '';
-    return { id:'review-velocity-risk', workspace:'recommendations', hash:'#recommendations', label:`查看${suffix} 的 Velocity Risk`, reason:'先理解可能低估的速度證據。' };
+    return { id:'review-velocity-risk', workspace:'recommendations', hash:'#recommendations', targetId:'decisionDashboard', label:`查看${suffix} 的 Velocity Risk`, reason:'先理解可能低估的速度證據。' };
   }
   if (priorityCount > 0) {
-    return { id:'review-priorities', workspace:'recommendations', hash:'#recommendations', label:`查看 ${priorityCount} 個優先品項`, reason:'先處理目前優先順序最高的建議。' };
+    return { id:'review-priorities', workspace:'recommendations', hash:'#recommendations', targetId:'decisionDashboard', label:`查看 ${priorityCount} 個優先品項`, reason:'先處理目前優先順序最高的建議。' };
   }
   if (groupCounts.total > 0) {
     return { id:'continue-order', workspace:'orders', hash:'#orders', label:`繼續整理 ${groupCounts.total} 個訂單品項`, reason:'訂單草稿已有品項。' };
@@ -236,6 +242,7 @@ export function projectTodaySummary(input = {}) {
 const browserInterface = Object.freeze({
   WORKSPACE_IDS,
   LEGACY_WORKSPACE_HASHES,
+  canonicalWorkspaceId,
   resolveInitialWorkspace,
   workspaceHash,
   projectTodaySummary,

--- a/shared/workspace-ui.js
+++ b/shared/workspace-ui.js
@@ -1,17 +1,18 @@
 import {
   WORKSPACE_IDS,
+  canonicalWorkspaceId,
   projectTodaySummary,
   resolveInitialWorkspace,
   workspaceHash,
 } from './workspace-navigation.js';
 
-const NAV_ITEMS = Object.freeze([
-  Object.freeze({ id:'today', label:'Today' }),
-  Object.freeze({ id:'data', label:'Data' }),
-  Object.freeze({ id:'recommendations', label:'Recommendations' }),
-  Object.freeze({ id:'orders', label:'Orders' }),
-  Object.freeze({ id:'analysis', label:'Analysis' }),
-]);
+const WORKSPACE_LABELS = Object.freeze({
+  data:'資料',
+  recommendations:'今日建議',
+  orders:'訂單',
+  analysis:'資料分析',
+});
+const NAV_ITEMS = Object.freeze(WORKSPACE_IDS.map(id => Object.freeze({ id, label:WORKSPACE_LABELS[id] })));
 
 function navigationMarkup() {
   return `<nav class="workspaceTopNav" aria-label="主要工作區">
@@ -22,7 +23,7 @@ function navigationMarkup() {
 }
 
 function todayMarkup() {
-  return `<section class="todayWorkspaceSummary" id="todayWorkspaceSummary" data-workspace-panel="today" aria-live="polite">
+  return `<section class="todayWorkspaceSummary" id="todayWorkspaceSummary" data-workspace-panel="recommendations" aria-live="polite">
     <div class="todaySummaryHeader">
       <div><p class="eyebrow">Today</p><h2>今天先做什麼</h2></div>
       <span class="pill" id="todaySummaryState">等待資料</span>
@@ -44,10 +45,6 @@ function requiredElement(documentRef, id) {
   return element;
 }
 
-function canonicalPreference(value) {
-  return WORKSPACE_IDS.includes(value) ? value : null;
-}
-
 export function createWorkspaceUi({
   getSummaryInput,
   onWorkspaceChanged = () => {},
@@ -58,7 +55,7 @@ export function createWorkspaceUi({
   if (typeof onWorkspaceChanged !== 'function') throw new TypeError('onWorkspaceChanged must be a function');
   if (!documentRef || !windowRef) throw new TypeError('Workspace UI requires a browser document and window');
 
-  let activeWorkspace = 'today';
+  let activeWorkspace = 'data';
   let restoredPreference = null;
   let mounted = false;
   let wired = false;
@@ -112,6 +109,7 @@ export function createWorkspaceUi({
     if (action) {
       action.textContent = summary.nextAction.label;
       action.dataset.workspace = summary.nextAction.workspace;
+      action.dataset.targetId = summary.nextAction.targetId || '';
     }
     return summary;
   }
@@ -123,7 +121,7 @@ export function createWorkspaceUi({
     userInitiated = false,
   } = {}) {
     if (!mounted) throw new Error('Workspace UI must be started before activation');
-    if (!WORKSPACE_IDS.includes(workspace)) workspace = 'today';
+    workspace = canonicalWorkspaceId(workspace) || 'data';
     activeWorkspace = workspace;
     restoredPreference = workspace;
     let selectedTab = null;
@@ -189,10 +187,17 @@ export function createWorkspaceUi({
         userInitiated:true,
       });
     });
-    documentRef.getElementById('todayNextAction')?.addEventListener('click', event => activate(
-      event.currentTarget.dataset.workspace || 'data',
-      { historyMode:'push', focus:true, scroll:true, userInitiated:true },
-    ));
+    documentRef.getElementById('todayNextAction')?.addEventListener('click', event => {
+      const targetId = event.currentTarget.dataset.targetId || '';
+      activate(
+        event.currentTarget.dataset.workspace || 'data',
+        { historyMode:'push', focus:true, scroll:!targetId, userInitiated:true },
+      );
+      if (targetId) {
+        const reduced = windowRef.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+        documentRef.getElementById(targetId)?.scrollIntoView({ behavior:reduced ? 'auto' : 'smooth', block:'start' });
+      }
+    });
     windowRef.addEventListener('popstate', syncFromLocation);
     windowRef.addEventListener('hashchange', syncFromLocation);
     wired = true;
@@ -200,7 +205,7 @@ export function createWorkspaceUi({
 
   function start({ preference = null } = {}) {
     mount();
-    restoredPreference = canonicalPreference(preference);
+    restoredPreference = canonicalWorkspaceId(preference);
     const initial = resolveInitialWorkspace({
       url:windowRef.location.href,
       preference:restoredPreference,

--- a/tests/browser/boss-acceptance.spec.mjs
+++ b/tests/browser/boss-acceptance.spec.mjs
@@ -87,6 +87,7 @@ test('Boss matches the public scenario while mocked auth/cloud persists exact mu
 
   await page.goto('/Boss/#today');
   await waitForSupplyApp(page);
+  await expect(page).toHaveURL(/#recommendations$/);
   await expect(page.locator('#bossAuthGate')).toBeVisible();
   await page.locator('#bossLoginUsername').fill('fixture-user');
   await page.locator('#bossLoginPassword').fill('fixture-password');
@@ -95,7 +96,7 @@ test('Boss matches the public scenario while mocked auth/cloud persists exact mu
   await expect(page.locator('#todaySourceReadiness')).toHaveText('3 / 3');
   await expect(page.locator('#bossSaveState')).toContainText('已從雲端載入');
   await expectFixturePlanning(page);
-  await expectOnlyWorkspace(page, 'today');
+  await expectOnlyWorkspace(page, 'recommendations');
   expect(cloud.calls.login).toBe(1);
   expect(cloud.calls.get).toBe(1);
   expect(cloud.calls.files).toBe(4);
@@ -165,6 +166,8 @@ test('Boss matches the public scenario while mocked auth/cloud persists exact mu
   await clearButton.click();
   await expect.poll(() => cloud.calls.delete).toBe(1);
   await expect(page.locator('#bossSaveState')).toHaveText('已清除雲端與這個瀏覽器的工作區資料。');
+  await expect(page).toHaveURL(/#data$/);
+  await expectOnlyWorkspace(page, 'data');
   expectNoFixtureSourceState(await readBossSourceState(page));
   for (const key of ['supply-order-draft-v2', 'supply-generator-drafts-v1', 'supply-velocity-history-v1', 'supply-workspace-preferences-v1']) {
     expect(await page.evaluate(storageKey => localStorage.getItem(storageKey), key)).toBeNull();
@@ -176,7 +179,9 @@ test('Boss matches the public scenario while mocked auth/cloud persists exact mu
   const errorsBeforeExpectedMissingSnapshot = browserErrors.length;
   await page.reload();
   await waitForSupplyApp(page);
+  await expect(page).toHaveURL(/#data$/);
   await expect(page.locator('#bossAuthGate')).toBeHidden();
+  await expectOnlyWorkspace(page, 'data');
   await expect(page.locator('#bossSaveState')).toContainText('雲端目前沒有資料');
   expectNoFixtureSourceState(await readBossSourceState(page));
   for (const key of ['supply-order-draft-v2', 'supply-generator-drafts-v1', 'supply-velocity-history-v1', 'supply-workspace-preferences-v1']) {

--- a/tests/browser/boss-security.spec.mjs
+++ b/tests/browser/boss-security.spec.mjs
@@ -26,6 +26,7 @@ test('Boss rejects a cross-origin cloud file URL before sending a request or Bea
 
   await page.goto('/Boss/#today');
   await waitForSupplyApp(page);
+  await expect(page).toHaveURL(/#recommendations$/);
   await page.locator('#bossLoginUsername').fill('fixture-user');
   await page.locator('#bossLoginPassword').fill('fixture-password');
   await page.locator('#bossLoginButton').click();

--- a/tests/browser/browser-helpers.mjs
+++ b/tests/browser/browser-helpers.mjs
@@ -218,6 +218,7 @@ export async function waitForSupplyApp(page) {
   await expect.poll(() => page.evaluate(() => Boolean(
     window.SupplyWorkspaceNavigation?.WORKSPACE_IDS
     && window.SupplyWorkspaceUI?.createWorkspaceUi
+    && window.SupplyCoverageIndicator?.renderCoverageMeter
     && window.SupplyOrderDraftState?.ORDER_GROUP_IDS
     && window.SupplyWorkspaceSnapshot?.createWorkspaceSnapshotStore
     && window.XLSX?.utils
@@ -328,11 +329,14 @@ export async function orderDraftGroupCounts(page) {
 
 export async function exerciseWorkspaceNavigationAndLayout(page, { expectEmptyToday = false } = {}) {
   await page.setViewportSize({ width:1280, height:900 });
-  await page.locator('.workspaceNavTab[data-workspace="today"]').click();
-  await expectOnlyWorkspace(page, 'today');
-  await expect(page.locator('[data-workspace-panel="today"]')).toHaveCount(1);
+  await expect(page.locator('.workspaceNavTab')).toHaveCount(4);
+  await expect(page.locator('.workspaceNavTab')).toHaveText(['資料', '今日建議', '訂單', '資料分析']);
+  await page.locator('.workspaceNavTab[data-workspace="recommendations"]').click();
+  await expectOnlyWorkspace(page, 'recommendations');
+  await expect(page.locator('[data-workspace-panel="today"]')).toHaveCount(0);
   await expect(page.locator('#todayWorkspaceSummary')).toBeVisible();
   await expect(page.locator('#decisionDashboard')).toHaveAttribute('data-workspace-panel', 'recommendations');
+  await expect(page.locator('#decisionDashboard')).toBeVisible();
   if (expectEmptyToday) {
     await expect(page.locator('#todaySourceReadiness')).toHaveText('0 / 3');
     await expect(page.locator('#todayNextAction')).toHaveText('開始準備資料');
@@ -360,6 +364,12 @@ export async function exerciseWorkspaceNavigationAndLayout(page, { expectEmptyTo
   await page.evaluate(() => { window.location.hash = '#decisionDashboard'; });
   await expect(page).toHaveURL(/#recommendations$/);
   await expectOnlyWorkspace(page, 'recommendations');
+
+  await page.evaluate(() => { window.location.hash = '#today'; });
+  await expect(page).toHaveURL(/#recommendations$/);
+  await expectOnlyWorkspace(page, 'recommendations');
+  await expect(page.locator('#todayWorkspaceSummary')).toBeVisible();
+  await expect(page.locator('#decisionDashboard')).toBeVisible();
 
   const desktopLayout = await page.evaluate(() => ({
     viewport:document.documentElement.clientWidth,
@@ -401,7 +411,43 @@ export async function exerciseWorkspaceNavigationAndLayout(page, { expectEmptyTo
   await page.setViewportSize({ width:1280, height:900 });
 }
 
+async function expectCoverageMeter(cell, {
+  band,
+  valueText,
+  statusText,
+  ariaNow,
+  fillColor,
+}) {
+  const indicator = cell.locator('.coverageMeter');
+  await expect(indicator).toHaveCount(1);
+  await expect(indicator).toHaveClass(new RegExp(`coverageMeter--${band}`));
+  await expect(indicator).toHaveAttribute('data-band', band);
+  await expect(indicator).toHaveAttribute('data-assessment', 'ready');
+  const value = indicator.locator('.coverageMeter__value');
+  const status = indicator.locator('.coverageMeter__status');
+  await expect(value).toHaveText(valueText);
+  await expect(status).toHaveText(statusText);
+  const actualValueText = (await value.textContent())?.trim();
+  const track = indicator.getByRole('meter', { name:'可售天數' });
+  await expect(track).toHaveAttribute('aria-valuemin', '0');
+  await expect(track).toHaveAttribute('aria-valuemax', '365');
+  await expect(track).toHaveAttribute('aria-valuenow', String(ariaNow));
+  await expect(track).toHaveAttribute('aria-valuetext', `${actualValueText}，${statusText}`);
+
+  const fillStyle = await indicator.locator('.coverageMeter__fill').evaluate(element => {
+    const style = getComputedStyle(element);
+    return { backgroundColor:style.backgroundColor, backgroundImage:style.backgroundImage };
+  });
+  if (fillColor === 'yellow') expect(fillStyle.backgroundColor).toBe('rgb(250, 204, 21)');
+  if (fillColor === 'green') expect(fillStyle.backgroundColor).toBe('rgb(34, 197, 94)');
+  if (fillColor === 'red') {
+    expect(fillStyle.backgroundImage).toContain('rgb(239, 68, 68)');
+    expect(fillStyle.backgroundImage).toContain('rgb(220, 38, 38)');
+  }
+}
+
 export async function buildThreeGroupOrderScenario(page) {
+  await page.setViewportSize({ width:1280, height:900 });
   await page.locator('.workspaceNavTab[data-workspace="recommendations"]').click();
   await expectOnlyWorkspace(page, 'recommendations');
   await expect(page.locator('#reorderTableWrap tbody tr')).toHaveCount(5);
@@ -430,6 +476,43 @@ export async function buildThreeGroupOrderScenario(page) {
   expect(packedQuantityLayout).toEqual({ direction:'column', labels:['包', '袋'] });
 
   const palletRow = page.locator('#productTable tbody tr[data-product="GTSL01"]');
+  const compactControls = await palletRow.evaluate(row => {
+    const rect = element => {
+      const box = element.getBoundingClientRect();
+      return { left:box.left, top:box.top, right:box.right, bottom:box.bottom, width:box.width, height:box.height };
+    };
+    const palletControl = row.querySelector('.palletStepControl');
+    const stepButtons = Array.from(row.querySelectorAll('.palletStepButton'));
+    const actionGroup = row.querySelector('.generatorActionGroup');
+    const actions = Array.from(actionGroup.querySelectorAll(':scope > button'));
+    const controlBox = rect(palletControl);
+    const stepBoxes = stepButtons.map(rect);
+    return {
+      palletControl:controlBox,
+      stepLabels:stepButtons.map(button => button.textContent.trim()),
+      stepsInsideControl:stepBoxes.every(box => box.left >= controlBox.left - 0.5
+        && box.top >= controlBox.top - 0.5
+        && box.right <= controlBox.right + 0.5
+        && box.bottom <= controlBox.bottom + 0.5),
+      stepsStackVertically:stepBoxes.length === 2 && stepBoxes[0].bottom <= stepBoxes[1].top + 0.5,
+      actionGroup:rect(actionGroup),
+      actionLabels:actions.map(button => button.getAttribute('aria-label')),
+      actions:actions.map(rect),
+    };
+  });
+  expect(compactControls.palletControl.width).toBeLessThanOrEqual(90);
+  expect(compactControls.palletControl.height).toBeLessThanOrEqual(36);
+  expect(compactControls.stepLabels).toEqual(['▲', '▼']);
+  expect(compactControls.stepsInsideControl).toBe(true);
+  expect(compactControls.stepsStackVertically).toBe(true);
+  expect(compactControls.actionLabels).toEqual(['按住拖曳排序', '鎖定這列', '刪除這列']);
+  expect(compactControls.actions).toHaveLength(3);
+  for (const action of compactControls.actions) {
+    expect(action.width).toBeLessThanOrEqual(30);
+    expect(action.height).toBeLessThanOrEqual(30);
+  }
+  expect(compactControls.actionGroup.width).toBeLessThanOrEqual(94);
+
   const palletInput = palletRow.locator('.edit-pallets-input');
   await palletInput.fill('0.5');
   const palletBeforeStep = Number(await palletInput.inputValue());
@@ -442,19 +525,61 @@ export async function buildThreeGroupOrderScenario(page) {
   }).toEqual({ mode:'manual', authoritativeField:'pallets' });
 
   const ttsRow = page.locator('#productTable tbody tr[data-product="TTS05AM-1"]');
+  for (const selector of ['.estimated-days', '.arrival-days']) {
+    const cell = ttsRow.locator(selector);
+    await expect(cell.locator('.coverageMeter')).toHaveCount(1);
+    await expect(cell.locator('.coverageMeter__value')).toHaveText(/^\d+\.\d 天$/);
+    await expect(cell.locator('.coverageMeter__status')).toHaveText(/^(?:低於 180 天|健康範圍 180–365 天|超過 365 天)$/);
+    const valueText = (await cell.locator('.coverageMeter__value').textContent())?.trim();
+    const statusText = (await cell.locator('.coverageMeter__status').textContent())?.trim();
+    await expect(cell.getByRole('meter', { name:'可售天數' })).toHaveAttribute('aria-valuetext', `${valueText}，${statusText}`);
+  }
+
   await ttsRow.locator('.lock-button').click();
   const ttsQuantity = ttsRow.locator('.edit-quantity-input');
   await ttsQuantity.fill('10000');
-  const highCoverage = Number((await ttsRow.locator('.arrival-days').innerText()).match(/[\d.]+/)?.[0]);
+  const arrivalCell = ttsRow.locator('.arrival-days');
+  const highCoverage = Number((await arrivalCell.locator('.coverageMeter__value').innerText()).match(/[\d.]+/)?.[0]);
   expect(highCoverage).toBeGreaterThan(365);
   const assumedStockAtArrival = highCoverage * 10 - 10000;
+  const quantityFor180Days = Math.round(1800 - assumedStockAtArrival);
   const quantityFor365Days = Math.round(3650 - assumedStockAtArrival);
+
+  await ttsQuantity.fill(String(quantityFor180Days - 10));
+  await expectCoverageMeter(arrivalCell, {
+    band:'low',
+    valueText:'179.0 天',
+    statusText:'低於 180 天',
+    ariaNow:179,
+    fillColor:'yellow',
+  });
+
+  await ttsQuantity.fill(String(quantityFor180Days));
+  await expectCoverageMeter(arrivalCell, {
+    band:'healthy',
+    valueText:'180.0 天',
+    statusText:'健康範圍 180–365 天',
+    ariaNow:180,
+    fillColor:'green',
+  });
+
   await ttsQuantity.fill(String(quantityFor365Days));
-  await expect(ttsRow.locator('.generatorCoverageStatus')).toHaveClass(/healthy/);
-  await expect(ttsRow.locator('.generatorCoverageStatus')).toContainText('365 天');
+  await expectCoverageMeter(arrivalCell, {
+    band:'healthy',
+    valueText:'365.0 天',
+    statusText:'健康範圍 180–365 天',
+    ariaNow:365,
+    fillColor:'green',
+  });
+
   await ttsQuantity.fill(String(quantityFor365Days + 10));
-  await expect(ttsRow.locator('.generatorCoverageStatus')).toHaveClass(/excess/);
-  await expect(ttsRow.locator('.generatorCoverageStatus')).toHaveText('超過 365 天');
+  await expectCoverageMeter(arrivalCell, {
+    band:'excess',
+    valueText:'366.0 天',
+    statusText:'超過 365 天',
+    ariaNow:365,
+    fillColor:'red',
+  });
   await expect.poll(async () => {
     const row = (await readOrderDraft(page)).rowsByProductSku['TTS05AM-1'];
     return { mode:row.pallet.mode, authoritativeField:row.pallet.authoritativeField };

--- a/tests/browser/public-acceptance.spec.mjs
+++ b/tests/browser/public-acceptance.spec.mjs
@@ -107,15 +107,18 @@ test('public sanitized data flows through planning, shared navigation, three gro
   page.once('dialog', dialog => dialog.accept());
   await page.locator('#btnClearAll').click();
   await expect(page.locator('#workspaceSnapshotState')).toContainText('已清除這個瀏覽器');
+  await expect(page).toHaveURL(/#data$/);
+  await expectOnlyWorkspace(page, 'data');
   expect(await readWorkspaceSnapshot(page)).toBeNull();
   expect(await page.evaluate(() => localStorage.getItem('supply-velocity-history-v1'))).toBeNull();
   const clearedDraft = await readOrderDraft(page);
   expect(clearedDraft === null || Object.keys(clearedDraft.rowsByProductSku || {}).length === 0).toBe(true);
   expect(await page.locator('#inputH10').inputValue()).toBe('');
 
-  await page.reload();
+  await page.goto('/');
   await waitForSupplyApp(page);
-  await expectOnlyWorkspace(page, 'today');
+  await expect(page).toHaveURL(/#data$/);
+  await expectOnlyWorkspace(page, 'data');
   await expect(page.locator('#workspaceSnapshotState')).toContainText('尚無 Workspace Snapshot');
   await expect(page.locator('#todaySourceReadiness')).toHaveText('0 / 3');
   expect(await readWorkspaceSnapshot(page)).toBeNull();

--- a/tests/browser/public-manual-persistence.spec.mjs
+++ b/tests/browser/public-manual-persistence.spec.mjs
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import { SANITIZED_H10_TEXT } from '../fixtures/sanitized-supply-browser.mjs';
 import {
+  expectOnlyWorkspace,
   freezeBrowserTime,
   installOfflineAssetRoutes,
   monitorBrowserErrors,
@@ -9,12 +10,48 @@ import {
   waitForSupplyApp,
 } from './browser-helpers.mjs';
 
+const LEGACY_TODAY_PREFERENCES = Object.freeze({
+  schemaVersion:1,
+  updatedAt:'2026-08-27T08:30:00.000Z',
+  activeWorkspace:'today',
+  planning:{},
+  filters:{},
+  otherText:{},
+});
+
 async function waitForSnapshot(page, predicate) {
   await expect.poll(async () => {
     const snapshot = await readWorkspaceSnapshot(page);
     return snapshot && predicate(snapshot) ? snapshot : null;
   }, { timeout:8_000 }).not.toBeNull();
 }
+
+test('legacy saved Today preference restores and resaves as canonical Recommendations', async ({ page, context }) => {
+  await freezeBrowserTime(page);
+  const unexpectedRequests = [];
+  await installOfflineAssetRoutes(context, unexpectedRequests);
+  const browserErrors = monitorBrowserErrors(page);
+  await page.addInitScript(preferences => {
+    localStorage.setItem('supply-workspace-preferences-v1', JSON.stringify(preferences));
+  }, LEGACY_TODAY_PREFERENCES);
+
+  await page.goto('/');
+  await waitForSupplyApp(page);
+  await expect(page).toHaveURL(/#recommendations$/);
+  await expectOnlyWorkspace(page, 'recommendations');
+  await expect(page.locator('#todayWorkspaceSummary')).toBeVisible();
+  await expect(page.locator('#decisionDashboard')).toBeVisible();
+  await expect(page.locator('.workspaceNavTab[data-workspace="today"]')).toHaveCount(0);
+
+  await page.locator('.workspaceNavTab[data-workspace="recommendations"]').click();
+  await expect.poll(() => page.evaluate(() => {
+    const value = localStorage.getItem('supply-workspace-preferences-v1');
+    return value ? JSON.parse(value).activeWorkspace : null;
+  }), { timeout:8_000 }).toBe('recommendations');
+
+  expect(unexpectedRequests).toEqual([]);
+  expect(browserErrors).toEqual([]);
+});
 
 test('manual-only JAM, H10, and JSP restore ready and continue autosaving after reload', async ({ page, context }) => {
   await freezeBrowserTime(page);

--- a/tests/browser/public-smoke.spec.mjs
+++ b/tests/browser/public-smoke.spec.mjs
@@ -9,6 +9,24 @@ import {
   waitForSupplyApp,
 } from './browser-helpers.mjs';
 
+test('public root defaults to Data with exactly four ordered workspace tabs', async ({ page, context }) => {
+  await freezeBrowserTime(page);
+  const unexpectedRequests = [];
+  await installOfflineAssetRoutes(context, unexpectedRequests);
+  const browserErrors = monitorBrowserErrors(page);
+
+  await page.goto('/');
+  await waitForSupplyApp(page);
+  await expect(page).toHaveURL(/#data$/);
+  await expectOnlyWorkspace(page, 'data');
+  await expect(page.locator('.workspaceNavTab')).toHaveCount(4);
+  await expect(page.locator('.workspaceNavTab')).toHaveText(['資料', '今日建議', '訂單', '資料分析']);
+  await expect(page.locator('.workspaceNavTab[data-workspace="today"]')).toHaveCount(0);
+
+  expect(unexpectedRequests).toEqual([]);
+  expect(browserErrors).toEqual([]);
+});
+
 test('public workspace navigation, legacy URL, history, and bounded layout are real-browser safe', async ({ page, context }) => {
   await freezeBrowserTime(page);
   const unexpectedRequests = [];
@@ -17,18 +35,15 @@ test('public workspace navigation, legacy URL, history, and bounded layout are r
 
   await page.goto('/#today');
   await waitForSupplyApp(page);
-  await expect(page).toHaveURL(/#today$/);
+  await expect(page).toHaveURL(/#recommendations$/);
   await expect(page.locator('input[type="file"]')).toHaveCount(5);
   for (const input of await page.locator('input[type="file"]').all()) await expect(input).toHaveValue('');
   await expect(page.locator('#todayWorkspaceSummary button')).toHaveCount(1);
+  await expect(page.locator('#todayWorkspaceSummary')).toBeVisible();
+  await expect(page.locator('#decisionDashboard')).toBeVisible();
   await expect(page.locator('#workflowTop')).toBeHidden();
   await expect(page.locator('#workflowHealth')).toBeHidden();
-  await expect(page.locator('.controlDock')).toBeHidden();
-  const todayLayout = await page.evaluate(() => ({
-    viewportHeight:window.innerHeight,
-    pageHeight:document.documentElement.scrollHeight,
-  }));
-  expect(todayLayout.pageHeight).toBeLessThanOrEqual(todayLayout.viewportHeight + 80);
+  await expect(page.locator('.controlDock')).toBeVisible();
 
   await page.locator('#todayNextAction').focus();
   await page.locator('#todayNextAction').press('Enter');

--- a/tests/browser/workspace-accessibility.spec.mjs
+++ b/tests/browser/workspace-accessibility.spec.mjs
@@ -42,7 +42,7 @@ async function expectKeyboardFocusRing(locator) {
   expect(Number.parseFloat(focus.outlineWidth)).toBeGreaterThanOrEqual(3);
 }
 
-test('keyboard alone reaches and operates workspace navigation and the Today action', async ({ page, context }) => {
+test('keyboard alone reaches and operates four-workspace navigation and the Today action', async ({ page, context }) => {
   await freezeBrowserTime(page);
   const unexpectedRequests = [];
   await installOfflineAssetRoutes(context, unexpectedRequests);
@@ -50,23 +50,29 @@ test('keyboard alone reaches and operates workspace navigation and the Today act
   await waitForSupplyApp(page);
 
   await page.keyboard.press('Tab');
-  const todayTab = page.locator('.workspaceNavTab[data-workspace="today"]');
-  await expect(todayTab).toBeFocused();
-  await expectKeyboardFocusRing(todayTab);
+  const recommendationsTab = page.locator('.workspaceNavTab[data-workspace="recommendations"]');
+  await expect(recommendationsTab).toBeFocused();
+  await expectKeyboardFocusRing(recommendationsTab);
 
-  await page.keyboard.press('ArrowRight');
+  await page.keyboard.press('ArrowLeft');
   const dataTab = page.locator('.workspaceNavTab[data-workspace="data"]');
   await expect(dataTab).toBeFocused();
   await expectOnlyWorkspace(page, 'data');
   await expectKeyboardFocusRing(dataTab);
 
+  await page.keyboard.press('ArrowRight');
+  await expect(recommendationsTab).toBeFocused();
+  await expectOnlyWorkspace(page, 'recommendations');
+
   await page.keyboard.press('End');
   await expect(page.locator('.workspaceNavTab[data-workspace="analysis"]')).toBeFocused();
   await expectOnlyWorkspace(page, 'analysis');
   await page.keyboard.press('Home');
-  await expect(todayTab).toBeFocused();
-  await expectOnlyWorkspace(page, 'today');
+  await expect(dataTab).toBeFocused();
+  await expectOnlyWorkspace(page, 'data');
 
+  await page.keyboard.press('ArrowRight');
+  await expect(recommendationsTab).toBeFocused();
   await page.keyboard.press('Tab');
   const todayAction = page.locator('#todayNextAction');
   await expect(todayAction).toBeFocused();
@@ -75,8 +81,8 @@ test('keyboard alone reaches and operates workspace navigation and the Today act
   await expect(dataTab).toBeFocused();
   await expectOnlyWorkspace(page, 'data');
 
-  await page.keyboard.press('Home');
-  await expect(todayTab).toBeFocused();
+  await page.keyboard.press('ArrowRight');
+  await expect(recommendationsTab).toBeFocused();
   await page.keyboard.press('Tab');
   await expect(todayAction).toBeFocused();
   await page.keyboard.press('Space');
@@ -161,8 +167,8 @@ test('reduced-motion preference disables smooth scrolling and collapses animatio
   expect(Math.max(...reducedStyles.transitionDurations)).toBeLessThanOrEqual(0.001);
   expect(Math.max(...reducedStyles.animationDurations)).toBeLessThanOrEqual(0.001);
 
-  await page.locator('.workspaceNavTab[data-workspace="recommendations"]').click();
-  await expectOnlyWorkspace(page, 'recommendations');
+  await page.locator('.workspaceNavTab[data-workspace="data"]').click();
+  await expectOnlyWorkspace(page, 'data');
   expect(await page.evaluate(() => window.__workspaceScrollBehaviors)).toEqual(['auto']);
   expect(unexpectedRequests).toEqual([]);
 });

--- a/tests/coverage-indicator.test.mjs
+++ b/tests/coverage-indicator.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildCoverageMeterModel,
+  renderCoverageMeter,
+} from '../shared/coverage-indicator.js';
+
+test('coverage meter owns the fixed 180 and 365 day health bands', () => {
+  assert.equal(buildCoverageMeterModel({ coverageDays:179.9 }).band, 'low');
+  assert.equal(buildCoverageMeterModel({ coverageDays:180 }).band, 'healthy');
+  assert.equal(buildCoverageMeterModel({ coverageDays:365 }).band, 'healthy');
+  assert.equal(buildCoverageMeterModel({ coverageDays:365.000000002 }).band, 'excess');
+});
+
+test('coverage meter preserves a numeric value and clamps only the visual fill', () => {
+  const belowZero = buildCoverageMeterModel({ coverageDays:-12.5 });
+  assert.equal(belowZero.band, 'low');
+  assert.equal(belowZero.valueText, '-12.5 天');
+  assert.equal(belowZero.fillPercent, 0);
+  assert.equal(belowZero.meterValue, 0);
+
+  const excess = buildCoverageMeterModel({ coverageDays:500 });
+  assert.equal(excess.band, 'excess');
+  assert.equal(excess.valueText, '500.0 天');
+  assert.equal(excess.fillPercent, 100);
+  assert.equal(excess.meterValue, 365);
+});
+
+test('coverage meter fill is proportional to days over the 365 day track', () => {
+  const model = buildCoverageMeterModel({ coverageDays:180 });
+  assert.ok(Math.abs(model.fillPercent - (180 / 365) * 100) < 1e-12);
+  assert.equal(model.targetDays, 180);
+  assert.equal(model.maximumDays, 365);
+  assert.equal(Object.isFrozen(model), true);
+});
+
+test('unavailable assessment is neutral while retaining its finite value', () => {
+  const model = buildCoverageMeterModel({ coverageDays:220, assessment:'unavailable' });
+  assert.equal(model.band, 'neutral');
+  assert.equal(model.valueText, '220.0 天');
+  assert.equal(model.statusText, '資料未完整，不判色');
+  assert.equal(model.fillPercent, (220 / 365) * 100);
+
+  const html = renderCoverageMeter({ coverageDays:220, assessment:'unavailable' });
+  assert.match(html, /coverageMeter--neutral/);
+  assert.match(html, />220\.0 天</);
+  assert.match(html, /資料未完整，不判色/);
+  assert.match(html, /role="meter"/);
+  assert.match(html, /aria-valuenow="220"/);
+});
+
+test('missing values render an explicit neutral no-data state without a fake meter value', () => {
+  for (const coverageDays of [null, undefined, Number.NaN]) {
+    const model = buildCoverageMeterModel({ coverageDays });
+    assert.equal(model.band, 'neutral');
+    assert.equal(model.hasValue, false);
+    assert.equal(model.valueText, '—');
+    assert.equal(model.statusText, '無資料');
+  }
+
+  const html = renderCoverageMeter({ coverageDays:null });
+  assert.match(html, /coverageMeter--neutral/);
+  assert.match(html, /aria-label="可售天數：無資料"/);
+  assert.doesNotMatch(html, /role="meter"/);
+  assert.doesNotMatch(html, /aria-valuenow=/);
+});
+
+test('rendered meter keeps numeric and status text alongside accessible meter semantics', () => {
+  const healthy = renderCoverageMeter({ coverageDays:180 });
+  assert.match(healthy, /class="coverageMeter coverageMeter--healthy"/);
+  assert.match(healthy, /data-band="healthy"/);
+  assert.match(healthy, />180\.0 天</);
+  assert.match(healthy, />健康範圍 180–365 天</);
+  assert.match(healthy, /role="meter"/);
+  assert.match(healthy, /aria-valuemin="0"/);
+  assert.match(healthy, /aria-valuemax="365"/);
+  assert.match(healthy, /aria-valuenow="180"/);
+  assert.match(healthy, /aria-valuetext="180\.0 天，健康範圍 180–365 天"/);
+  assert.match(healthy, /--coverage-fill:49\.3151%/);
+
+  const excess = renderCoverageMeter({ coverageDays:500 });
+  assert.match(excess, /coverageMeter--excess/);
+  assert.match(excess, />500\.0 天</);
+  assert.match(excess, />超過 365 天</);
+  assert.match(excess, /aria-valuenow="365"/);
+  assert.match(excess, /aria-valuetext="500\.0 天，超過 365 天"/);
+  assert.match(excess, /--coverage-fill:100%/);
+});

--- a/tests/lead-time-plan.test.mjs
+++ b/tests/lead-time-plan.test.mjs
@@ -4,8 +4,6 @@ import path from 'node:path';
 import test from 'node:test';
 import vm from 'node:vm';
 
-import { classifyCoverageDays } from '../shared/supply-planner.js';
-
 const repoRoot = path.resolve(import.meta.dirname, '..');
 const indexHtml = fs.readFileSync(path.join(repoRoot, 'index.html'), 'utf8');
 const bossHtml = fs.readFileSync(path.join(repoRoot, 'Boss', 'index.html'), 'utf8');
@@ -75,22 +73,39 @@ for (const [entrypoint, html] of [['public', indexHtml], ['Boss', bossHtml]]) {
     const persistDraftSource = extractFunctionSource(html, 'persistGeneratorDraft');
     const restoreDraftSource = extractFunctionSource(html, 'restoreGeneratorDraft');
     const loadDraftSource = extractFunctionSource(html, 'loadGeneratorDraftState');
+    const equivalentToggleSource = extractFunctionSource(html, 'renderEquivalentOrderToggle');
+    const hydrateRowSource = extractFunctionSource(html, 'hydrateGeneratorRow');
+    const syncLockSource = extractFunctionSource(html, 'syncGeneratorLockButton');
     const lockSource = extractFunctionSource(html, 'toggleLock');
+    const palletStepSource = extractFunctionSource(html, 'stepGeneratorPallets');
+    const palletKeySource = extractFunctionSource(html, 'handleGeneratorPalletKey');
     const exportSource = extractFunctionSource(html, 'exportGeneratorToExcel');
     assert.match(addProductSource, /generatorQuantityGroup/);
     assert.match(addProductSource, /class="palletStepControl"/);
-    assert.match(addProductSource, /class="edit-pallets-input"[^>]*step="any"/);
+    assert.match(addProductSource, /class="edit-pallets-input"[^>]*step="any"[^>]*min="0"/);
     assert.match(addProductSource, /stepGeneratorPallets\(this,-1\)/);
     assert.match(addProductSource, /stepGeneratorPallets\(this,1\)/);
     assert.match(addProductSource, /handleGeneratorPalletKey\(event\)/);
     assert.match(addProductSource, /normalizeGeneratorPallets\(this,/);
     assert.match(addProductSource, /class="box-size-cell"/);
+    assert.match(addProductSource, /class="generatorActionGroup"/);
     assert.match(addProductSource, /class="drag-handle"[^>]*aria-label="按住拖曳排序"/);
+    assert.match(addProductSource, /class="lock-button"[^>]*aria-label="鎖定這列"[^>]*aria-pressed="false"[^>]*title="鎖定這列"/);
+    assert.match(addProductSource, /class="remove-button"[^>]*aria-label="刪除這列"[^>]*title="刪除這列"/);
+    assert.match(addProductSource, /aria-label="增加 1 棧板" title="增加 1 棧板"/);
+    assert.match(addProductSource, /aria-label="減少 1 棧板" title="減少 1 棧板"/);
     assert.match(totalsSource, /querySelector\('\.box-size-cell'\)/);
     assert.doesNotMatch(totalsSource, /row\.cells\[7\]/);
     assert.match(html, /\.generatorQuantityGroup \{[^}]*display:flex;[^}]*flex-direction:column/);
-    assert.match(html, /\.generatorCoverageStatus\.healthy \{ color:#15803d; \}/);
-    assert.match(html, /\.generatorCoverageStatus\.excess \{ color:#b91c1c; \}/);
+    assert.match(html, /\.palletStepControl \{[^}]*width:88px;[^}]*height:34px;/);
+    assert.match(html, /\.palletStepButtons \{[^}]*position:absolute;[^}]*width:20px;/);
+    assert.match(html, /\.order-generator \.action-button,[^{]+\{[^}]*inline-size:28px;[^}]*block-size:28px;/);
+    assert.match(html, /\.generatorActionGroup \{[^}]*inline-size:90px;/);
+    assert.match(html, /@media \(pointer:coarse\) \{[\s\S]*?\.order-generator \.generatorActionGroup > button, \.order-generator \.miniBtn \{[^}]*inline-size:40px;[^}]*block-size:40px;/);
+    const coverageBase = entrypoint === 'public' ? './shared/' : '../shared/';
+    assert.match(html, new RegExp(`<link rel="stylesheet" href="${coverageBase.replaceAll('.', '\\.')}coverage-indicator\\.css">`));
+    assert.match(html, new RegExp(`<script type="module" src="${coverageBase.replaceAll('.', '\\.')}coverage-indicator\\.js"></script>`));
+    assert.doesNotMatch(html, /generatorCoverageStatus/);
     assert.match(html, /wireGeneratorRowSorting\(\);/);
     assert.doesNotMatch(html, /function roundUpToHalfPallet\(/);
     assert.doesNotMatch(html, /最小 0\.5 棧板/);
@@ -108,7 +123,25 @@ for (const [entrypoint, html] of [['public', indexHtml], ['Boss', bossHtml]]) {
     assert.doesNotMatch(loadDraftSource, /\(result\.issues \|\| \[\]\)\.length \+ \(generatorDraft\.repairOrder \|\| \[\]\)\.length/);
     assert.match(restoreDraftSource, /setActiveOrderGroup/);
     assert.match(restoreDraftSource, /renderActiveOrderGroup/);
+    assert.match(equivalentToggleSource, /class="miniBtn"/);
+    assert.match(equivalentToggleSource, /aria-label="切換下單品號為 \$\{safeNextCode\}"/);
+    assert.match(equivalentToggleSource, /title="切換為 \$\{safeNextCode\}"/);
+    assert.match(equivalentToggleSource, /data-next-order-sku="\$\{safeNextCode\}"/);
+    assert.match(equivalentToggleSource, /fa-repeat/);
+    assert.doesNotMatch(equivalentToggleSource, />切換下單：/);
+    assert.match(hydrateRowSource, /syncGeneratorLockButton\(row\)/);
+    assert.match(syncLockSource, /locked \? '解除鎖定這列' : '鎖定這列'/);
+    assert.match(syncLockSource, /setAttribute\('aria-label', label\)/);
+    assert.match(syncLockSource, /setAttribute\('title', label\)/);
+    assert.match(syncLockSource, /setAttribute\('aria-pressed', String\(locked\)\)/);
+    assert.match(syncLockSource, /aria-hidden="true"/);
     assert.match(lockSource, /setGeneratorPalletState/);
+    assert.match(lockSource, /row\.querySelectorAll\('input'\)/);
+    assert.match(lockSource, /syncGeneratorLockButton\(row\)/);
+    assert.doesNotMatch(lockSource, /btn\.disabled|querySelectorAll\('button'\)/);
+    assert.match(palletStepSource, /currentPallets:input\.value/);
+    assert.match(palletStepSource, /delta,/);
+    assert.match(palletKeySource, /event\.key === 'ArrowUp' \? 1 : -1/);
     assert.match(exportSource, /projectOrderWorkbook/);
     assert.doesNotMatch(exportSource, /getRowExactMetrics/);
     assert.doesNotMatch(extractFunctionSource(html, 'updateFields'), /perPallet\s*\|\|\s*1/);
@@ -307,19 +340,21 @@ test('Book coverage comes from the shared planner and excludes the current Order
   }
 });
 
-test('coverage colors use the displayed 180 and 365 day boundaries', () => {
-  const context = { window: { SupplyPlanningLegacy: { classifyCoverageDays } } };
-  vm.createContext(context);
-  vm.runInContext(`${extractFunctionSource(indexHtml, 'getGeneratorCoverageBand')}\nthis.getGeneratorCoverageBand = getGeneratorCoverageBand;`, context);
-  assert.equal(context.getGeneratorCoverageBand(null, 180), 'neutral');
-  assert.equal(context.getGeneratorCoverageBand(179.999999998, 180), 'low');
-  assert.equal(context.getGeneratorCoverageBand(179.9999999995, 180), 'healthy');
-  assert.equal(context.getGeneratorCoverageBand(365, 180), 'healthy');
-  assert.equal(context.getGeneratorCoverageBand(365.0000000005, 180), 'healthy');
-  assert.equal(context.getGeneratorCoverageBand(365.000000002, 180), 'excess');
-  assert.equal(context.getGeneratorCoverageBand(179.96, 180), 'low');
-  assert.equal(context.getGeneratorCoverageBand(365.04, 180), 'excess');
-  assert.match(extractFunctionSource(indexHtml, 'getGeneratorCoverageBand'), /SupplyPlanningLegacy\.classifyCoverageDays/);
+test('coverage surfaces delegate the fixed 180 and 365 day bands to one shared indicator', () => {
+  for (const [entrypoint, html] of [['public', indexHtml], ['Boss', bossHtml]]) {
+    const renderMeter = extractFunctionSource(html, 'renderCoverageMeterHtml');
+    const renderArrival = extractFunctionSource(html, 'renderGeneratorArrivalCoverage');
+    const renderBook = extractFunctionSource(html, 'renderGeneratorBookCoverage');
+    assert.match(renderMeter, /SupplyCoverageIndicator/);
+    assert.match(renderMeter, /api\.renderCoverageMeter\(\{ coverageDays:/);
+    assert.match(renderArrival, /renderCoverageMeterHtml\(days,/);
+    assert.match(renderBook, /renderCoverageMeterHtml\(plan\.bookCoverageDays,/);
+    assert.doesNotMatch(`${renderMeter}\n${renderArrival}\n${renderBook}`, /getReorderTargetDays|classifyCoverageDays/);
+    assert.match(html, /低於 180 天黃色、180–365 天綠色、超過 365 天紅色/);
+    assert.doesNotMatch(html, /generatorCoverageStatus/);
+    assert.match(html, /coverageHealthCell/);
+    assert.ok(entrypoint);
+  }
 });
 
 test('planned quantity application updates the shared Product SKU row without using the active tab as factory truth', () => {
@@ -462,19 +497,25 @@ test('fractional totals sum canonical pallet precision before formatting once', 
   }
 });
 
-test('main and generator coverage surfaces mark only real values above 365 as excess', () => {
+test('main and generator coverage surfaces preserve values and assessment while delegating rendering', () => {
   for (const [entrypoint, html] of [['public', indexHtml], ['Boss', bossHtml]]) {
+    const calls = [];
     const context = {
-      getReorderTargetDays: () => 180,
-      getGeneratorCoverageBand: value => classifyCoverageDays({ coverageDays:value, targetDays:180, maximumCoverageDays:365 }),
+      window:{ SupplyCoverageIndicator:{ renderCoverageMeter(options) { calls.push(options); return `<meter>${options.coverageDays ?? 'none'}:${options.assessment}</meter>`; } } },
       fmtDays: value => `${value} 天`,
+      escapeHtml: value => value,
     };
     vm.createContext(context);
-    vm.runInContext(`${extractFunctionSource(html, 'renderCoverageDaysCell')}\nthis.renderCoverageDaysCell = renderCoverageDaysCell;`, context);
-    assert.match(context.renderCoverageDaysCell(365), /class="ok"/, entrypoint);
-    assert.doesNotMatch(context.renderCoverageDaysCell(365), /超過 365 天/, entrypoint);
-    assert.match(context.renderCoverageDaysCell(365.04), /class="bad"/, entrypoint);
-    assert.match(context.renderCoverageDaysCell(365.04), /超過 365 天/, entrypoint);
+    vm.runInContext(`${extractFunctionSource(html, 'renderCoverageMeterHtml')}\n${extractFunctionSource(html, 'renderCoverageDaysCell')}\nthis.renderCoverageDaysCell = renderCoverageDaysCell;`, context);
+    const healthyCell = context.renderCoverageDaysCell(365);
+    const unavailableCell = context.renderCoverageDaysCell(null);
+    assert.match(healthyCell, /class="coverageHealthCell"/);
+    assert.match(healthyCell, /<meter>365:ready<\/meter>/);
+    assert.match(unavailableCell, /<meter>none:unavailable<\/meter>/);
+    assert.deepEqual(calls.map(call => ({ ...call })), [
+      { coverageDays:365, assessment:'ready' },
+      { coverageDays:null, assessment:'unavailable' },
+    ], entrypoint);
   }
 });
 

--- a/tests/live-browser-smoke.test.mjs
+++ b/tests/live-browser-smoke.test.mjs
@@ -57,11 +57,13 @@ function createFakeBrowserType({ failures = [] } = {}) {
                 async goto(url, options) {
                   pageLog.gotos.push({ url, options });
                   const failure = failures[attemptIndex];
-                  if (failure?.phase === 'goto' && failure.page === pageIndex % 3) {
+                  if (failure?.phase === 'goto' && failure.page === pageIndex % 4) {
                     throw new Error(failure.message);
                   }
                   currentUrl = url.endsWith('#decisionDashboard')
                     ? url.replace(/#decisionDashboard$/, '#recommendations')
+                    : url.endsWith('#today') && !/\/Boss\//.test(url)
+                      ? url.replace(/#today$/, '#recommendations')
                     : url;
                   if (failure?.phase === 'mutation' && /\/Boss\//.test(url)) {
                     requestListeners.forEach(listener => listener({
@@ -75,12 +77,11 @@ function createFakeBrowserType({ failures = [] } = {}) {
                   pageLog.selectors.push(selector);
                   log.locators.push(selector);
                   const isSidebar = selector === '.appSidebar';
-                  const isToday = selector.startsWith('#todayWorkspaceSummary');
+                  const isWorkspaceTabs = selector === '.workspaceNavTab';
                   return {
-                    async count() { return isSidebar ? 0 : 1; },
+                    async count() { return isSidebar ? 0 : isWorkspaceTabs ? 4 : 1; },
                     async waitFor(options) { log.waits.push({ selector, ...options }); },
-                    async isVisible() { return !isToday; },
-                    async isHidden() { return isToday; },
+                    async isVisible() { return true; },
                   };
                 },
               };
@@ -104,6 +105,7 @@ test('URL contract keeps the live revision cache buster and separates legacy, ca
   }), {
     releaseUrl:`${BASE_URL}release.json?supply-release=${REVISION}-3`,
     legacyPublicUrl:`${BASE_URL}?supply-release=${REVISION}-3#decisionDashboard`,
+    legacyTodayUrl:`${BASE_URL}?supply-release=${REVISION}-3#today`,
     legacyCanonicalUrl:`${BASE_URL}?supply-release=${REVISION}-3#recommendations`,
     canonicalPublicUrl:`${BASE_URL}?supply-release=${REVISION}-3#recommendations`,
     bossUrl:`${BASE_URL}Boss/?supply-release=${REVISION}-3#today`,
@@ -145,24 +147,26 @@ test('browser smoke proves legacy canonicalization, canonical public UI, absent 
   }]);
   assert.deepEqual(log.pages.map(page => page.gotos[0].url), [
     `${BASE_URL}?supply-release=${REVISION}-1#decisionDashboard`,
+    `${BASE_URL}?supply-release=${REVISION}-1#today`,
     `${BASE_URL}?supply-release=${REVISION}-1#recommendations`,
     `${BASE_URL}Boss/?supply-release=${REVISION}-1#today`,
   ]);
-  assert.deepEqual(log.pages.map(page => page.gotos[0].options), Array(3).fill({
+  assert.deepEqual(log.pages.map(page => page.gotos[0].options), Array(4).fill({
     waitUntil:'domcontentloaded',
     timeout:3210,
   }));
 
-  for (const publicPage of log.pages.slice(0, 2)) {
+  for (const publicPage of log.pages.slice(0, 3)) {
     assert.deepEqual(publicPage.selectors, [
       'html[data-workspace-ui-ready="true"]',
+      '.workspaceNavTab',
       '.workspaceNavTab[data-workspace="recommendations"][aria-selected="true"]',
       '#decisionDashboard[data-workspace-panel="recommendations"]',
-      '#todayWorkspaceSummary[data-workspace-panel="today"]',
+      '#todayWorkspaceSummary[data-workspace-panel="recommendations"]',
       '.appSidebar',
     ]);
   }
-  assert.deepEqual(log.pages[2].selectors, ['#bossAuthGate:not([hidden])', '#bossLoginForm']);
+  assert.deepEqual(log.pages[3].selectors, ['#bossAuthGate:not([hidden])', '#bossLoginForm']);
   assert.equal(log.locators.some(selector => /submit|save|delete/i.test(selector)), false);
   assert.deepEqual(log.closes, { browser:1, context:1 });
 });

--- a/tests/site-artifact.test.mjs
+++ b/tests/site-artifact.test.mjs
@@ -56,6 +56,8 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'index.html',
     'product-data.js',
     'release.json',
+    'shared/coverage-indicator.css',
+    'shared/coverage-indicator.js',
     'shared/legacy-planning-adapter.js',
     'shared/order-draft-quantity.js',
     'shared/order-draft-state.js',
@@ -78,6 +80,8 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'Boss/index.html',
     'index.html',
     'product-data.js',
+    'shared/coverage-indicator.css',
+    'shared/coverage-indicator.js',
     'shared/legacy-planning-adapter.js',
     'shared/order-draft-quantity.js',
     'shared/order-draft-state.js',
@@ -90,6 +94,7 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'vendor/LICENSE.sheetjs.txt',
     'vendor/xlsx.full.min.js',
   ]);
+  assert.equal(Object.keys(manifest.files).length, 16);
   for (const relativePath of Object.keys(manifest.files)) {
     assert.match(manifest.files[relativePath], /^[a-f0-9]{64}$/);
     assert.equal(manifest.files[relativePath], sha256(path.join(firstDist, relativePath)));
@@ -113,7 +118,7 @@ test('artifact verifier accepts a complete unmodified site build', t => {
 
   const verified = runNode(verifyScript, ['--dir', dist, '--revision', 'verified-revision']);
   assert.equal(verified.status, 0, verified.stderr || verified.stdout);
-  assert.match(verified.stdout, /Verified 14 hashed site files for verified-revision/);
+  assert.match(verified.stdout, /Verified 16 hashed site files for verified-revision/);
 });
 
 test('artifact verifier rejects repository-only or unexpected files', t => {

--- a/tests/workspace-navigation-page.test.mjs
+++ b/tests/workspace-navigation-page.test.mjs
@@ -56,17 +56,13 @@ function panelForId(html, id) {
   return match[1];
 }
 
-test('shared workspace UI is the only source of top navigation and Today markup', () => {
-  const tabs = Array.from(workspaceUiSource.matchAll(/Object\.freeze\(\{ id:'([^']+)', label:'([^']+)' \}\)/g), match => [match[1], match[2]]);
-  assert.deepEqual(tabs, [
-    ['today', 'Today'],
-    ['data', 'Data'],
-    ['recommendations', 'Recommendations'],
-    ['orders', 'Orders'],
-    ['analysis', 'Analysis'],
-  ]);
+test('shared workspace UI is the only source of four-workspace navigation and merged Today markup', () => {
+  assert.match(workspaceUiSource, /const WORKSPACE_LABELS = Object\.freeze\(\{[\s\S]*?data:'資料',[\s\S]*?recommendations:'今日建議',[\s\S]*?orders:'訂單',[\s\S]*?analysis:'資料分析',[\s\S]*?\}\);/);
+  assert.match(workspaceUiSource, /WORKSPACE_IDS\.map\(id => Object\.freeze\(\{ id, label:WORKSPACE_LABELS\[id\] \}\)\)/);
   assert.match(workspaceUiSource, /function navigationMarkup\(\)/);
   assert.match(workspaceUiSource, /function todayMarkup\(\)/);
+  assert.match(workspaceUiSource, /id="todayWorkspaceSummary" data-workspace-panel="recommendations"/);
+  assert.doesNotMatch(workspaceUiSource, /data-workspace-panel="today"/);
   assert.equal((workspaceUiSource.match(/class="todayNextAction"/g) || []).length, 1);
   for (const id of ['todaySourceReadiness', 'todayPriorityCount', 'todayVelocityRiskCount', 'todayOrderGroupTotal', 'todayOrderGroupCounts', 'todayHighestRisk', 'todayNextActionReason']) {
     assert.match(workspaceUiSource, new RegExp(`id="${id}"`));
@@ -124,7 +120,7 @@ for (const { entrypoint, html } of pages) {
     assert.match(start, /getSummaryInput:getTodayWorkspaceInput/);
     assert.match(start, /onWorkspaceChanged/);
     assert.match(capture, /workspaceUiController\?\.getActiveWorkspace\(\)/);
-    assert.match(apply, /restoredWorkspacePreference = ids\.includes\(preferences\.activeWorkspace\)/);
+    assert.match(apply, /canonicalWorkspaceId\?\.\(preferences\.activeWorkspace\)/);
     assert.match(html, /startWorkspaceUi\(restoredWorkspacePreference\)/);
   });
 
@@ -142,6 +138,7 @@ for (const { entrypoint, html } of pages) {
 }
 
 test('shared controller owns activation, URL history, keyboard focus, reduced motion, and Today projection', () => {
+  assert.match(workspaceUiSource, /canonicalWorkspaceId\(workspace\) \|\| 'data'/);
   assert.match(workspaceUiSource, /projectTodaySummary\(getSummaryInput\(\) \|\| \{\}\)/);
   assert.match(workspaceUiSource, /querySelectorAll\('\[data-workspace-panel\]'\)/);
   assert.match(workspaceUiSource, /panel\.hidden = panel\.dataset\.workspacePanel !== workspace/);

--- a/tests/workspace-navigation.test.mjs
+++ b/tests/workspace-navigation.test.mjs
@@ -4,30 +4,38 @@ import test from 'node:test';
 import {
   LEGACY_WORKSPACE_HASHES,
   WORKSPACE_IDS,
+  canonicalWorkspaceId,
   projectTodaySummary,
   resolveInitialWorkspace,
   workspaceHash,
 } from '../shared/workspace-navigation.js';
 
 test('canonical workspace ids and hashes are stable', () => {
-  assert.deepEqual(WORKSPACE_IDS, ['today', 'data', 'recommendations', 'orders', 'analysis']);
+  assert.deepEqual(WORKSPACE_IDS, ['data', 'recommendations', 'orders', 'analysis']);
   assert.equal(Object.isFrozen(WORKSPACE_IDS), true);
   for (const workspace of WORKSPACE_IDS) {
     assert.equal(workspaceHash(workspace), `#${workspace}`);
   }
-  assert.equal(workspaceHash('unknown'), '#today');
+  assert.equal(workspaceHash('today'), '#recommendations');
+  assert.equal(workspaceHash('unknown'), '#data');
+  assert.equal(canonicalWorkspaceId(' Today '), 'recommendations');
+  assert.equal(canonicalWorkspaceId('ANALYSIS'), 'analysis');
+  assert.equal(canonicalWorkspaceId('unknown'), null);
+  assert.equal(canonicalWorkspaceId('toString'), null);
 });
 
-test('initial workspace prefers a valid URL, then preference, then Today', () => {
+test('initial workspace prefers a valid URL, then canonicalized preference, then Data', () => {
   assert.equal(resolveInitialWorkspace({ url:'https://jspusa.github.io/Supply/#reorderCard', preference:'orders' }), 'recommendations');
   assert.equal(resolveInitialWorkspace({ url:'#not-a-workspace', preference:'orders' }), 'orders');
-  assert.equal(resolveInitialWorkspace({ url:'#not-a-workspace', preference:'not-a-workspace' }), 'today');
+  assert.equal(resolveInitialWorkspace({ url:'#not-a-workspace', preference:'today' }), 'recommendations');
+  assert.equal(resolveInitialWorkspace({ url:'#not-a-workspace', preference:'not-a-workspace' }), 'data');
   assert.equal(resolveInitialWorkspace({ hash:'#analysis', preference:'data' }), 'analysis');
-  assert.equal(resolveInitialWorkspace(), 'today');
+  assert.equal(resolveInitialWorkspace(), 'data');
 });
 
 test('every legacy card hash resolves to its canonical workspace', () => {
   assert.deepEqual(LEGACY_WORKSPACE_HASHES, {
+    '#today':'recommendations',
     '#decisionDashboard':'recommendations',
     '#uploadCard':'data',
     '#reorderCard':'recommendations',
@@ -137,6 +145,19 @@ test('Today selects the highest-priority matching Velocity Risk and uses non-con
   assert.equal(summary.nextAction.id, 'review-velocity-risk');
   assert.equal(summary.nextAction.workspace, 'recommendations');
   assert.equal(summary.nextAction.hash, '#recommendations');
+  assert.equal(summary.nextAction.targetId, 'decisionDashboard');
+});
+
+test('Today priority action targets the merged recommendation dashboard', () => {
+  const summary = projectTodaySummary({
+    sourceReadiness:{ h10:true, openOrders:true, inventory:true },
+    priorityRows:[{ sku:'AFA12AM' }],
+    velocityRiskRows:[],
+  });
+  assert.equal(summary.nextAction.id, 'review-priorities');
+  assert.equal(summary.nextAction.workspace, 'recommendations');
+  assert.equal(summary.nextAction.hash, '#recommendations');
+  assert.equal(summary.nextAction.targetId, 'decisionDashboard');
 });
 
 test('three Order Draft groups are counted and become the one next action after priorities clear', () => {
@@ -166,7 +187,7 @@ test('browser consumers receive one frozen workspace-navigation interface', asyn
     assert.equal(Object.isFrozen(browserInterface), true);
     assert.deepEqual(browserInterface.WORKSPACE_IDS, WORKSPACE_IDS);
     assert.equal(browserInterface.LEGACY_WORKSPACE_HASHES['#decisionDashboard'], 'recommendations');
-    for (const name of ['resolveInitialWorkspace', 'workspaceHash', 'projectTodaySummary']) {
+    for (const name of ['canonicalWorkspaceId', 'resolveInitialWorkspace', 'workspaceHash', 'projectTodaySummary']) {
       assert.equal(typeof browserInterface[name], 'function', name);
     }
   } finally {

--- a/tests/workspace-ui.test.mjs
+++ b/tests/workspace-ui.test.mjs
@@ -37,27 +37,30 @@ function createElement(id = '') {
     attributes:{},
     hidden:false,
     tabIndex:-1,
-    addEventListener() {},
+    listeners:{},
+    scrollCalls:[],
+    addEventListener(name, listener) { this.listeners[name] = listener; },
     focus() {},
-    scrollIntoView() {},
+    scrollIntoView(options) { this.scrollCalls.push(options); },
     setAttribute(name, value) { this.attributes[name] = String(value); },
   };
 }
 
-function createWorkspaceUiHarness(initialSummary) {
+function createWorkspaceUiHarness(initialSummary, { href = 'https://supply.test/#today' } = {}) {
   let summaryInput = initialSummary;
   const ids = [
     'workspaceNavMount', 'todayWorkspaceMount', 'todaySourceReadiness', 'todaySourceReadinessHint',
     'todayPriorityCount', 'todayVelocityRiskCount', 'todayOrderGroupTotal', 'todayOrderGroupCounts',
     'todaySummaryState', 'todayHighestRisk', 'todayNextActionReason', 'todayNextAction',
+    'decisionDashboard',
   ];
   const elements = new Map(ids.map(id => [id, createElement(id)]));
-  const navTabs = ['today', 'data', 'recommendations', 'orders', 'analysis'].map(workspace => {
+  const navTabs = ['data', 'recommendations', 'orders', 'analysis'].map(workspace => {
     const element = createElement();
     element.dataset.workspace = workspace;
     return element;
   });
-  const panels = ['today', 'data', 'recommendations', 'orders', 'analysis'].map(workspace => {
+  const panels = ['data', 'recommendations', 'recommendations', 'orders', 'analysis'].map(workspace => {
     const element = createElement();
     element.dataset.workspacePanel = workspace;
     return element;
@@ -79,11 +82,12 @@ function createWorkspaceUiHarness(initialSummary) {
       return null;
     },
   };
+  const initialUrl = new URL(href);
   const location = {
-    href:'https://supply.test/#today',
-    pathname:'/',
-    search:'',
-    hash:'#today',
+    href:initialUrl.href,
+    pathname:initialUrl.pathname,
+    search:initialUrl.search,
+    hash:initialUrl.hash,
   };
   const updateLocation = nextUrl => {
     const parsed = new URL(nextUrl, location.href);
@@ -109,6 +113,7 @@ function createWorkspaceUiHarness(initialSummary) {
   return {
     controller,
     elements,
+    location,
     setSummaryInput(value) { summaryInput = value; },
   };
 }
@@ -140,12 +145,28 @@ test('browser consumers receive the frozen shared workspace UI factory', async (
   }
 });
 
+test('shared UI canonicalizes the old Today hash and preference and defaults invalid activation to Data', () => {
+  const legacyHash = createWorkspaceUiHarness({});
+  assert.equal(legacyHash.controller.start(), 'recommendations');
+  assert.equal(legacyHash.controller.getActiveWorkspace(), 'recommendations');
+  assert.equal(legacyHash.location.hash, '#recommendations');
+
+  const legacyPreference = createWorkspaceUiHarness({}, { href:'https://supply.test/' });
+  assert.equal(legacyPreference.controller.start({ preference:'today' }), 'recommendations');
+  assert.equal(legacyPreference.controller.getActiveWorkspace(), 'recommendations');
+  assert.equal(legacyPreference.location.hash, '#recommendations');
+  assert.equal(legacyPreference.controller.activate('unknown'), 'data');
+  assert.equal(legacyPreference.controller.getActiveWorkspace(), 'data');
+  assert.equal(legacyPreference.location.hash, '#data');
+});
+
 test('shared Today renders one next action and honest empty, loading, warning, and invalid states', () => {
   assert.equal((workspaceUiSource.match(/id="todayNextAction"/g) || []).length, 1);
   const harness = createWorkspaceUiHarness({
     sourceReadiness:{ h10:false, jam:false, jsp:false },
   });
   harness.controller.start();
+  assert.equal(harness.controller.getActiveWorkspace(), 'recommendations');
   assert.equal(harness.elements.get('todaySummaryState').textContent, '等待資料');
   assert.equal(harness.elements.get('todaySourceReadinessHint').textContent, '等待 H10、JAM、JSP');
   assert.equal(harness.elements.get('todayNextAction').textContent, '開始準備資料');
@@ -176,6 +197,9 @@ test('shared Today renders one next action and honest empty, loading, warning, a
   assert.equal(harness.elements.get('todayHighestRisk').dataset.state, 'risk');
   assert.match(harness.elements.get('todayHighestRisk').textContent, /速度證據可能衝突或被低估/);
   assert.equal(harness.elements.get('todayNextAction').textContent, '查看 GTP03 的 Velocity Risk');
+  assert.equal(harness.elements.get('todayNextAction').dataset.targetId, 'decisionDashboard');
+  harness.elements.get('todayNextAction').listeners.click({ currentTarget:harness.elements.get('todayNextAction') });
+  assert.deepEqual(harness.elements.get('decisionDashboard').scrollCalls, [{ behavior:'smooth', block:'start' }]);
 
   harness.setSummaryInput({ sourceReadiness:'invalid' });
   harness.controller.renderToday();


### PR DESCRIPTION
Fixes #63

## Summary
- replace five English workspaces with four Chinese workspaces: 資料、今日建議、訂單、資料分析
- merge Today and recommendations while migrating legacy #today links and saved preferences
- replace oversized pallet controls with a compact embedded spinner that preserves fractional values and exact one-pallet steps
- render fixed coverage health bars: below 180 yellow, 180 through 365 green, above 365 red
- shrink row actions and keep accessible labels, lock state, keyboard support, and touch sizing

## Verification
- 215 unit and contract tests passed
- deterministic 16-file site build and artifact verification passed
- 11 Chromium acceptance tests passed for public and Boss pages