### PR TITLE
Fix Boss legacy URL deployment verification

### DIFF
--- a/scripts/verify-live-browser.mjs
+++ b/scripts/verify-live-browser.mjs
@@ -51,6 +51,7 @@ export function buildLiveBrowserUrls({ baseUrl, expectedRevision, attempt = 1 } 
     legacyCanonicalUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#recommendations'),
     canonicalPublicUrl:cacheBustedUrl(resolvedBaseUrl, './', revision, boundedAttempt, '#recommendations'),
     bossUrl:cacheBustedUrl(resolvedBaseUrl, 'Boss/', revision, boundedAttempt, '#today'),
+    bossCanonicalUrl:cacheBustedUrl(resolvedBaseUrl, 'Boss/', revision, boundedAttempt, '#recommendations'),
   });
 }
 
@@ -156,7 +157,7 @@ async function verifyBrowserAttempt({ browserType, urls, expectedRevision, navig
         waitUntil:'domcontentloaded',
         timeout:navigationTimeoutMs,
       });
-      requireExactUrl(bossPage, urls.bossUrl, 'Boss entrypoint');
+      requireExactUrl(bossPage, urls.bossCanonicalUrl, 'Boss entrypoint');
       await requireVisible(bossPage, '#bossAuthGate:not([hidden])', 'Boss authentication gate', assertionTimeoutMs);
       await requireVisible(bossPage, '#bossLoginForm', 'Boss login form', assertionTimeoutMs);
 

--- a/tests/live-browser-smoke.test.mjs
+++ b/tests/live-browser-smoke.test.mjs
@@ -62,9 +62,9 @@ function createFakeBrowserType({ failures = [] } = {}) {
                   }
                   currentUrl = url.endsWith('#decisionDashboard')
                     ? url.replace(/#decisionDashboard$/, '#recommendations')
-                    : url.endsWith('#today') && !/\/Boss\//.test(url)
+                    : url.endsWith('#today')
                       ? url.replace(/#today$/, '#recommendations')
-                    : url;
+                      : url;
                   if (failure?.phase === 'mutation' && /\/Boss\//.test(url)) {
                     requestListeners.forEach(listener => listener({
                       method:() => failure.method || 'POST',
@@ -109,6 +109,7 @@ test('URL contract keeps the live revision cache buster and separates legacy, ca
     legacyCanonicalUrl:`${BASE_URL}?supply-release=${REVISION}-3#recommendations`,
     canonicalPublicUrl:`${BASE_URL}?supply-release=${REVISION}-3#recommendations`,
     bossUrl:`${BASE_URL}Boss/?supply-release=${REVISION}-3#today`,
+    bossCanonicalUrl:`${BASE_URL}Boss/?supply-release=${REVISION}-3#recommendations`,
   });
 });
 


### PR DESCRIPTION
## Summary
- keep testing the legacy Boss #today entrypoint
- expect the browser to canonicalize it to #recommendations, matching the shipped four-workspace behavior
- update the deterministic fake-browser contract accordingly

## Verification
- live-browser unit tests: 6/6 passed
- direct Chromium verification against deployed revision 88132b0 passed in one attempt