### PR TITLE
共用產品主檔與 Apple 風可售天數血條

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,15 +9,19 @@ The canonical SKU that owns demand, inventory, catalog specifications, and cover
 _Avoid_: Order SKU, alias SKU
 
 **Order SKU**:
-The SKU printed on the purchase order for a Product SKU. It may be the Product SKU itself or an approved 7-prefixed equivalent.
+The SKU printed on the purchase order for a Product SKU. It may be the Product SKU itself or an approved 7-prefixed Order SKU Alias.
 _Avoid_: Product SKU, display SKU
+
+**Order SKU Alias**:
+A 7-prefixed purchasing identity with its own versioned carton packaging. An approved alias names one canonical Product SKU; an unmapped legacy alias preserves known historical packaging with no guessed Product SKU owner. It never owns demand, inventory, or coverage.
+_Avoid_: Product SKU, duplicate product, inferred owner
 
 **Standard Order**:
 An order whose Order SKU does not begin with `7`, grouped under either Taiwan or Vietnam according to the Product SKU's standard factory.
 _Avoid_: Main order, normal factory row
 
 **Subcontract Order**:
-An order whose Order SKU begins with `7`. All Subcontract Orders belong to the same subcontract vendor and retain the Product SKU's demand and packaging specifications.
+An order whose Order SKU begins with `7`. All Subcontract Orders belong to the same subcontract vendor and retain the Product SKU's demand ownership; FBA carton specifications may come from the Order SKU Alias.
 _Avoid_: Standard Order, alias-only display
 
 **Order Group**:

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ npm run check
 It installs the locked dependencies, runs the regression tests, builds the exact static deployment artifact in `dist/`, and verifies the artifact allowlist, references, revision, and file hashes.
 
 Only `dist/` is deployable. Repository files, tests, documentation, credentials, and user input files must never be included in the Pages artifact.
+
+## Shared product catalog
+
+Supply and FBA are generated from one versioned Excel product master. The workbook contract, public-data boundary, validation rules, and two-site release flow are documented in [docs/product-catalog.md](docs/product-catalog.md).
+
+```sh
+npm run catalog:import -- --input <workbook.xlsx> --output catalog/product-catalog.json
+npm run catalog:build
+npm run catalog:check
+```
+
+`catalog/product-catalog.json` and `product-data.js` are generated release artifacts. Do not maintain either file by hand.

--- a/catalog/product-catalog.js
+++ b/catalog/product-catalog.js
@@ -1,0 +1,309 @@
+const CATALOG_KEYS = ['catalogVersion', 'orderSkuAliases', 'products', 'schemaVersion'];
+const PRODUCT_KEYS = [
+  'approvedOrderSkus',
+  'lifecycle',
+  'origin',
+  'packagingVersions',
+  'productName',
+  'productSku',
+  'standardFactory',
+];
+const PACKAGING_KEYS = [
+  'cartonDimensionsCm',
+  'cartonsPerPallet',
+  'effectiveFrom',
+  'effectiveTo',
+  'grossWeightKg',
+  'grossWeightLb',
+  'orderUnit',
+  'source',
+  'unitsPerCarton',
+  'version',
+];
+const ORDER_UNIT_KEYS = ['kind', 'units'];
+const SOURCE_KEYS = ['row', 'sheet'];
+const ORDER_SKU_ALIAS_KEYS = [
+  'canonicalProductSku',
+  'lifecycle',
+  'orderSku',
+  'packagingVersions',
+];
+const ORIGINS = new Set(['KH', 'OTHER', 'TW', 'VN']);
+const STANDARD_FACTORIES = new Set(['OTHER', 'TW', 'VN']);
+const LIFECYCLES = new Set(['active', 'incomplete', 'retired']);
+const ORDER_SKU_ALIAS_LIFECYCLES = new Set(['approved', 'unmapped-legacy']);
+const ORDER_UNIT_KINDS = new Set(['box', 'pack', 'single']);
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const CATALOG_VERSION = /^\d{4}-\d{2}-\d{2}(?:\.\d+)?$/;
+const SKU = /^[A-Z0-9][A-Z0-9-]*$/;
+
+export class CatalogValidationError extends Error {
+  constructor(issues) {
+    const list = Array.isArray(issues) ? issues : [String(issues)];
+    super(`Invalid product catalog:\n- ${list.join('\n- ')}`);
+    this.name = 'CatalogValidationError';
+    this.issues = Object.freeze([...list]);
+  }
+}
+
+function unsupportedKeys(value, allowed, path, issues) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) issues.push(`${path} has unsupported field ${key}`);
+  }
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() === value && value.length > 0;
+}
+
+function positiveInteger(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function positiveNumberOrNull(value) {
+  return value === null || (typeof value === 'number' && Number.isFinite(value) && value > 0);
+}
+
+function validDate(value) {
+  if (!nonEmptyString(value) || !ISO_DATE.test(value)) return false;
+  return new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value;
+}
+
+function validatePackaging({ lifecycle, path }, packaging, packagingIndex, issues) {
+  const packagingPath = `${path}.packagingVersions[${packagingIndex}]`;
+  unsupportedKeys(packaging, PACKAGING_KEYS, packagingPath, issues);
+  if (!nonEmptyString(packaging?.version)) issues.push(`${packagingPath}.version must be a non-empty string`);
+  if (!validDate(packaging?.effectiveFrom)) issues.push(`${packagingPath}.effectiveFrom must be an ISO date`);
+  if (packaging?.effectiveTo !== null && !validDate(packaging?.effectiveTo)) {
+    issues.push(`${packagingPath}.effectiveTo must be an ISO date or null`);
+  }
+  if (validDate(packaging?.effectiveFrom) && validDate(packaging?.effectiveTo) && packaging.effectiveTo < packaging.effectiveFrom) {
+    issues.push(`${packagingPath}.effectiveTo must not precede effectiveFrom`);
+  }
+  if (packaging?.unitsPerCarton === null) {
+    if (lifecycle !== 'incomplete') {
+      issues.push(`${packagingPath}.unitsPerCarton must be known unless the product is incomplete`);
+    }
+  } else if (!positiveInteger(packaging?.unitsPerCarton)) {
+    issues.push(`${packagingPath}.unitsPerCarton must be a positive integer or null for an incomplete product`);
+  }
+  if (packaging?.cartonsPerPallet === null) {
+    if (lifecycle !== 'incomplete' && !ORDER_SKU_ALIAS_LIFECYCLES.has(lifecycle)) {
+      issues.push(`${packagingPath}.cartonsPerPallet must be known unless the product is incomplete or an Order SKU Alias`);
+    }
+  } else if (!positiveInteger(packaging?.cartonsPerPallet)) {
+    issues.push(`${packagingPath}.cartonsPerPallet must be a positive integer or null`);
+  }
+  if (packaging?.cartonDimensionsCm === null) {
+    if (lifecycle !== 'incomplete') {
+      issues.push(`${packagingPath}.cartonDimensionsCm must be known unless the product is incomplete`);
+    }
+  } else if (!Array.isArray(packaging?.cartonDimensionsCm)
+      || packaging.cartonDimensionsCm.length !== 3
+      || !packaging.cartonDimensionsCm.every(value => typeof value === 'number' && Number.isFinite(value) && value > 0)) {
+    issues.push(`${packagingPath}.cartonDimensionsCm must contain three positive numbers or be null for an incomplete product`);
+  }
+  if (!positiveNumberOrNull(packaging?.grossWeightKg ?? null)) issues.push(`${packagingPath}.grossWeightKg must be positive or null`);
+  if (!positiveNumberOrNull(packaging?.grossWeightLb ?? null)) issues.push(`${packagingPath}.grossWeightLb must be positive or null`);
+  unsupportedKeys(packaging?.orderUnit, ORDER_UNIT_KEYS, `${packagingPath}.orderUnit`, issues);
+  if (!ORDER_UNIT_KINDS.has(packaging?.orderUnit?.kind)) issues.push(`${packagingPath}.orderUnit.kind is unsupported`);
+  if (!positiveInteger(packaging?.orderUnit?.units)) issues.push(`${packagingPath}.orderUnit.units must be a positive integer`);
+  if (packaging?.orderUnit?.kind === 'single' && packaging?.orderUnit?.units !== 1) {
+    issues.push(`${packagingPath}.orderUnit.units must be 1 for single products`);
+  }
+  if (packaging?.source !== undefined) {
+    unsupportedKeys(packaging.source, SOURCE_KEYS, `${packagingPath}.source`, issues);
+    if (!nonEmptyString(packaging.source?.sheet)) issues.push(`${packagingPath}.source.sheet must be a non-empty string`);
+    if (!positiveInteger(packaging.source?.row)) issues.push(`${packagingPath}.source.row must be a positive integer`);
+  }
+}
+
+function packagingRangesOverlap(left, right) {
+  const leftEnd = left.effectiveTo || '9999-12-31';
+  const rightEnd = right.effectiveTo || '9999-12-31';
+  return left.effectiveFrom <= rightEnd && right.effectiveFrom <= leftEnd;
+}
+
+function validateProduct(product, productIndex, issues, productSkus, orderSkuOwners) {
+  const path = `products[${productIndex}]`;
+  unsupportedKeys(product, PRODUCT_KEYS, path, issues);
+  if (!nonEmptyString(product?.productSku) || !SKU.test(product.productSku)) issues.push(`${path}.productSku must be normalized uppercase SKU text`);
+  if (product?.productSku?.startsWith('7')) issues.push(`${path}.productSku must not be 7-prefixed; model it as an Order SKU Alias`);
+  if (productSkus.has(product?.productSku)) issues.push(`${path}.productSku duplicates ${product.productSku}`);
+  else productSkus.add(product?.productSku);
+  if (typeof product?.productName !== 'string') issues.push(`${path}.productName must be text`);
+  if (product?.lifecycle === 'active' && !nonEmptyString(product.productName)) {
+    issues.push(`${path}.productName must be a non-empty string for an active product`);
+  }
+  if (product?.origin !== null && !ORIGINS.has(product?.origin)) issues.push(`${path}.origin is unsupported`);
+  if (product?.standardFactory !== null && !STANDARD_FACTORIES.has(product?.standardFactory)) {
+    issues.push(`${path}.standardFactory is unsupported`);
+  }
+  if (!LIFECYCLES.has(product?.lifecycle)) issues.push(`${path}.lifecycle is unsupported`);
+  if (product?.lifecycle === 'active' && product?.standardFactory === null) {
+    issues.push(`${path}.standardFactory must be known for an active product`);
+  }
+
+  if (!Array.isArray(product?.approvedOrderSkus) || product.approvedOrderSkus.length === 0) {
+    issues.push(`${path}.approvedOrderSkus must be a non-empty array`);
+  } else {
+    const local = new Set();
+    for (const orderSku of product.approvedOrderSkus) {
+      if (!nonEmptyString(orderSku) || !SKU.test(orderSku)) issues.push(`${path}.approvedOrderSkus contains an invalid SKU`);
+      if (nonEmptyString(orderSku) && orderSku !== product.productSku && !orderSku.startsWith('7')) {
+        issues.push(`${path}.approvedOrderSkus alternative ${orderSku} must be 7-prefixed`);
+      }
+      if (local.has(orderSku)) issues.push(`${path}.approvedOrderSkus duplicates ${orderSku}`);
+      local.add(orderSku);
+      const owner = orderSkuOwners.get(orderSku);
+      if (owner && owner !== product.productSku) issues.push(`${path}.approvedOrderSkus reuses ${orderSku} from ${owner}`);
+      else orderSkuOwners.set(orderSku, product.productSku);
+    }
+    if (!local.has(product.productSku)) issues.push(`${path}.approvedOrderSkus must include its Product SKU`);
+  }
+
+  if (!Array.isArray(product?.packagingVersions) || product.packagingVersions.length === 0) {
+    issues.push(`${path}.packagingVersions must be a non-empty array`);
+    return;
+  }
+  const versions = new Set();
+  product.packagingVersions.forEach((packaging, index) => {
+    validatePackaging({ lifecycle:product.lifecycle, path }, packaging, index, issues);
+    if (versions.has(packaging?.version)) issues.push(`${path}.packagingVersions duplicates version ${packaging.version}`);
+    versions.add(packaging?.version);
+  });
+  const current = product.packagingVersions.filter(packaging => packaging?.effectiveTo === null);
+  if (current.length !== 1) issues.push(`${path} must have exactly one current packaging version`);
+  for (let left = 0; left < product.packagingVersions.length; left += 1) {
+    for (let right = left + 1; right < product.packagingVersions.length; right += 1) {
+      const a = product.packagingVersions[left];
+      const b = product.packagingVersions[right];
+      if (validDate(a?.effectiveFrom) && validDate(b?.effectiveFrom) && packagingRangesOverlap(a, b)) {
+        issues.push(`${path} packaging date ranges overlap: ${a.version} and ${b.version}`);
+      }
+    }
+  }
+}
+
+function validateOrderSkuAlias(alias, aliasIndex, issues, productsBySku, orderSkuOwners, aliasOrderSkus) {
+  const path = `orderSkuAliases[${aliasIndex}]`;
+  unsupportedKeys(alias, ORDER_SKU_ALIAS_KEYS, path, issues);
+  if (!nonEmptyString(alias?.orderSku) || !SKU.test(alias.orderSku) || !alias.orderSku.startsWith('7')) {
+    issues.push(`${path}.orderSku must be a normalized 7-prefixed SKU`);
+  }
+  if (aliasOrderSkus.has(alias?.orderSku)) issues.push(`${path}.orderSku duplicates ${alias.orderSku}`);
+  else aliasOrderSkus.add(alias?.orderSku);
+  if (!ORDER_SKU_ALIAS_LIFECYCLES.has(alias?.lifecycle)) issues.push(`${path}.lifecycle is unsupported`);
+  if (alias?.canonicalProductSku !== null
+      && (!nonEmptyString(alias?.canonicalProductSku) || !SKU.test(alias.canonicalProductSku))) {
+    issues.push(`${path}.canonicalProductSku must be a normalized Product SKU or null`);
+  }
+
+  if (alias?.lifecycle === 'approved') {
+    if (!nonEmptyString(alias?.canonicalProductSku)) {
+      issues.push(`${path}.canonicalProductSku must identify an existing Product SKU for an approved alias`);
+    } else {
+      const owner = productsBySku.get(alias.canonicalProductSku);
+      if (!owner) issues.push(`${path}.canonicalProductSku does not exist: ${alias.canonicalProductSku}`);
+      else if (!owner.approvedOrderSkus.includes(alias.orderSku)) {
+        issues.push(`${path}.orderSku must be listed in ${alias.canonicalProductSku}.approvedOrderSkus`);
+      }
+    }
+  }
+  if (alias?.lifecycle === 'unmapped-legacy' && alias?.canonicalProductSku !== null) {
+    issues.push(`${path}.canonicalProductSku must be null for an unmapped-legacy alias`);
+  }
+  if (alias?.lifecycle === 'unmapped-legacy' && orderSkuOwners.has(alias?.orderSku)) {
+    issues.push(`${path}.orderSku is already approved by ${orderSkuOwners.get(alias.orderSku)} and cannot be unmapped-legacy`);
+  }
+
+  if (!Array.isArray(alias?.packagingVersions) || alias.packagingVersions.length === 0) {
+    issues.push(`${path}.packagingVersions must be a non-empty array`);
+    return;
+  }
+  const versions = new Set();
+  alias.packagingVersions.forEach((packaging, index) => {
+    validatePackaging({ lifecycle:alias.lifecycle, path }, packaging, index, issues);
+    if (versions.has(packaging?.version)) issues.push(`${path}.packagingVersions duplicates version ${packaging.version}`);
+    versions.add(packaging?.version);
+  });
+  const current = alias.packagingVersions.filter(packaging => packaging?.effectiveTo === null);
+  if (current.length !== 1) issues.push(`${path} must have exactly one current packaging version`);
+  for (let left = 0; left < alias.packagingVersions.length; left += 1) {
+    for (let right = left + 1; right < alias.packagingVersions.length; right += 1) {
+      const a = alias.packagingVersions[left];
+      const b = alias.packagingVersions[right];
+      if (validDate(a?.effectiveFrom) && validDate(b?.effectiveFrom) && packagingRangesOverlap(a, b)) {
+        issues.push(`${path} packaging date ranges overlap: ${a.version} and ${b.version}`);
+      }
+    }
+  }
+}
+
+function cloneCatalog(catalog) {
+  return JSON.parse(JSON.stringify(catalog));
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  Object.values(value).forEach(deepFreeze);
+  return value;
+}
+
+export function validateCatalog(catalog) {
+  const issues = [];
+  unsupportedKeys(catalog, CATALOG_KEYS, 'catalog', issues);
+  if (catalog?.schemaVersion !== 2) issues.push('catalog.schemaVersion must equal 2');
+  if (!nonEmptyString(catalog?.catalogVersion) || !CATALOG_VERSION.test(catalog.catalogVersion)) {
+    issues.push('catalog.catalogVersion must be a dated version such as 2026-08-25 or 2026-08-25.2');
+  }
+  const productSkus = new Set();
+  const orderSkuOwners = new Map();
+  if (!Array.isArray(catalog?.products) || catalog.products.length === 0) {
+    issues.push('catalog.products must be a non-empty array');
+  } else {
+    catalog.products.forEach((product, index) => validateProduct(product, index, issues, productSkus, orderSkuOwners));
+  }
+  const productsBySku = new Map((Array.isArray(catalog?.products) ? catalog.products : [])
+    .map(product => [product?.productSku, product]));
+  const aliasOrderSkus = new Set();
+  if (!Array.isArray(catalog?.orderSkuAliases)) {
+    issues.push('catalog.orderSkuAliases must be an array');
+  } else {
+    catalog.orderSkuAliases.forEach((alias, index) => {
+      validateOrderSkuAlias(alias, index, issues, productsBySku, orderSkuOwners, aliasOrderSkus);
+    });
+    for (const [orderSku, owner] of orderSkuOwners) {
+      if (orderSku.startsWith('7') && !aliasOrderSkus.has(orderSku)) {
+        issues.push(`approved 7-prefixed Order SKU ${orderSku} from ${owner} is missing from orderSkuAliases`);
+      }
+    }
+  }
+  if (issues.length) throw new CatalogValidationError(issues);
+
+  const validated = cloneCatalog(catalog);
+  validated.products.forEach(product => {
+    product.currentPackaging = product.packagingVersions.find(packaging => packaging.effectiveTo === null);
+  });
+  validated.orderSkuAliases.forEach(alias => {
+    alias.currentPackaging = alias.packagingVersions.find(packaging => packaging.effectiveTo === null);
+  });
+  return deepFreeze(validated);
+}
+
+export function orderGroupForOrderSku(orderSku, standardFactory) {
+  if (String(orderSku || '').trim().toUpperCase().startsWith('7')) return 'subcontract';
+  if (standardFactory === 'TW') return 'taiwan';
+  if (standardFactory === 'VN') return 'vietnam';
+  return 'other';
+}
+
+export function compileCatalog(catalog, adapter) {
+  if (!adapter || typeof adapter.project !== 'function' || !nonEmptyString(adapter.name)) {
+    throw new TypeError('Catalog adapter must provide a non-empty name and project(snapshot)');
+  }
+  const snapshot = validateCatalog(catalog);
+  return adapter.project(snapshot);
+}

--- a/catalog/product-catalog.json
+++ b/catalog/product-catalog.json
@@ -1,0 +1,11816 @@
+{
+  "schemaVersion": 2,
+  "catalogVersion": "2026-08-28.3",
+  "products": [
+    {
+      "productSku": "1GBRD019A0",
+      "productName": "Gootoe - Buffalo Bites Bone Shaped - 1.5lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GBRD019A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 9,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GBRD029A0",
+      "productName": "Gootoe - Buffalo Bites Stick (Large) - 1.5lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GBRD029A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD010A0",
+      "productName": "A freschi Air-Dried Dog Food-Turkey Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD010A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD170A0",
+      "productName": "A freschi Air-Dried Dog Food-Turkey & Salmon Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD170A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD073A0",
+      "productName": "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 1lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD073A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD075A0",
+      "productName": "A Freschi Air-dried Dog Food-Chicken & Salmon Recipe , 2.2lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD075A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD070A0",
+      "productName": "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD070A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD063A0",
+      "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 1lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD063A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD065A0",
+      "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 2.2lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD065A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD060A0",
+      "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD060A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD473A0",
+      "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 1lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD473A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD475A0",
+      "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 2.2lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD475A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD470A0",
+      "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD470A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD463A0",
+      "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 1lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD463A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD465A0",
+      "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 2.2lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD465A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD460A0",
+      "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 0.9oz",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1AWDD460A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 250,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VADD063A0",
+      "productName": "VITADAY - Air-Dried Dog Food - Chicken Recipe - Stomach Support Formula - 454g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1VADD063A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VADD073A0",
+      "productName": "VITADAY - Air-Dried Dog Food - Chicken & Mackerels Recipe - Joint Support Formula - 454g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1VADD073A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD017A0",
+      "productName": "Gootoe - Chicken Fillet Jerky - 1lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GCRD017A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 9,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD027A0",
+      "productName": "Gootoe - Chicken Breast Jerky - 1lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GCRD027A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 11,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 38,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD037A0",
+      "productName": "Gootoe - Chicken Chips - 1lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GCRD037A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 9,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GQRD017A0",
+      "productName": "Gootoe - Soft Chicken Breast Strips - 1lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GQRD017A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 10,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GQRD027A0",
+      "productName": "Gootoe - Soft Chicken Sticks - 1lb (Pack of 3)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GQRD027A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 11,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 38,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GSDD011A0",
+      "productName": "GooToE Chicken Breast Wrapped Salmon Sticks , 6oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GSDD011A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GSDD015A0",
+      "productName": "GooToE Chicken Breast Wrapped Salmon Sticks , 1.5lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GSDD015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD005A0",
+      "productName": "GooToE Chicken Breast Wrapped Sticks , 6oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GCRD005A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD004A0",
+      "productName": "GooToE Chicken Breast Wrapped Sticks , 1.5lb",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1GCRD004A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1ABRD001A0",
+      "productName": "A Freschi  Buffalo Jerky Dog Treats , 4oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1ABRD001A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1ABRD002A0",
+      "productName": "A Freschi  Buffalo Jerky Dog Treats , 12oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1ABRD002A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": 16.9,
+          "grossWeightLb": 37.25812230924431,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 209
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1ABRD003A0",
+      "productName": "A Freschi  Buffalo Strips , 4oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1ABRD003A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 37,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1ABRD004A0",
+      "productName": "A Freschi  Buffalo Strips , 12oz",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1ABRD004A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 48,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD011A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Skin & Coat Care - 150g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD011A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD021A0",
+      "productName": "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - 150g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD021A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD031A0",
+      "productName": "Healthy Moment - Functional Dog Treat-Joint Care - 150g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD031A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD041A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Eyes Care - 150g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD041A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD051A0",
+      "productName": "Healthy Moment - Functional Dog Treat-Heart Health Care - 150g",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD051A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD017A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Skin & Coat Care - Box",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD017A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD027A0",
+      "productName": "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - Box",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD027A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD037A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Joint Care - Box",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD037A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD047A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Eyes Care - Box",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD047A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MHTD057A0",
+      "productName": "Healthy Moment - Functional Dog Treat - Heart Health Care - Box",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "1MHTD057A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA11AM",
+      "productName": "AFreschi-Classic Turkey Tendon Thin Stick (100g /pk)；AFK package (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA11AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 34,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA12AM",
+      "productName": "AFreschi-Classic Turkey Tendon Braided Stick(100g /pk)；AFK package (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA12AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 34,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA13AM",
+      "productName": "AFreschi-Classic Turkey Tendon Slice (100g /pk)；AFK package (100 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA13AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA14AM",
+      "productName": "AFreschi-Classic Turkey Tendon Flake(100g /pk)；AFK package (80 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA14AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA21AM",
+      "productName": "AFreschi-Soft Turkey Tendon & Pumpkin strip (100g /pk)；AFK package (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA21AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 34,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA22AM",
+      "productName": "AFreschi-Soft Turkey Tendon Strip (100g /pk)；AFK package (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA22AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 34,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA31AM",
+      "productName": "AFreschi-Wrapped Turkey Tendon with Chicken Stick (100g /pk)；AFK package (100 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA31AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA32AM",
+      "productName": "AFreschi-Wrapped Turkey Tendon with Brown Rice Stick(100g /pk)；AFK package (100 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA32AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA25AM",
+      "productName": "AFreschi-Classic Turkey Tendon Coil-L(85g /pk)；AFK package (70 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA25AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 19,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFA135AM",
+      "productName": "AFreschi-Classic Turkey Tendon Coil-S(85g /pk)；AFK package (70 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFA135AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 19,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTS01",
+      "productName": "Gootoe - Turkey Tendon Strip (85g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTS01",
+        "7GTSD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTR01",
+      "productName": "Gootoe - Turkey Tendon Ring_S(72g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTR01",
+        "7GTRD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB01",
+      "productName": "Gootoe - Turkey Tendon Bone_S(72g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB01",
+        "7GTBD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP01",
+      "productName": "Gootoe - Turkey Tendon Rope_S(72g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP01",
+        "7GTPD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTZ01",
+      "productName": "Gootoe - Turkey Tendon Pretzel_S(72g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTZ01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTA01",
+      "productName": "Gootoe - Turkey Tendon Braid_S(90g x 120)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTA01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 31,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTC01",
+      "productName": "Gootoe - Sliced Turkey Tendon (85g x 120)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTC01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 30,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTR03",
+      "productName": "Gootoe - Turkey Tendon Ring_M(90g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTR03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB03",
+      "productName": "Gootoe - Turkey Tendon Bone_M(90g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP03",
+      "productName": "Gootoe - Turkey Tendon Rope_M(90g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": 12,
+          "grossWeightLb": 26.455471462185308,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 6
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTS03",
+      "productName": "Gootoe - Turkey Tendon Stick_M(90g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTS03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTZ03",
+      "productName": "Gootoe - Turkey Tendon Pretzel_M(90g x 120)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTZ03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 31,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB05",
+      "productName": "Gootoe - Turkey Tendon Bone_L(100g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB05",
+        "7GTBD053AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": 13,
+          "grossWeightLb": 28.660094084034085,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 28
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP05",
+      "productName": "Gootoe - Turkey Tendon Rope_L(100g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP05",
+        "7GTPD053AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": 13,
+          "grossWeightLb": 28.660094084034085,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 24
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB07",
+      "productName": "Gootoe - Turkey tendon lolipop 15g x 5pcs (75g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB07"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSF01",
+      "productName": "Soft Turkey Tendon Strip with Pumpkin (85g x 150)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSF01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 150,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSF02",
+      "productName": "Soft Turkey Tendon Strip (85g x 150)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSF02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 150,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTSL01",
+      "productName": "Gootoe - Turkey Tendon Strip (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTSL01",
+        "7GTSD017AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 39
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTRL01",
+      "productName": "Gootoe - Turkey Tendon Ring_S (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTRL01",
+        "7GTRD017AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 22,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 46
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTPL01",
+      "productName": "Gootoe - Turkey Tendon Rope_S (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTPL01",
+        "7GTPD017AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 41
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTBL01",
+      "productName": "Gootoe - Turkey Tendon Bone_S (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTBL01",
+        "7GTBD017AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 26,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 44
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTAL01",
+      "productName": "Gootoe - Turkey Tendon Braid_S (454g x 38)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTAL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 20,
+          "grossWeightLb": 44.09245243697551,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 21
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTCL01",
+      "productName": "Gootoe - Turkey Tendon Sliced (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTCL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 19
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTRL03",
+      "productName": "Gootoe - Turkey Tendon Ring_M (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTRL03",
+        "7GTRD037AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 16
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTPL03",
+      "productName": "Gootoe - Turkey Tendon Rope_M (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTPL03",
+        "7GTPD037AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 12
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTBL03",
+      "productName": "Gootoe - Turkey Tendon Bone_M (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTBL03",
+        "7GTBD037AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 14
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTZL03",
+      "productName": "Gootoe - Turkey Tendon Pretzel_M (454g x 30)",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTZL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTPL05",
+      "productName": "Gootoe - Turkey Tendon Rope_L (454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTPL05",
+        "7GTPD057AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 26
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTBL05",
+      "productName": "Gootoe - Turkey Tendon Bone_L(454g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTBL05",
+        "7GTBD057AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "supply-2026-07-19",
+          "effectiveFrom": "2026-07-19",
+          "effectiveTo": "2026-08-24",
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        },
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": 16,
+          "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 30
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSFL01",
+      "productName": "Soft Turkey Tendon Strip with Pumpkin (454g x 38)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSFL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 44,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSFL02",
+      "productName": "Soft Turkey Tendon Strip (454g x 38)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSFL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 44,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATS01",
+      "productName": "Natural Turkey Tendon Strip (100g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATS01",
+        "7ATSD011AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATB01",
+      "productName": "Afreschi srl - Natural Turkey Tendon Bone_S(72g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATB01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATR01AM",
+      "productName": "Afreschi srl - Natural Turkey Tendon Ring_S(72g)",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATR01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATP01",
+      "productName": "Afreschi srl - Natural Turkey Tendon Rope_S(72g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATP01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATZ01",
+      "productName": "Afreschi srl - Natural Turkey Tendon Pretzel_S(72g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATZ01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATA01",
+      "productName": "Afreschi srl - Natural Turkey Tendon Braid(90g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATA01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATB03",
+      "productName": "Afreschi srl - Natural Turkey Tendon Bone_M(90g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATB03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATR03",
+      "productName": "Afreschi srl - Natural Turkey Tendon Ring_M(90g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATR03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATP03",
+      "productName": "Afreschi srl - Natural Turkey Tendon Rope_M(90g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATP03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATZ03",
+      "productName": "Afreschi srl - Natural Turkey Tendon Pretzel_M(90g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATZ03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATB05",
+      "productName": "Afreschi srl - Natural Turkey Tendon Bone_L(100g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATB05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATP05",
+      "productName": "Afreschi srl- Natural Turkey Tendon Rope_L(100g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATP05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATAL01",
+      "productName": "Afreschi Natural Turkey Tendon Braid 8oz (GTA01:227g x 42)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATAL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB01AM",
+      "productName": "Natural Turkey Tendon Bone_S (40 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP01AM",
+      "productName": "Natural Turkey Tendon Rope_S (40 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 19,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR01AM",
+      "productName": "Natural Turkey Tendon Ring_S (40 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ01AM",
+      "productName": "Natural Turkey Tendon Pretzel_S (40 units /box ; 8 boxes /CTN)",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB03AM",
+      "productName": "Natural Turkey Tendon Bone_M (20 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB03AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP03AM",
+      "productName": "Natural Turkey Tendon Rope_M (20 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP03AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR03AM",
+      "productName": "Natural Turkey Tendon Ring_M (20 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR03AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ03AM",
+      "productName": "Natural Turkey Tendon Pretzel-M (20 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ03AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP05AM",
+      "productName": "Natural Turkey Tendon Rope_L (10 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP05AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB05AM",
+      "productName": "Natural Turkey Tendon Bone_L (10 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB05AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR05AM",
+      "productName": "Natural Turkey Tendon Ring_L (10 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR05AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ05AM",
+      "productName": "Natural Turkey Tendon Pretzel_L (10 units；8 boxes /CTN)",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ05AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTS05AM",
+      "productName": "Natural Turkey Tendon Strip (10 units /box ; 8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTS05AM",
+        "7ATSD019AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB06AM",
+      "productName": "Natural Turkey Tendon Lollipop (40 units；8 boxes /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB06AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB01AM-4",
+      "productName": "Natural Turkey Tendon Bone_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB01AM-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR01AM-4",
+      "productName": "Natural Turkey Tendon Ring_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR01AM-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP01AM-4",
+      "productName": "Natural Turkey Tendon Rope_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP01AM-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ01AM-4",
+      "productName": "Natural Turkey Tendon Pretzel_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ01AM-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB03AM-2",
+      "productName": "Natural Turkey Tendon Bone_M (80 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB03AM-2"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 2
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP03AM-2",
+      "productName": "Natural Turkey Tendon Rope_M (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP03AM-2"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 2
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR03AM-2",
+      "productName": "Natural Turkey Tendon Ring_M (80 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR03AM-2"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 2
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ03AM-2",
+      "productName": "Natural Turkey Tendon Pretzel_M (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ03AM-2"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 2
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB05AM-1",
+      "productName": "Natural Turkey Tendon Bone_L (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB05AM-1"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP05AM-1",
+      "productName": "Natural Turkey Tendon Rope_L (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP05AM-1"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR05AM-1",
+      "productName": "Natural Turkey Tendon Ring_L (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR05AM-1"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZ05AM-1",
+      "productName": "Natural Turkey Tendon Pretzel_L (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZ05AM-1"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTS05AM-1",
+      "productName": "Natural Turkey Tendon Strip (100 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTS05AM-1",
+        "7ATSD010AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB06AM-4",
+      "productName": "Natural Turkey Tendon Lollipop (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB06AM-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTBL01",
+      "productName": "Afreschi Natural Turkey Tendon Bone 8oz_S-15g (227g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTBL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTRL01",
+      "productName": "Afreschi Natural Turkey Tendon Ring 8oz_S-12g (227g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTRL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZL01",
+      "productName": "Afreschi Natural Turkey Tendon Pretzel 8oz_S-12g (227g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRPL01",
+      "productName": "Afreschi Natural Turkey Tendon Rope 8oz_S-12g (227g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRPL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTBL03",
+      "productName": "Afreschi Natural Turkey Tendon Bone 10oz_M-36g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTBL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTRL03",
+      "productName": "Afreschi Natural Turkey Tendon Ring 10oz_M-36g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTRL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZL03",
+      "productName": "Afreschi Natural Turkey Tendon Pretzel 10oz_M-36g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRPL03",
+      "productName": "Afreschi Natural Turkey Tendon Rope 10oz_M-36g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRPL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTRL05",
+      "productName": "Afreschi Natural Turkey Tendon Ring 10oz_L-72g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTRL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRPL05",
+      "productName": "Afreschi Natural Turkey Tendon Rope 10oz_L-72g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRPL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TPZL05",
+      "productName": "Afreschi Natural Turkey Tendon Pretzel 10oz_L-72g (285g x 36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TPZL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTBL05",
+      "productName": "Afreschi Natural Turkey Tendon Bone 10oz_L-72g (285g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTBL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTSL05",
+      "productName": "Afreschi Natural Turkey Tendon Strip 10oz (285g x 30)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTSL05",
+        "7ATSD017AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFML01",
+      "productName": "AFreschi Turkey Tendon Variety Pack 8oz_Small (227gx36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFML01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 23,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFML03",
+      "productName": "AFreschi Turkey Tendon Variety Pack 10oz_Medium (285gx36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFML03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AFML05",
+      "productName": "AFreschi Turkey Tendon Variety Pack 10oz_Large (285gx36)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AFML05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASF01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Soft Sticks (170g x 100)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASF01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ABM01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (170g x 110)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ABM01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 110,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 49,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATN01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Star Bites (170g x 80)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATN01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASA01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Mini Bars (170g x 80)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASA01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ADT03",
+      "productName": "Natural Dental Treats-Real Turkey Meat (1kg x20 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ADT03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATJ01",
+      "productName": "Afreschi - Natural Turkey Jerky 4oz (113gx110)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATJ01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 110,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTT01",
+      "productName": "Gootoe Turkey Tendon Twists 5oz_Small (142g*120)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTT01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 46,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTT03",
+      "productName": "Gootoe Turkey Tendon Twists 5oz_Medium (142g*120)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTT03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASFL01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Soft Sticks (454g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASFL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ABML01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (454g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ABML01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATNL01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Star Bites (454g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATNL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASAL01",
+      "productName": "A Freschi Srl – Natural Turkey Treats Mini Bars (454g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASAL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATJL01",
+      "productName": "A Freschi Srl – Natural Turkey Jerky (12oz-340g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ATJL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 37,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCBL01",
+      "productName": "Gootoe - Chicken Fillet Jerky 454gx30",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCBL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCBL02",
+      "productName": "Gootoe - Chicken Jerky Breast 454gx36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCBL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCBL03",
+      "productName": "Gootoe - Chicken Chips 454gx28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCBL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 33,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSCL01",
+      "productName": "Gootoe - Soft Chicken Breast Strips 454gx36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSCL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSCL02",
+      "productName": "Gootoe - Soft Chicken Sticks 454gx36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSCL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSCL03",
+      "productName": "Gootoe - Soft Chicken Dental Chews with Chlorophyll, 1.5lb (681gx28)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSCL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSCL04",
+      "productName": "Gootoe - Soft Chicken Knots 454gx30",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSCL04"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSCL05",
+      "productName": "Gootoe - Soft Chicken Jerky Cuts 454gx36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSCL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL01",
+      "productName": "Gootoe - Chicken Sticks 1.5lb-681gx28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL02",
+      "productName": "Gootoe - Chicken Sticks With Chicken Liver 1.5lb-681gx28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL03",
+      "productName": "Gootoe - Chicken Sticks With Sweet Potato 1.5lb-681gx28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL04",
+      "productName": "Gootoe - Chicken Mini Sticks 1.5lb-681gx22",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL04"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 22,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 37,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL05",
+      "productName": "Gootoe - Chicken Roll 12oz-340gx24",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GCTL06",
+      "productName": "Gootoe - Chicken Dipped Sticks 1.5lb-681gx28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GCTL06"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBS01",
+      "productName": "Gootoe - Buffalo Bites Stick _S (70units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBS01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBS03",
+      "productName": "Gootoe - Buffalo Bites Stick _L (70 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBS03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBB01",
+      "productName": "Gootoe - Buffalo Bites Bone Shaped (60 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBB01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 60,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBSL01",
+      "productName": "Gootoe - Buffalo Bites Stick (small) (S) 1.5lb-681g",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBSL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBSL03",
+      "productName": "Gootoe - Buffalo Bites Stick (Large) (L) 1.5lb-681g",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBSL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GBBL01",
+      "productName": "Gootoe - Buffalo Bites Bone Shaped 1.5lb-681g",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GBBL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AWD010",
+      "productName": "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-454g",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AWD010"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AWD011",
+      "productName": "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-1kg",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AWD011"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AWD070",
+      "productName": "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-454g",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AWD070"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "AWD071",
+      "productName": "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-1kg",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "AWD071"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VTS01-1",
+      "productName": "Turkey Tendon Strip (100 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VTS01-1",
+        "7VTSD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VTB01-4",
+      "productName": "Turkey Tendon Bone_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VTB01-4",
+        "7VTBD410AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VTR01-4",
+      "productName": "Turkey Tendon Ring_S (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VTR01-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VTB05-1",
+      "productName": "Turkey Tendon Bone_L (120 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VTB05-1"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VTB06-4",
+      "productName": "Turkey Tendon Lollipop (90 units /CTN)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VTB06-4"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "HDR01AM",
+      "productName": "Herz_ Turkey Tendon_Duo-Protein_Ring (S) (85g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "HDR01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "HDP01AM",
+      "productName": "Herz_ Turkey Tendon_Duo-Protein_Rope(S)(85g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "HDP01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "HDS03AM",
+      "productName": "Herz_ Turkey Tendon_Duo-Protein_Strip(85g)",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "HDS03AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 120,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACBL01",
+      "productName": "AFreschi - Natural Chicken Fillet Jerky 454g*30",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACBL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACBL02",
+      "productName": "AFreschi - Natural Chicken Breast Jerky 454g*36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACBL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACBL03",
+      "productName": "AFreschi - Natural Chicken Chips 454g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACBL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 33,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASCL01",
+      "productName": "AFreschi - Natural Soft Chicken Breast Strips 454g*36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASCL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASCL02",
+      "productName": "AFreschi - Natural Soft Chicken Sticks 454g*36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASCL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASCL03",
+      "productName": "AFreschi - Natural Soft Chicken Dental Chews with Chlorophyll 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASCL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASCL04",
+      "productName": "AFreschi - Natural Soft Chicken Knots 454g*30",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASCL04"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ASCL05",
+      "productName": "AFreschi - Natural Soft Chicken Jerky Cuts 454g*36",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ASCL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL01",
+      "productName": "AFreschi - Natural Chicken Sticks 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL02",
+      "productName": "AFreschi - Natural Chicken Sticks with Chicken Liver 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL03",
+      "productName": "AFreschi - Natural Chicken Sticks with Sweet Potato 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL04",
+      "productName": "AFreschi - Natural Chicken Sticks (Mini) 681g*22",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL04"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 22,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 37,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL05",
+      "productName": "AFreschi - Natural Chicken Roll 340g*24",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL05"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL06",
+      "productName": "AFreschi - Natural Chicken Dipped Sticks 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL06"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL07",
+      "productName": "AFreschi - Natural Chicken Dipped Rice Sticks 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL07"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL08",
+      "productName": "AFreschi - Natural Chicken Sliced 681g*24",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL08"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL09",
+      "productName": "AFreschi - Natural Chicken Dipped Rice Bone 454g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL09"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 42,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACTL10",
+      "productName": "AFreschi - Natural Chicken Sticks with Pumpkin 681g*28",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACTL10"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACA01",
+      "productName": "Afreschi - Natural Cat Treats (Chicken & Mackerel) -6oz-170gx100",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACA01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACA02",
+      "productName": "Afreschi - Natural Cat Treats (Buffalo& Chicken & Fish) -6oz-170gx100",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACA02"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ACA03",
+      "productName": "Afreschi - Natural Cat Treats (Turkey & Chicken & Mackerel) -6oz-170gx100",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ACA03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VBS01",
+      "productName": "Vitaday - Buffalo Treats Stick (Small) 227g*70",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VBS01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VBS03",
+      "productName": "Vitaday - Buffalo Treats Stick (Medium) 227g*70",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VBS03"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VBB01",
+      "productName": "Vitaday - Buffalo Treats Bone Shaped 227g*60",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VBB01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 60,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "VBW01",
+      "productName": "Vitaday - Buffalo Treats W Shaped 227g*80",
+      "origin": "TW",
+      "standardFactory": "VN",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "VBW01"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD011AM",
+      "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (908g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD011AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD021AM",
+      "productName": "Herz Grain-Free Australian Lamb Recipe (908g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD021AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD041AM",
+      "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (908g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD041AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD051AM",
+      "productName": "Herz Grain-Free New Zealand Venison Recipe (908g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD051AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD061AM",
+      "productName": "Herz Grain-Free U.S.A. Chicken Recipe (908g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD061AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD010AM",
+      "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD010AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD020AM",
+      "productName": "Herz Grain-Free Australian Lamb Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD020AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD040AM",
+      "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD040AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD050AM",
+      "productName": "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD050AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD060AM",
+      "productName": "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD060AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD010AM-3",
+      "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD010AM-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD020AM-3",
+      "productName": "Herz Grain-Free Australian Lamb Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD020AM-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD040AM-3",
+      "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD040AM-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD050AM-3",
+      "productName": "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD050AM-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD060AM-3",
+      "productName": "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EZD060AM-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 3
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD011J",
+      "productName": "Herz Premium Canine Cuisine – Turkey with Duck Liver Recipe, 1kg",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD011J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD021J",
+      "productName": "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-1kg",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD021J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD041J",
+      "productName": "Premium Canine Cuisine-Beef with Duck Liver Ricipe-1kg",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD041J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD061J",
+      "productName": "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-1kg",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD061J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD010J",
+      "productName": "Premium Canine Cuisine – Turkey with Duck Liver Recipe-454g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD010J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD020J",
+      "productName": "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-454g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD020J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD040J",
+      "productName": "Premium Canine Cuisine-Beef with Duck Liver Ricipe-454g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD040J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD060J",
+      "productName": "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-454g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "EPD060J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTSL01J",
+      "productName": "Gootoe - Turkey Tendon Strip",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTSL01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTRL05J",
+      "productName": "Gootoe - Turkey Tendon Ring_L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTRL05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTPL05J",
+      "productName": "Gootoe - Turkey Tendon Rope_L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTPL05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTBL05J",
+      "productName": "Gootoe - Turkey Tendon Bone_L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTBL05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTRL01J",
+      "productName": "Gootoe - Turkey Tendon Ring_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTRL01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTPL01J",
+      "productName": "Gootoe - Turkey Tendon Rope_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTPL01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTBL01J",
+      "productName": "Gootoe - Turkey Tendon Bone_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTBL01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GSF01J",
+      "productName": "Gootoe -Turkey Tendon Pumpkin Strip",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GSF01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 150,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTR01J",
+      "productName": "Gootoe - Turkey Tendon Ring_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTR01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTR03J",
+      "productName": "Gootoe - Turkey Tendon Ring_M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTR03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB01J",
+      "productName": "Gootoe - Turkey Tendon Bone_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB03J",
+      "productName": "Gootoe - Turkey Tendon Bone_M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTB05J",
+      "productName": "Gootoe - Turkey Tendon Bone_L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTB05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP01J",
+      "productName": "Gootoe - Turkey Tendon Rope_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP03J",
+      "productName": "Gootoe - Turkey Tendon Rope _M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTP05J",
+      "productName": "Gootoe - Turkey Tendon Rope _L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTP05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTS01J",
+      "productName": "Gootoe - Turkey Tendon Strip",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTS01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTS03J",
+      "productName": "Gootoe - Turkey Tendon Stick_M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTS03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTZ01J",
+      "productName": "Gootoe - Turkey Tendon Pretzel_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTZ01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTZ03J",
+      "productName": "Gootoe - Turkey Tendon Pretzel_M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTZ03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GTA01J",
+      "productName": "Gootoe - Turkey Tendon Braid",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GTA01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB01J",
+      "productName": "Natural Turkey Tendon Bone_S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 320,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB03J",
+      "productName": "Natural Turkey Tendon Bone_ M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB05J",
+      "productName": "Natural Turkey Tendon Bone_L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "KTB06J",
+      "productName": "Natural Turkey Tendon Lollipop",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "KTB06J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 320,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR01J",
+      "productName": "Natural Turkey Tendon Ring_ S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 320,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR03J",
+      "productName": "Natural Turkey Tendon Ring_ M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTR05J",
+      "productName": "Natural Turkey Tendon Ring_ L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTR05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP01J",
+      "productName": "Natural Turkey Tendon Rope_ S",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 320,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 40
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP03J",
+      "productName": "Natural Turkey Tendon Rope_ M",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TRP05J",
+      "productName": "Natural Turkey Tendon Rope_ L",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TRP05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTS05J",
+      "productName": "Natural Turkey Tendon Strip",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTS05J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTA01J",
+      "productName": "Turkey Tendon Rice Stick",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTA01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTA02J",
+      "productName": "Turkey Tendon Chicken Stick",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTA02J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTA03J",
+      "productName": "Turkey Tendon Thin Stick",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTA03J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "TTA04J",
+      "productName": "Turkey Tendon Pumpkin Strip",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "TTA04J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 160,
+          "cartonsPerPallet": 12,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "box",
+            "units": 20
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GRB01AM",
+      "productName": "Gootoe - Veal Rib Bone, 85g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GRB01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 130,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "GRB01J",
+      "productName": "Gootoe - Veal Rib Bone, 85g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "GRB01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 130,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ART01AM",
+      "productName": "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ART01AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 130,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ART01J",
+      "productName": "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g",
+      "origin": null,
+      "standardFactory": "TW",
+      "lifecycle": "active",
+      "approvedOrderSkus": [
+        "ART01J"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 130,
+          "cartonsPerPallet": 21,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFAD053A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFAD053A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 110,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFBD053A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFBD053A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFBD015A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFBD015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 19,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFCD017A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFCD017A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 36,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 12,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFRD055A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFRD055A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 60,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 16,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFRD015A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFRD015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 50,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 14,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFSD013A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFSD013A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 16,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GFTD033A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GFTD033A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GFTD035A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GFTD035A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GFTD043A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GFTD043A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GFTD045A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GFTD045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GFTD061A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GFTD061A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 60,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 16,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GSDD023A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GSDD023A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 80,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GSDD033A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GSDD033A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 52,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VDFD011A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VDFD011A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GBRD027A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GBRD027A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 12,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1ABRD016A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1ABRD016A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 14,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFRD058A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFRD058A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 16,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFBD018A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFBD018A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFRD018A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFRD018A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 16,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFAD058A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFAD058A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD026A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GCRD026A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD041A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GCRD041A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 70,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 28,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD045A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GCRD045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GBRD041A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GBRD041A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GBRD045A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GBRD045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 47,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GQRD016A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GQRD016A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GCRD036A0",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GCRD036A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 40,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ATR01",
+      "productName": "",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "ATR01",
+        "7ATRD013AB"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD021",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD021"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD040",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD040"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD051",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD051"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD060",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD060"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD011",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD011"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD050",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD050"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD020",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD020"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD010",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD010"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD041",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD041"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EPD061",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EPD061"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD051",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD051"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD041",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD041"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD021",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD021"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD011",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD011"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD061",
+      "productName": "",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD061"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1HGCC015A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1HGCC015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1HGCC025A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1HGCC025A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1HGCC035A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1HGCC035A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1HGCC045A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1HGCC045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1HGRD015A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1HGRD015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRC015A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRC015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRC025A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRC025A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRC035A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRC035A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRC045A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRC045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRC055A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRC055A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRD015A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRD015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRD025A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRD025A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRD035A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRD035A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRD045A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRD045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1MGRD055A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1MGRD055A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            32.5,
+            23,
+            6.1
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AGHC015A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AGHC015A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            28.5,
+            19.65,
+            8.2
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AGHC025A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AGHC025A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            28.5,
+            19.65,
+            8.2
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AGHC035A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AGHC035A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            28.5,
+            19.65,
+            8.2
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AGHC045A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": "VN",
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AGHC045A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 100,
+          "cartonDimensionsCm": [
+            28.5,
+            19.65,
+            8.2
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 6,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD773A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AWDD773A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 43,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AWDD775A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AWDD775A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 48,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AXXD001A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AXXD001A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            58.42,
+            35.56,
+            35.56
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1AXXD002A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1AXXD002A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GLTD011A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GLTD011A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GXXD001A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GXXD001A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            48.26,
+            38.1,
+            27.94
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1GXXD002A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1GXXD002A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            48.26,
+            38.1,
+            27.94
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFPD010A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFPD010A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 16,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFPD018A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFPD018A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 16,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 20,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFPD050A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFPD050A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 17,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFPD058A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFPD058A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 12,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 16,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFRD010A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFRD010A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFSD010A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFSD010A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "1VFSD018A0",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "1VFSD018A0"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "ED011AM",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "ED011AM"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD010",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD010"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD010-3",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD010-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD020",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD020"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD020-3",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD020-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD040",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD040"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD040-3",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD040-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD050",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD050"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD050-3",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD050-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD060",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD060"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "productSku": "EZD060-3",
+      "productName": "",
+      "origin": null,
+      "standardFactory": null,
+      "lifecycle": "incomplete",
+      "approvedOrderSkus": [
+        "EZD060-3"
+      ],
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": null,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": null,
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    }
+  ],
+  "orderSkuAliases": [
+    {
+      "orderSku": "7ATRD013AB",
+      "canonicalProductSku": "ATR01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7ATSD010AB",
+      "canonicalProductSku": "TTS05AM-1",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7ATSD011AB",
+      "canonicalProductSku": "ATS01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": null,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7ATSD017AB",
+      "canonicalProductSku": "TTSL05",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7ATSD019AB",
+      "canonicalProductSku": "TTS05AM",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTBD013AB",
+      "canonicalProductSku": "GTB01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTBD017AB",
+      "canonicalProductSku": "GTBL01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 26,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 30,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTBD037AB",
+      "canonicalProductSku": "GTBL03",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTBD053AB",
+      "canonicalProductSku": "GTB05",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTBD057AB",
+      "canonicalProductSku": "GTBL05",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTPD013AB",
+      "canonicalProductSku": "GTP01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTPD017AB",
+      "canonicalProductSku": "GTPL01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTPD037AB",
+      "canonicalProductSku": "GTPL03",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTPD053AB",
+      "canonicalProductSku": "GTP05",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTPD057AB",
+      "canonicalProductSku": "GTPL05",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTRD013AB",
+      "canonicalProductSku": "GTR01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTRD017AB",
+      "canonicalProductSku": "GTRL01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 22,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTRD037AB",
+      "canonicalProductSku": "GTRL03",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTSD013AB",
+      "canonicalProductSku": "GTS01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7GTSD017AB",
+      "canonicalProductSku": "GTSL01",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTBD015AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 50,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 17,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTBD410AB",
+      "canonicalProductSku": "VTB01-4",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTRD015AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 50,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 17,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTRD215AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 25,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTSD013AB",
+      "canonicalProductSku": "VTS01-1",
+      "lifecycle": "approved",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTSD017AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTSD513AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    },
+    {
+      "orderSku": "7VTSD913AB",
+      "canonicalProductSku": null,
+      "lifecycle": "unmapped-legacy",
+      "packagingVersions": [
+        {
+          "version": "fba-2026-08-25",
+          "effectiveFrom": "2026-08-25",
+          "effectiveTo": null,
+          "unitsPerCarton": 10,
+          "cartonsPerPallet": null,
+          "cartonDimensionsCm": [
+            50.8,
+            40.64,
+            30.48
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/catalog/product-master-workbook.js
+++ b/catalog/product-master-workbook.js
@@ -1,0 +1,268 @@
+import { validateCatalog } from './product-catalog.js';
+
+export const PRODUCT_MASTER_SHEET = '產品主檔';
+export const PRODUCT_MASTER_TABLE = 'ProductMasterTable';
+export const PRODUCT_MASTER_HEADERS = Object.freeze([
+  'Product SKU', '品名', '實際產地', '標準下單廠別', '核准替代下單品號',
+  '包裝版本', '生效日期', '失效日期', '現行版本', '包裝模式',
+  '箱入數', '每包單位數', '每盒單位數', '箱／棧板',
+  '箱長(cm)', '箱寬(cm)', '箱高(cm)', '箱毛重(kg)', '箱毛重(lb)',
+  '產品狀態', '資料來源工作表', '來源列', '備註', '發布檢查',
+]);
+export const ORDER_SKU_PACKAGING_SHEET = '下單品號箱規';
+export const ORDER_SKU_PACKAGING_TABLE = 'OrderSkuPackagingTable';
+export const ORDER_SKU_PACKAGING_HEADERS = Object.freeze([
+  'Order SKU', '對應 Product SKU', 'Alias 狀態',
+  '包裝版本', '生效日期', '失效日期', '現行版本', '包裝模式',
+  '箱入數', '每包單位數', '每盒單位數', '箱／棧板',
+  '箱長(cm)', '箱寬(cm)', '箱高(cm)', '箱毛重(kg)', '箱毛重(lb)',
+  '資料來源工作表', '來源列', '備註', '發布檢查',
+]);
+
+const ORIGINS = new Map([
+  ['台灣', 'TW'], ['TW', 'TW'],
+  ['越南', 'VN'], ['VN', 'VN'],
+  ['柬埔寨', 'KH'], ['KH', 'KH'],
+  ['其他', 'OTHER'], ['OTHER', 'OTHER'],
+  ['待補', null],
+]);
+const FACTORIES = new Map([
+  ['台灣', 'TW'], ['TW', 'TW'],
+  ['越南', 'VN'], ['VN', 'VN'],
+  ['其他', 'OTHER'], ['OTHER', 'OTHER'],
+  ['待補', null],
+]);
+const LIFECYCLES = new Map([['正常', 'active'], ['資料待補', 'incomplete'], ['停產', 'retired']]);
+const ORDER_UNITS = new Map([['單品', 'single'], ['包裝', 'pack'], ['盒裝', 'box']]);
+const ORDER_SKU_ALIAS_LIFECYCLES = new Map([
+  ['核准', 'approved'], ['APPROVED', 'approved'],
+  ['未映射舊品號', 'unmapped-legacy'], ['UNMAPPED-LEGACY', 'unmapped-legacy'],
+]);
+
+function text(value) {
+  return value === null || value === undefined ? '' : String(value).trim();
+}
+
+function numberOrNull(value) {
+  if (value === null || value === undefined || text(value) === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : value;
+}
+
+function isoDate(value, path) {
+  if (value === null || value === undefined || text(value) === '') return null;
+  if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+    const year = String(value.getFullYear()).padStart(4, '0');
+    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const day = String(value.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(Math.round((value - 25569) * 86400) * 1000).toISOString().slice(0, 10);
+  }
+  const normalized = text(value).replaceAll('/', '-');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) throw new Error(`${path} must be a date`);
+  return normalized;
+}
+
+function mapped(value, mapping, path) {
+  const key = text(value).toUpperCase();
+  if (!mapping.has(key)) throw new Error(`${path} has unsupported value ${text(value) || '(blank)'}`);
+  return mapping.get(key);
+}
+
+function aliases(value) {
+  if (!text(value)) return [];
+  return text(value).split(/[;；]/).map(part => part.trim().toUpperCase()).filter(Boolean);
+}
+
+function stableProductFields(row, rowNumber) {
+  const productSku = text(row[0]).toUpperCase();
+  const productName = text(row[1]);
+  const origin = mapped(row[2], ORIGINS, `row ${rowNumber} origin`);
+  const standardFactory = mapped(row[3], FACTORIES, `row ${rowNumber} standard factory`);
+  const alternateOrderSkus = aliases(row[4]);
+  const lifecycle = mapped(row[19], LIFECYCLES, `row ${rowNumber} lifecycle`);
+  return { productSku, productName, origin, standardFactory, alternateOrderSkus, lifecycle };
+}
+
+function packagingFromRow(row, rowNumber) {
+  const current = text(row[8]);
+  if (current !== '是' && current !== '否') throw new Error(`row ${rowNumber} current version must be 是 or 否`);
+  const effectiveTo = isoDate(row[7], `row ${rowNumber} effective date end`);
+  if ((current === '是') !== (effectiveTo === null)) {
+    throw new Error(`row ${rowNumber} current version and effective date end disagree`);
+  }
+  const kind = mapped(row[9], ORDER_UNITS, `row ${rowNumber} order unit`);
+  const packUnits = numberOrNull(row[11]);
+  const boxUnits = numberOrNull(row[12]);
+  if (kind === 'pack' && boxUnits !== null) throw new Error(`row ${rowNumber} pack product must not set box units`);
+  if (kind === 'box' && packUnits !== null) throw new Error(`row ${rowNumber} box product must not set pack units`);
+  if (kind === 'single' && (packUnits !== null || boxUnits !== null)) {
+    throw new Error(`row ${rowNumber} single product must not set pack or box units`);
+  }
+
+  const cartonDimensionsCm = [numberOrNull(row[14]), numberOrNull(row[15]), numberOrNull(row[16])];
+  const packaging = {
+    version:text(row[5]),
+    effectiveFrom:isoDate(row[6], `row ${rowNumber} effective date start`),
+    effectiveTo,
+    unitsPerCarton:numberOrNull(row[10]),
+    cartonsPerPallet:numberOrNull(row[13]),
+    cartonDimensionsCm:cartonDimensionsCm.every(value => value === null) ? null : cartonDimensionsCm,
+    grossWeightKg:numberOrNull(row[17]),
+    grossWeightLb:numberOrNull(row[18]),
+    orderUnit:{
+      kind,
+      units:kind === 'pack' ? packUnits : kind === 'box' ? boxUnits : 1,
+    },
+  };
+  const sourceSheet = text(row[20]);
+  const sourceRow = numberOrNull(row[21]);
+  const initialSource = sourceSheet === '初始共用主檔' && sourceRow === null;
+  if (!initialSource && (sourceSheet || sourceRow !== null)) {
+    if (!sourceSheet || !Number.isInteger(sourceRow) || sourceRow <= 0) {
+      throw new Error(`row ${rowNumber} source sheet and source row must be provided together`);
+    }
+    packaging.source = { sheet:sourceSheet, row:sourceRow };
+  }
+  return packaging;
+}
+
+function stableSignature(fields) {
+  return JSON.stringify([
+    fields.productName,
+    fields.origin,
+    fields.standardFactory,
+    fields.alternateOrderSkus,
+    fields.lifecycle,
+  ]);
+}
+
+function orderSkuPackagingFromRow(row, rowNumber) {
+  const current = text(row[6]);
+  if (current !== '是' && current !== '否') throw new Error(`row ${rowNumber} current version must be 是 or 否`);
+  const effectiveTo = isoDate(row[5], `row ${rowNumber} effective date end`);
+  if ((current === '是') !== (effectiveTo === null)) {
+    throw new Error(`row ${rowNumber} current version and effective date end disagree`);
+  }
+  const kind = mapped(row[7], ORDER_UNITS, `row ${rowNumber} order unit`);
+  const packUnits = numberOrNull(row[9]);
+  const boxUnits = numberOrNull(row[10]);
+  if (kind === 'pack' && boxUnits !== null) throw new Error(`row ${rowNumber} pack product must not set box units`);
+  if (kind === 'box' && packUnits !== null) throw new Error(`row ${rowNumber} box product must not set pack units`);
+  if (kind === 'single' && (packUnits !== null || boxUnits !== null)) {
+    throw new Error(`row ${rowNumber} single product must not set pack or box units`);
+  }
+  const cartonDimensionsCm = [numberOrNull(row[12]), numberOrNull(row[13]), numberOrNull(row[14])];
+  const packaging = {
+    version:text(row[3]),
+    effectiveFrom:isoDate(row[4], `row ${rowNumber} effective date start`),
+    effectiveTo,
+    unitsPerCarton:numberOrNull(row[8]),
+    cartonsPerPallet:numberOrNull(row[11]),
+    cartonDimensionsCm:cartonDimensionsCm.every(value => value === null) ? null : cartonDimensionsCm,
+    grossWeightKg:numberOrNull(row[15]),
+    grossWeightLb:numberOrNull(row[16]),
+    orderUnit:{
+      kind,
+      units:kind === 'pack' ? packUnits : kind === 'box' ? boxUnits : 1,
+    },
+  };
+  const sourceSheet = text(row[17]);
+  const sourceRow = numberOrNull(row[18]);
+  const initialSource = sourceSheet === '初始共用主檔' && sourceRow === null;
+  if (!initialSource && (sourceSheet || sourceRow !== null)) {
+    if (!sourceSheet || !Number.isInteger(sourceRow) || sourceRow <= 0) {
+      throw new Error(`row ${rowNumber} source sheet and source row must be provided together`);
+    }
+    packaging.source = { sheet:sourceSheet, row:sourceRow };
+  }
+  return packaging;
+}
+
+function workbookMetadata(rows, sheetName) {
+  if (!Array.isArray(rows) || rows.length < 5) throw new Error(`${sheetName} does not contain its required rows`);
+  return {
+    schemaVersion:Number(rows[2]?.[1]),
+    catalogVersion:text(rows[2]?.[3]),
+  };
+}
+
+function orderSkuAliasesFromRows(rows, expectedMetadata) {
+  const metadata = workbookMetadata(rows, ORDER_SKU_PACKAGING_SHEET);
+  if (metadata.schemaVersion !== expectedMetadata.schemaVersion || metadata.catalogVersion !== expectedMetadata.catalogVersion) {
+    throw new Error(`${ORDER_SKU_PACKAGING_SHEET} metadata must match ${PRODUCT_MASTER_SHEET}`);
+  }
+  const headers = (rows[4] || []).map(text);
+  while (headers.at(-1) === '') headers.pop();
+  if (JSON.stringify(headers) !== JSON.stringify(ORDER_SKU_PACKAGING_HEADERS)) {
+    throw new Error(`${ORDER_SKU_PACKAGING_SHEET} row 5 headers do not match the release contract`);
+  }
+  const aliases = [];
+  const byOrderSku = new Map();
+  for (let index = 5; index < rows.length; index += 1) {
+    const row = rows[index] || [];
+    const rowNumber = index + 1;
+    if (row.slice(0, 19).every(value => text(value) === '')) continue;
+    const orderSku = text(row[0]).toUpperCase();
+    const canonicalProductSku = text(row[1]).toUpperCase() || null;
+    const lifecycle = mapped(row[2], ORDER_SKU_ALIAS_LIFECYCLES, `row ${rowNumber} alias lifecycle`);
+    if (!orderSku) throw new Error(`row ${rowNumber} is missing Order SKU`);
+    const stable = JSON.stringify([canonicalProductSku, lifecycle]);
+    let alias = byOrderSku.get(orderSku);
+    if (!alias) {
+      alias = { orderSku, canonicalProductSku, lifecycle, packagingVersions:[] };
+      Object.defineProperty(alias, '__stable', { value:stable });
+      byOrderSku.set(orderSku, alias);
+      aliases.push(alias);
+    } else if (alias.__stable !== stable) {
+      throw new Error(`row ${rowNumber} changes stable fields for Order SKU ${orderSku}`);
+    }
+    alias.packagingVersions.push(orderSkuPackagingFromRow(row, rowNumber));
+  }
+  return aliases;
+}
+
+export function catalogFromProductMasterRows(rows, orderSkuRows) {
+  const metadata = workbookMetadata(rows, PRODUCT_MASTER_SHEET);
+  const headers = (rows[4] || []).map(text);
+  while (headers.at(-1) === '') headers.pop();
+  if (JSON.stringify(headers) !== JSON.stringify(PRODUCT_MASTER_HEADERS)) {
+    throw new Error('產品主檔 row 5 headers do not match the release contract');
+  }
+  const { schemaVersion, catalogVersion } = metadata;
+  const products = [];
+  const bySku = new Map();
+
+  for (let index = 5; index < rows.length; index += 1) {
+    const row = rows[index] || [];
+    const rowNumber = index + 1;
+    if (row.slice(0, 22).every(value => text(value) === '')) continue;
+    const fields = stableProductFields(row, rowNumber);
+    if (!fields.productSku) throw new Error(`row ${rowNumber} is missing Product SKU`);
+    let product = bySku.get(fields.productSku);
+    if (!product) {
+      product = {
+        productSku:fields.productSku,
+        productName:fields.productName,
+        origin:fields.origin,
+        standardFactory:fields.standardFactory,
+        lifecycle:fields.lifecycle,
+        approvedOrderSkus:[fields.productSku, ...fields.alternateOrderSkus],
+        packagingVersions:[],
+      };
+      Object.defineProperty(product, '__stable', { value:stableSignature(fields) });
+      bySku.set(fields.productSku, product);
+      products.push(product);
+    } else if (product.__stable !== stableSignature(fields)) {
+      throw new Error(`row ${rowNumber} changes stable fields for Product SKU ${fields.productSku}`);
+    }
+    product.packagingVersions.push(packagingFromRow(row, rowNumber));
+  }
+
+  const orderSkuAliases = orderSkuAliasesFromRows(orderSkuRows, metadata);
+  const catalog = { schemaVersion, catalogVersion, products, orderSkuAliases };
+  validateCatalog(catalog);
+  return catalog;
+}

--- a/catalog/supply-catalog-adapter.js
+++ b/catalog/supply-catalog-adapter.js
@@ -1,0 +1,83 @@
+function publicProduct(product) {
+  const packaging = product.currentPackaging;
+  const orderUnit = packaging.orderUnit;
+  return {
+    productCode:product.productSku,
+    productName:product.productName,
+    boxSize:packaging.cartonDimensionsCm.join('*'),
+    perCarton:packaging.unitsPerCarton,
+    perPack:orderUnit.kind === 'pack' ? orderUnit.units : null,
+    perBox:orderUnit.kind === 'box' ? orderUnit.units : null,
+    perPallet:packaging.cartonsPerPallet,
+    country:product.standardFactory === 'TW' || product.standardFactory === 'VN'
+      ? product.standardFactory
+      : 'Others',
+  };
+}
+
+export const supplyCatalogAdapter = Object.freeze({
+  name:'supply',
+  project(snapshot) {
+    const equivalentSkuPairs = snapshot.products.flatMap(product => product.approvedOrderSkus
+      .filter(orderSku => orderSku !== product.productSku)
+      .map(orderSku => [product.productSku, orderSku]));
+    return {
+      meta:{ schemaVersion:snapshot.schemaVersion, catalogVersion:snapshot.catalogVersion },
+      equivalentSkuPairs,
+      products:snapshot.products
+        .filter(product => product.lifecycle !== 'retired'
+          && product.standardFactory !== null
+          && Number.isInteger(product.currentPackaging.cartonsPerPallet)
+          && product.currentPackaging.cartonsPerPallet > 0)
+        .map(publicProduct),
+    };
+  },
+});
+
+function json(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+export function renderSupplyProductData(projection) {
+  return `// Generated from catalog/product-catalog.json. Do not edit by hand.\n`+
+`window.SUPPLY_PRODUCT_CATALOG_META = Object.freeze(${json(projection.meta)});\n`+
+`window.SUPPLY_EQUIVALENT_SKU_PAIRS = Object.freeze(${json(projection.equivalentSkuPairs)}.map(pair => Object.freeze(pair)));\n`+
+`window.allProductsData = ${json(projection.products)};\n`+
+`\n`+
+`// Turkey / Non-Turkey classification remains synchronous for legacy callers.\n`+
+`(function () {\n`+
+`  function normalizeProductCode(value) {\n`+
+`    return String(value || "").trim().toUpperCase();\n`+
+`  }\n`+
+`\n`+
+`  function getProductByCode(productCode) {\n`+
+`    const key = normalizeProductCode(productCode);\n`+
+`    if (!key) return null;\n`+
+`    const list = Array.isArray(window.allProductsData) ? window.allProductsData : [];\n`+
+`    return list.find(function (item) {\n`+
+`      return normalizeProductCode(item && item.productCode) === key;\n`+
+`    }) || null;\n`+
+`  }\n`+
+`\n`+
+`  function isTurkeyName(productName) {\n`+
+`    return /turkey/i.test(String(productName || ""));\n`+
+`  }\n`+
+`\n`+
+`  function getTurkeyGroupByCode(productCode) {\n`+
+`    const product = getProductByCode(productCode);\n`+
+`    if (!product) return { group: "unknown", groupName: "未對應", product: null };\n`+
+`    const isTurkey = isTurkeyName(product.productName);\n`+
+`    return {\n`+
+`      group: isTurkey ? "turkey" : "non_turkey",\n`+
+`      groupName: isTurkey ? "火雞" : "非火雞",\n`+
+`      product: product\n`+
+`    };\n`+
+`  }\n`+
+`\n`+
+`  window.normalizeProductCode = window.normalizeProductCode || normalizeProductCode;\n`+
+`  window.getProductByCode = window.getProductByCode || getProductByCode;\n`+
+`  window.getTurkeyGroupByCode = getTurkeyGroupByCode;\n`+
+`  window.isTurkeyProduct = function (productCode) { return getTurkeyGroupByCode(productCode).group === "turkey"; };\n`+
+`  window.isNonTurkeyProduct = function (productCode) { return getTurkeyGroupByCode(productCode).group === "non_turkey"; };\n`+
+`})();\n`;
+}

--- a/docs/adr/0003-use-one-versioned-product-catalog.md
+++ b/docs/adr/0003-use-one-versioned-product-catalog.md
@@ -1,0 +1,11 @@
+# Use one versioned product catalog
+
+Supply and FBA will treat the same Excel workbook and its `ProductMasterTable` plus `OrderSkuPackagingTable` as the only manually maintained product source, validate them into one versioned canonical catalog, and fan out project-specific snapshots at build time. The canonical JSON and site-specific JavaScript are generated release artifacts, not additional manual sources. This keeps runtime callers synchronous and independent of network, cache, and cross-repository availability while making `schemaVersion` and `catalogVersion` explicit release contracts.
+
+## Consequences
+
+Packaging changes for one Product SKU are retained as dated versions with exactly one current version; overlapping versions are invalid. Country of origin and standard factory are separate facts, so an unknown origin remains `null` instead of being inferred from Supply's TW/VN order grouping, and a `7`-prefixed Order SKU is always routed as a Subcontract Order.
+
+Schema v2 keeps a `7`-prefixed Order SKU out of the Product SKU collection and models it as an Order SKU Alias. The alias owns only its versioned carton packaging; the canonical Product SKU continues to own demand, inventory, coverage, and Supply pallet planning. An approved alias must point to an existing Product SKU that explicitly approves it. A legacy alias with no confirmed owner is retained as `unmapped-legacy` with a `null` owner instead of being guessed or discarded.
+
+Only allowlisted public catalog fields may be released. Cost, supplier, inventory, credentials, and other operational data remain outside the canonical public artifact. Supply and FBA each own a small adapter that projects the validated catalog into their existing synchronous runtime interface; neither site fetches the other repository at runtime.

--- a/docs/product-catalog.md
+++ b/docs/product-catalog.md
@@ -1,0 +1,69 @@
+# 共用產品主檔規格
+
+Supply 與 FBA 使用同一份 Excel 的 `產品主檔` 與 `下單品號箱規` 工作表作為唯一人工維護來源。Canonical JSON、Supply 的 `product-data.js` 與 FBA 的 snapshot 都是生成檔，不得手動修改。
+
+## ProductMasterTable
+
+表頭固定在第 5 列；每一列代表一個 Product SKU 的一個包裝版本。
+
+| 欄位 | 用途 |
+| --- | --- |
+| Product SKU | 擁有需求、庫存、產品規格與 coverage 的品號 |
+| 品名 | Supply 顯示名稱 |
+| 實際產地 | 台灣、越南、柬埔寨、其他或待補 |
+| 標準下單廠別 | 台灣、越南、其他或待補；與實際產地分開 |
+| 核准替代下單品號 | 以分號分隔；7 字頭會歸入委外 |
+| 包裝版本 | Product SKU 內唯一的版本名稱 |
+| 生效日期／失效日期 | 包裝有效期間；現行版本的失效日期留白 |
+| 現行版本 | 是或否；每個 Product SKU 必須恰有一筆「是」 |
+| 包裝模式 | 單品、包裝或盒裝 |
+| 箱入數／每包單位數／每盒單位數 | Supply 與 FBA 的數量換算來源 |
+| 箱／棧板 | Supply 訂單與棧板計算來源 |
+| 箱長／箱寬／箱高 | 公分 |
+| 箱毛重 | 公斤與磅可同時保存 |
+| 產品狀態 | 正常、資料待補或停產 |
+| 資料來源工作表／來源列 | 初次轉換與衝突稽核證據 |
+| 備註／發布檢查 | 維護說明與公式檢查結果；只有 `⚠` 會阻止發布，未知產地與資料待補會誠實標示但不假造資料 |
+
+## OrderSkuPackagingTable
+
+`下單品號箱規` 表頭同樣固定在第 5 列；每列代表一個 7 字頭 Order SKU Alias 的一個包裝版本。箱入數、尺寸與重量只有在 Order SKU 層級真實不同時才放這裡；不會複製需求、庫存或 coverage。
+
+| 欄位 | 用途 |
+| --- | --- |
+| Order SKU | 必須是唯一、正規化的 7 字頭品號 |
+| 對應 Product SKU | `核准` 時必填且必須在產品主檔的核准清單；`未映射舊品號` 必須留白 |
+| Alias 狀態 | `核准` 或 `未映射舊品號` |
+| 包裝版本／日期／現行版本 | 與 Product SKU 相同的版本規則，必須恰有一筆現行版本 |
+| 箱入數／包裝模式／箱規／箱重 | FBA 依實際 Order SKU 出貨包裝讀取 |
+| 箱／棧板 | 可留白；Supply 棧板建議仍使用 Product SKU 現行包裝 |
+| 資料來源／備註／發布檢查 | 證據、未映射狀態與公式檢查 |
+
+## 不變條件
+
+- Product SKU、Order SKU 儲存前一律去除前後空白並轉成大寫。
+- Product SKU 不得以 `7` 開頭；7 字頭必須建模為 Order SKU Alias。
+- 一個 Order SKU 只能屬於一個 Product SKU。
+- Product SKU 本身是 Standard Order 可用的 Order SKU；核准替代品號不得建立第二份產品需求。
+- 非 7 字頭 Order SKU 依標準下單廠別歸入台灣或越南；7 字頭一律歸入委外。
+- 實際產地未知時保留為 `null`，不得由標準下單廠別推測。
+- 同一 Product SKU 的包裝有效期間不得重疊，且必須恰有一個現行版本。
+- 同一 Order SKU Alias 的包裝有效期間不得重疊，且必須恰有一個現行版本。
+- `approved` alias 的 owner 必須存在且明列該 Order SKU；`unmapped-legacy` alias 的 owner 必須是 `null`。
+- 正常產品必須有品名、標準下單廠別與完整 Supply 包裝資料；資料待補產品可先供具備足夠欄位的 FBA adapter 使用，但不會自動進入 Supply 訂單清單。
+- 任一重複、欄位不完整、版本重疊或 alias 衝突都會阻止生成；不得 first-row-wins、last-row-wins 或猜值。
+
+## 公開邊界
+
+公開 catalog 只允許 Product SKU、品名、產地、標準下單廠別、核准 Order SKU、包裝版本、箱規、箱重、棧板數與生命週期。成本、報價、供應商、聯絡方式、庫存、銷速、open orders、Order Draft、憑證與原始 Excel 檔不得進入 GitHub Pages artifact。
+
+## 發布流程
+
+1. 在 Excel 的 `ProductMasterTable` 維護產品包裝，並在 `OrderSkuPackagingTable` 維護 7 字頭專屬箱規；新增資料列時使用 Excel 表格列，發布檢查會以動態表格範圍計算。
+2. 執行 `npm run catalog:import -- --input <xlsx> --output catalog/product-catalog.json`。
+3. 確認兩張表的發布檢查都沒有 `⚠`，再檢查 old → new 差異與 catalog 測試；`可發布 · 產地待補` 與 `資料待補（僅 FBA）` 是允許發布的誠實狀態。
+4. 執行 `npm run catalog:build` 生成 Supply 的同步 legacy adapter。
+5. 在 FBA 專案執行 `npm run generate:catalog -- --source ../Supply/catalog/product-catalog.json`。
+6. 兩站各自完成測試、build、Pages 部署與 live catalogVersion/hash 驗證後，才可宣稱同步發布完成。
+
+兩個網站在 runtime 都使用各自已驗證的本地 snapshot，不會互相 fetch，因此其中一站暫時無法連線不會拖垮另一站。更新失敗時保留上一個已發布版本。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "node": ">=22"
   },
   "scripts": {
+    "catalog:build": "node scripts/compile-product-catalog.mjs",
+    "catalog:check": "node scripts/compile-product-catalog.mjs --check",
+    "catalog:import": "node scripts/compile-product-master-workbook.mjs",
     "check": "npm ci --ignore-scripts --no-audit --no-fund && npm run verify",
     "test": "node --test tests/*.test.mjs",
     "test:browser": "playwright test --config tests/browser/playwright.config.mjs",

--- a/product-data.js
+++ b/product-data.js
@@ -1,362 +1,3452 @@
-// 產品資料已獨立於 index.html，方便維護
+// Generated from catalog/product-catalog.json. Do not edit by hand.
+window.SUPPLY_PRODUCT_CATALOG_META = Object.freeze({
+  "schemaVersion": 2,
+  "catalogVersion": "2026-08-28.3"
+});
 window.SUPPLY_EQUIVALENT_SKU_PAIRS = Object.freeze([
-  ["TTS05AM-1", "7ATSD010AB"], ["TTS05AM", "7ATSD019AB"], ["TTSL05", "7ATSD017AB"],
-  ["ATR01", "7ATRD013AB"], ["ATS01", "7ATSD011AB"],
-  ["GTP01", "7GTPD013AB"], ["GTR01", "7GTRD013AB"], ["GTP05", "7GTPD053AB"],
-  ["GTB05", "7GTBD053AB"], ["GTS01", "7GTSD013AB"], ["GTB01", "7GTBD013AB"],
-  ["GTBL03", "7GTBD037AB"], ["GTRL01", "7GTRD017AB"], ["GTRL03", "7GTRD037AB"],
-  ["GTPL03", "7GTPD037AB"], ["GTSL01", "7GTSD017AB"], ["GTBL01", "7GTBD017AB"],
-  ["GTPL01", "7GTPD017AB"], ["GTPL05", "7GTPD057AB"], ["GTBL05", "7GTBD057AB"],
-  ["VTS01-1", "7VTSD013AB"], ["VTB01-4", "7VTBD410AB"]
+  [
+    "GTS01",
+    "7GTSD013AB"
+  ],
+  [
+    "GTR01",
+    "7GTRD013AB"
+  ],
+  [
+    "GTB01",
+    "7GTBD013AB"
+  ],
+  [
+    "GTP01",
+    "7GTPD013AB"
+  ],
+  [
+    "GTB05",
+    "7GTBD053AB"
+  ],
+  [
+    "GTP05",
+    "7GTPD053AB"
+  ],
+  [
+    "GTSL01",
+    "7GTSD017AB"
+  ],
+  [
+    "GTRL01",
+    "7GTRD017AB"
+  ],
+  [
+    "GTPL01",
+    "7GTPD017AB"
+  ],
+  [
+    "GTBL01",
+    "7GTBD017AB"
+  ],
+  [
+    "GTRL03",
+    "7GTRD037AB"
+  ],
+  [
+    "GTPL03",
+    "7GTPD037AB"
+  ],
+  [
+    "GTBL03",
+    "7GTBD037AB"
+  ],
+  [
+    "GTPL05",
+    "7GTPD057AB"
+  ],
+  [
+    "GTBL05",
+    "7GTBD057AB"
+  ],
+  [
+    "ATS01",
+    "7ATSD011AB"
+  ],
+  [
+    "TTS05AM",
+    "7ATSD019AB"
+  ],
+  [
+    "TTS05AM-1",
+    "7ATSD010AB"
+  ],
+  [
+    "TTSL05",
+    "7ATSD017AB"
+  ],
+  [
+    "VTS01-1",
+    "7VTSD013AB"
+  ],
+  [
+    "VTB01-4",
+    "7VTBD410AB"
+  ],
+  [
+    "ATR01",
+    "7ATRD013AB"
+  ]
 ].map(pair => Object.freeze(pair)));
-
 window.allProductsData = [
-  { productCode: "1GBRD019A0", productName: "Gootoe - Buffalo Bites Bone Shaped - 1.5lb (Pack of 3)", boxSize: "50*40*30", perCarton: 9, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GBRD029A0", productName: "Gootoe - Buffalo Bites Stick (Large) - 1.5lb (Pack of 3)", boxSize: "50*40*30", perCarton: 8, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD010A0", productName: "A freschi Air-Dried Dog Food-Turkey Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD170A0", productName: "A freschi Air-Dried Dog Food-Turkey & Salmon Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD073A0", productName: "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 1lb", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD075A0", productName: "A Freschi Air-dried Dog Food-Chicken & Salmon Recipe , 2.2lb", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD070A0", productName: "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD063A0", productName: "A Freschi  Air-dried Dog Food-Chicken Recipe , 1lb", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD065A0", productName: "A Freschi  Air-dried Dog Food-Chicken Recipe , 2.2lb", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD060A0", productName: "A Freschi  Air-dried Dog Food-Chicken Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD473A0", productName: "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 1lb", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD475A0", productName: "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 2.2lb", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD470A0", productName: "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD463A0", productName: "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 1lb", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD465A0", productName: "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 2.2lb", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1AWDD460A0", productName: "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 0.9oz", boxSize: "50*40*30", perCarton: 250, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VADD063A0", productName: "VITADAY - Air-Dried Dog Food - Chicken Recipe - Stomach Support Formula - 454g", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VADD073A0", productName: "VITADAY - Air-Dried Dog Food - Chicken & Mackerels Recipe - Joint Support Formula - 454g", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD017A0", productName: "Gootoe - Chicken Fillet Jerky - 1lb (Pack of 3)", boxSize: "50*40*30", perCarton: 9, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD027A0", productName: "Gootoe - Chicken Breast Jerky - 1lb (Pack of 3)", boxSize: "50*40*30", perCarton: 11, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD037A0", productName: "Gootoe - Chicken Chips - 1lb (Pack of 3)", boxSize: "50*40*30", perCarton: 9, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GQRD017A0", productName: "Gootoe - Soft Chicken Breast Strips - 1lb (Pack of 3)", boxSize: "50*40*30", perCarton: 10, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GQRD027A0", productName: "Gootoe - Soft Chicken Sticks - 1lb (Pack of 3)", boxSize: "50*40*30", perCarton: 11, perPack: 3, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GSDD011A0", productName: "GooToE Chicken Breast Wrapped Salmon Sticks , 6oz", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GSDD015A0", productName: "GooToE Chicken Breast Wrapped Salmon Sticks , 1.5lb", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD005A0", productName: "GooToE Chicken Breast Wrapped Sticks , 6oz", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD004A0", productName: "GooToE Chicken Breast Wrapped Sticks , 1.5lb", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1ABRD001A0", productName: "A Freschi  Buffalo Jerky Dog Treats , 4oz", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1ABRD002A0", productName: "A Freschi  Buffalo Jerky Dog Treats , 12oz", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1ABRD003A0", productName: "A Freschi  Buffalo Strips , 4oz", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1ABRD004A0", productName: "A Freschi  Buffalo Strips , 12oz", boxSize: "50*40*30", perCarton: 48, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD011A0", productName: "Healthy Moment - Functional Dog Treat - Skin & Coat Care - 150g", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD021A0", productName: "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - 150g", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD031A0", productName: "Healthy Moment - Functional Dog Treat-Joint Care - 150g", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD041A0", productName: "Healthy Moment - Functional Dog Treat - Eyes Care - 150g", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD051A0", productName: "Healthy Moment - Functional Dog Treat-Heart Health Care - 150g", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD017A0", productName: "Healthy Moment - Functional Dog Treat - Skin & Coat Care - Box", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD027A0", productName: "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - Box", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD037A0", productName: "Healthy Moment - Functional Dog Treat - Joint Care - Box", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD047A0", productName: "Healthy Moment - Functional Dog Treat - Eyes Care - Box", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "1MHTD057A0", productName: "Healthy Moment - Functional Dog Treat - Heart Health Care - Box", boxSize: "50*40*30", perCarton: 8, perPack: null, perBox: 6, perPallet: 42, country: "VN" },
-  { productCode: "AFA11AM", productName: "AFreschi-Classic Turkey Tendon Thin Stick (100g /pk)；AFK package (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA12AM", productName: "AFreschi-Classic Turkey Tendon Braided Stick(100g /pk)；AFK package (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA13AM", productName: "AFreschi-Classic Turkey Tendon Slice (100g /pk)；AFK package (100 units /CTN)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA14AM", productName: "AFreschi-Classic Turkey Tendon Flake(100g /pk)；AFK package (80 units /CTN)", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA21AM", productName: "AFreschi-Soft Turkey Tendon & Pumpkin strip (100g /pk)；AFK package (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA22AM", productName: "AFreschi-Soft Turkey Tendon Strip (100g /pk)；AFK package (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA31AM", productName: "AFreschi-Wrapped Turkey Tendon with Chicken Stick (100g /pk)；AFK package (100 units /CTN)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA32AM", productName: "AFreschi-Wrapped Turkey Tendon with Brown Rice Stick(100g /pk)；AFK package (100 units /CTN)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA25AM", productName: "AFreschi-Classic Turkey Tendon Coil-L(85g /pk)；AFK package (70 units /CTN)", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFA135AM", productName: "AFreschi-Classic Turkey Tendon Coil-S(85g /pk)；AFK package (70 units /CTN)", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTS01", productName: "Gootoe - Turkey Tendon Strip (85g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTR01", productName: "Gootoe - Turkey Tendon Ring_S(72g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTB01", productName: "Gootoe - Turkey Tendon Bone_S(72g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTP01", productName: "Gootoe - Turkey Tendon Rope_S(72g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTZ01", productName: "Gootoe - Turkey Tendon Pretzel_S(72g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTA01", productName: "Gootoe - Turkey Tendon Braid_S(90g x 120)", boxSize: "58.5*34.5*35", perCarton: 120, perPack: null, perBox: null, perPallet: 36, country: "VN" },
-  { productCode: "GTC01", productName: "Gootoe - Sliced Turkey Tendon (85g x 120)", boxSize: "58.5*34.5*35", perCarton: 120, perPack: null, perBox: null, perPallet: 36, country: "VN" },
-  { productCode: "GTR03", productName: "Gootoe - Turkey Tendon Ring_M(90g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTB03", productName: "Gootoe - Turkey Tendon Bone_M(90g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTP03", productName: "Gootoe - Turkey Tendon Rope_M(90g x 100)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTS03", productName: "Gootoe - Turkey Tendon Stick_M(90g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTZ03", productName: "Gootoe - Turkey Tendon Pretzel_M(90g x 120)", boxSize: "58.5*34.5*35", perCarton: 120, perPack: null, perBox: null, perPallet: 36, country: "VN" },
-  { productCode: "GTB05", productName: "Gootoe - Turkey Tendon Bone_L(100g x 100)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTP05", productName: "Gootoe - Turkey Tendon Rope_L(100g x 100)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTB07", productName: "Gootoe - Turkey tendon lolipop 15g x 5pcs (75g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSF01", productName: "Soft Turkey Tendon Strip with Pumpkin (85g x 150)", boxSize: "50*40*30", perCarton: 150, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSF02", productName: "Soft Turkey Tendon Strip (85g x 150)", boxSize: "50*40*30", perCarton: 150, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTSL01", productName: "Gootoe - Turkey Tendon Strip (454g x 30)", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTRL01", productName: "Gootoe - Turkey Tendon Ring_S (454g x 30)", boxSize: "50*40*30", perCarton: 22, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTPL01", productName: "Gootoe - Turkey Tendon Rope_S (454g x 30)", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTBL01", productName: "Gootoe - Turkey Tendon Bone_S (454g x 30)", boxSize: "50*40*30", perCarton: 26, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTAL01", productName: "Gootoe - Turkey Tendon Braid_S (454g x 38)", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTCL01", productName: "Gootoe - Turkey Tendon Sliced (454g x 30)", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTRL03", productName: "Gootoe - Turkey Tendon Ring_M (454g x 30)", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTPL03", productName: "Gootoe - Turkey Tendon Rope_M (454g x 30)", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTBL03", productName: "Gootoe - Turkey Tendon Bone_M (454g x 30)", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTZL03", productName: "Gootoe - Turkey Tendon Pretzel_M (454g x 30)", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 30, country: "VN" },
-  { productCode: "GTPL05", productName: "Gootoe - Turkey Tendon Rope_L (454g x 30)", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTBL05", productName: "Gootoe - Turkey Tendon Bone_L(454g x 30)", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSFL01", productName: "Soft Turkey Tendon Strip with Pumpkin (454g x 38)", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSFL02", productName: "Soft Turkey Tendon Strip (454g x 38)", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATS01", productName: "Natural Turkey Tendon Strip (100g)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATB01", productName: "Afreschi srl - Natural Turkey Tendon Bone_S(72g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATR01AM", productName: "Afreschi srl - Natural Turkey Tendon Ring_S(72g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATP01", productName: "Afreschi srl - Natural Turkey Tendon Rope_S(72g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATZ01", productName: "Afreschi srl - Natural Turkey Tendon Pretzel_S(72g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATA01", productName: "Afreschi srl - Natural Turkey Tendon Braid(90g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATB03", productName: "Afreschi srl - Natural Turkey Tendon Bone_M(90g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATR03", productName: "Afreschi srl - Natural Turkey Tendon Ring_M(90g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATP03", productName: "Afreschi srl - Natural Turkey Tendon Rope_M(90g)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATZ03", productName: "Afreschi srl - Natural Turkey Tendon Pretzel_M(90g)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATB05", productName: "Afreschi srl - Natural Turkey Tendon Bone_L(100g)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATP05", productName: "Afreschi srl- Natural Turkey Tendon Rope_L(100g)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATAL01", productName: "Afreschi Natural Turkey Tendon Braid 8oz (GTA01:227g x 42)", boxSize: "50*40*30", perCarton: 42, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTB01AM", productName: "Natural Turkey Tendon Bone_S (40 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 40, perPallet: 36, country: "VN" },
-  { productCode: "TRP01AM", productName: "Natural Turkey Tendon Rope_S (40 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 40, perPallet: 36, country: "VN" },
-  { productCode: "TTR01AM", productName: "Natural Turkey Tendon Ring_S (40 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 40, perPallet: 36, country: "VN" },
-  { productCode: "TPZ01AM", productName: "Natural Turkey Tendon Pretzel_S (40 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 40, perPallet: 36, country: "VN" },
-  { productCode: "KTB03AM", productName: "Natural Turkey Tendon Bone_M (20 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 20, perPallet: 36, country: "VN" },
-  { productCode: "TRP03AM", productName: "Natural Turkey Tendon Rope_M (20 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 20, perPallet: 36, country: "VN" },
-  { productCode: "TTR03AM", productName: "Natural Turkey Tendon Ring_M (20 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 20, perPallet: 36, country: "VN" },
-  { productCode: "TPZ03AM", productName: "Natural Turkey Tendon Pretzel-M (20 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 20, perPallet: 36, country: "VN" },
-  { productCode: "TRP05AM", productName: "Natural Turkey Tendon Rope_L (10 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 10, perPallet: 36, country: "VN" },
-  { productCode: "KTB05AM", productName: "Natural Turkey Tendon Bone_L (10 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 10, perPallet: 36, country: "VN" },
-  { productCode: "TTR05AM", productName: "Natural Turkey Tendon Ring_L (10 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 10, perPallet: 36, country: "VN" },
-  { productCode: "TPZ05AM", productName: "Natural Turkey Tendon Pretzel_L (10 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 10, perPallet: 36, country: "VN" },
-  { productCode: "TTS05AM", productName: "Natural Turkey Tendon Strip (10 units /box ; 8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 10, perPallet: 36, country: "VN" },
-  { productCode: "KTB06AM", productName: "Natural Turkey Tendon Lollipop (40 units；8 boxes /CTN)", boxSize: "58.5*34.5*35", perCarton: 8, perPack: null, perBox: 40, perPallet: 36, country: "VN" },
-  { productCode: "KTB01AM-4", productName: "Natural Turkey Tendon Bone_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTR01AM-4", productName: "Natural Turkey Tendon Ring_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRP01AM-4", productName: "Natural Turkey Tendon Rope_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZ01AM-4", productName: "Natural Turkey Tendon Pretzel_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTB03AM-2", productName: "Natural Turkey Tendon Bone_M (80 units /CTN)", boxSize: "50*40*30", perCarton: 80, perPack: 2, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRP03AM-2", productName: "Natural Turkey Tendon Rope_M (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 2, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTR03AM-2", productName: "Natural Turkey Tendon Ring_M (80 units /CTN)", boxSize: "50*40*30", perCarton: 80, perPack: 2, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZ03AM-2", productName: "Natural Turkey Tendon Pretzel_M (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 2, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTB05AM-1", productName: "Natural Turkey Tendon Bone_L (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRP05AM-1", productName: "Natural Turkey Tendon Rope_L (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTR05AM-1", productName: "Natural Turkey Tendon Ring_L (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZ05AM-1", productName: "Natural Turkey Tendon Pretzel_L (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTS05AM-1", productName: "Natural Turkey Tendon Strip (100 units /CTN)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTB06AM-4", productName: "Natural Turkey Tendon Lollipop (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTBL01", productName: "Afreschi Natural Turkey Tendon Bone 8oz_S-15g (227g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTRL01", productName: "Afreschi Natural Turkey Tendon Ring 8oz_S-12g (227g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZL01", productName: "Afreschi Natural Turkey Tendon Pretzel 8oz_S-12g (227g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRPL01", productName: "Afreschi Natural Turkey Tendon Rope 8oz_S-12g (227g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTBL03", productName: "Afreschi Natural Turkey Tendon Bone 10oz_M-36g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTRL03", productName: "Afreschi Natural Turkey Tendon Ring 10oz_M-36g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZL03", productName: "Afreschi Natural Turkey Tendon Pretzel 10oz_M-36g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRPL03", productName: "Afreschi Natural Turkey Tendon Rope 10oz_M-36g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTRL05", productName: "Afreschi Natural Turkey Tendon Ring 10oz_L-72g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TRPL05", productName: "Afreschi Natural Turkey Tendon Rope 10oz_L-72g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TPZL05", productName: "Afreschi Natural Turkey Tendon Pretzel 10oz_L-72g (285g x 36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "KTBL05", productName: "Afreschi Natural Turkey Tendon Bone 10oz_L-72g (285g x 30)", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "TTSL05", productName: "Afreschi Natural Turkey Tendon Strip 10oz (285g x 30)", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFML01", productName: "AFreschi Turkey Tendon Variety Pack 8oz_Small (227gx36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFML03", productName: "AFreschi Turkey Tendon Variety Pack 10oz_Medium (285gx36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AFML05", productName: "AFreschi Turkey Tendon Variety Pack 10oz_Large (285gx36)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASF01", productName: "A Freschi Srl – Natural Turkey Treats Soft Sticks (170g x 100)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ABM01", productName: "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (170g x 110)", boxSize: "50*40*30", perCarton: 110, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATN01", productName: "A Freschi Srl – Natural Turkey Treats Star Bites (170g x 80)", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASA01", productName: "A Freschi Srl – Natural Turkey Treats Mini Bars (170g x 80)", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ADT03", productName: "Natural Dental Treats-Real Turkey Meat (1kg x20 units /CTN)", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATJ01", productName: "Afreschi - Natural Turkey Jerky 4oz (113gx110)", boxSize: "50*40*30", perCarton: 110, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GTT01", productName: "Gootoe Turkey Tendon Twists 5oz_Small (142g*120)", boxSize: "58.5*34.5*35", perCarton: 120, perPack: null, perBox: null, perPallet: 36, country: "VN" },
-  { productCode: "GTT03", productName: "Gootoe Turkey Tendon Twists 5oz_Medium (142g*120)", boxSize: "58.5*34.5*35", perCarton: 120, perPack: null, perBox: null, perPallet: 36, country: "VN" },
-  { productCode: "ASFL01", productName: "A Freschi Srl – Natural Turkey Treats Soft Sticks (454g)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ABML01", productName: "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (454g)", boxSize: "50*40*30", perCarton: 42, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATNL01", productName: "A Freschi Srl – Natural Turkey Treats Star Bites (454g)", boxSize: "50*40*30", perCarton: 42, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASAL01", productName: "A Freschi Srl – Natural Turkey Treats Mini Bars (454g)", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATJL01", productName: "A Freschi Srl – Natural Turkey Jerky (12oz-340g)", boxSize: "50*40*30", perCarton: 42, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCBL01", productName: "Gootoe - Chicken Fillet Jerky 454gx30", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCBL02", productName: "Gootoe - Chicken Jerky Breast 454gx36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCBL03", productName: "Gootoe - Chicken Chips 454gx28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSCL01", productName: "Gootoe - Soft Chicken Breast Strips 454gx36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSCL02", productName: "Gootoe - Soft Chicken Sticks 454gx36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSCL03", productName: "Gootoe - Soft Chicken Dental Chews with Chlorophyll, 1.5lb (681gx28)", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSCL04", productName: "Gootoe - Soft Chicken Knots 454gx30", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GSCL05", productName: "Gootoe - Soft Chicken Jerky Cuts 454gx36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL01", productName: "Gootoe - Chicken Sticks 1.5lb-681gx28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL02", productName: "Gootoe - Chicken Sticks With Chicken Liver 1.5lb-681gx28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL03", productName: "Gootoe - Chicken Sticks With Sweet Potato 1.5lb-681gx28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL04", productName: "Gootoe - Chicken Mini Sticks 1.5lb-681gx22", boxSize: "50*40*30", perCarton: 22, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL05", productName: "Gootoe - Chicken Roll 12oz-340gx24", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GCTL06", productName: "Gootoe - Chicken Dipped Sticks 1.5lb-681gx28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBS01", productName: "Gootoe - Buffalo Bites Stick _S (70units /CTN)", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBS03", productName: "Gootoe - Buffalo Bites Stick _L (70 units /CTN)", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBB01", productName: "Gootoe - Buffalo Bites Bone Shaped (60 units /CTN)", boxSize: "50*40*30", perCarton: 60, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBSL01", productName: "Gootoe - Buffalo Bites Stick (small) (S) 1.5lb-681g", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBSL03", productName: "Gootoe - Buffalo Bites Stick (Large) (L) 1.5lb-681g", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "GBBL01", productName: "Gootoe - Buffalo Bites Bone Shaped 1.5lb-681g", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AWD010", productName: "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-454g", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AWD011", productName: "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-1kg", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AWD070", productName: "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-454g", boxSize: "50*40*30", perCarton: 38, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "AWD071", productName: "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-1kg", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VTS01-1", productName: "Turkey Tendon Strip (100 units /CTN)", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VTB01-4", productName: "Turkey Tendon Bone_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VTR01-4", productName: "Turkey Tendon Ring_S (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VTB05-1", productName: "Turkey Tendon Bone_L (120 units /CTN)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VTB06-4", productName: "Turkey Tendon Lollipop (90 units /CTN)", boxSize: "50*40*30", perCarton: 90, perPack: 4, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "HDR01AM", productName: "Herz_ Turkey Tendon_Duo-Protein_Ring (S) (85g)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "HDP01AM", productName: "Herz_ Turkey Tendon_Duo-Protein_Rope(S)(85g)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "HDS03AM", productName: "Herz_ Turkey Tendon_Duo-Protein_Strip(85g)", boxSize: "50*40*30", perCarton: 120, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACBL01", productName: "AFreschi - Natural Chicken Fillet Jerky 454g*30", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACBL02", productName: "AFreschi - Natural Chicken Breast Jerky 454g*36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACBL03", productName: "AFreschi - Natural Chicken Chips 454g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASCL01", productName: "AFreschi - Natural Soft Chicken Breast Strips 454g*36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASCL02", productName: "AFreschi - Natural Soft Chicken Sticks 454g*36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASCL03", productName: "AFreschi - Natural Soft Chicken Dental Chews with Chlorophyll 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASCL04", productName: "AFreschi - Natural Soft Chicken Knots 454g*30", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ASCL05", productName: "AFreschi - Natural Soft Chicken Jerky Cuts 454g*36", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL01", productName: "AFreschi - Natural Chicken Sticks 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL02", productName: "AFreschi - Natural Chicken Sticks with Chicken Liver 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL03", productName: "AFreschi - Natural Chicken Sticks with Sweet Potato 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL04", productName: "AFreschi - Natural Chicken Sticks (Mini) 681g*22", boxSize: "50*40*30", perCarton: 22, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL05", productName: "AFreschi - Natural Chicken Roll 340g*24", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL06", productName: "AFreschi - Natural Chicken Dipped Sticks 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL07", productName: "AFreschi - Natural Chicken Dipped Rice Sticks 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL08", productName: "AFreschi - Natural Chicken Sliced 681g*24", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL09", productName: "AFreschi - Natural Chicken Dipped Rice Bone 454g*28", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACTL10", productName: "AFreschi - Natural Chicken Sticks with Pumpkin 681g*28", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACA01", productName: "Afreschi - Natural Cat Treats (Chicken & Mackerel) -6oz-170gx100", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACA02", productName: "Afreschi - Natural Cat Treats (Buffalo& Chicken & Fish) -6oz-170gx100", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ACA03", productName: "Afreschi - Natural Cat Treats (Turkey & Chicken & Mackerel) -6oz-170gx100", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VBS01", productName: "Vitaday - Buffalo Treats Stick (Small) 227g*70", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VBS03", productName: "Vitaday - Buffalo Treats Stick (Medium) 227g*70", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VBB01", productName: "Vitaday - Buffalo Treats Bone Shaped 227g*60", boxSize: "50*40*30", perCarton: 60, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "VBW01", productName: "Vitaday - Buffalo Treats W Shaped 227g*80", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "EZD011AM", productName: "Herz Grain-Free U.S.A. Turkey Breast Recipe (908g/Pk)", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD021AM", productName: "Herz Grain-Free Australian Lamb Recipe (908g/Pk)", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD041AM", productName: "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (908g/Pk)", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD051AM", productName: "Herz Grain-Free New Zealand Venison Recipe (908g/Pk)", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD061AM", productName: "Herz Grain-Free U.S.A. Chicken Recipe (908g/Pk)", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD010AM", productName: "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 100, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD020AM", productName: "Herz Grain-Free Australian Lamb Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 100, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD040AM", productName: "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 100, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD050AM", productName: "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 100, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD060AM", productName: "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 100, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD010AM-3", productName: "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 90, perPack: 3, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD020AM-3", productName: "Herz Grain-Free Australian Lamb Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 90, perPack: 3, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD040AM-3", productName: "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 90, perPack: 3, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD050AM-3", productName: "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 90, perPack: 3, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD060AM-3", productName: "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)", boxSize: "48*38*28", perCarton: 90, perPack: 3, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD011J", productName: "Herz Premium Canine Cuisine – Turkey with Duck Liver Recipe, 1kg", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD021J", productName: "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-1kg", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD041J", productName: "Premium Canine Cuisine-Beef with Duck Liver Ricipe-1kg", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD061J", productName: "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-1kg", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD010J", productName: "Premium Canine Cuisine – Turkey with Duck Liver Recipe-454g", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD020J", productName: "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-454g", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD040J", productName: "Premium Canine Cuisine-Beef with Duck Liver Ricipe-454g", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "EPD060J", productName: "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-454g", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "GTSL01J", productName: "Gootoe - Turkey Tendon Strip", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTRL05J", productName: "Gootoe - Turkey Tendon Ring_L", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTPL05J", productName: "Gootoe - Turkey Tendon Rope_L", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTBL05J", productName: "Gootoe - Turkey Tendon Bone_L", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTRL01J", productName: "Gootoe - Turkey Tendon Ring_S", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTPL01J", productName: "Gootoe - Turkey Tendon Rope_S", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTBL01J", productName: "Gootoe - Turkey Tendon Bone_S", boxSize: "58.5*34.5*35", perCarton: 24, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GSF01J", productName: "Gootoe -Turkey Tendon Pumpkin Strip", boxSize: "58.5*34.5*35", perCarton: 150, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTR01J", productName: "Gootoe - Turkey Tendon Ring_S", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTR03J", productName: "Gootoe - Turkey Tendon Ring_M", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTB01J", productName: "Gootoe - Turkey Tendon Bone_S", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTB03J", productName: "Gootoe - Turkey Tendon Bone_M", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTB05J", productName: "Gootoe - Turkey Tendon Bone_L", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTP01J", productName: "Gootoe - Turkey Tendon Rope_S", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTP03J", productName: "Gootoe - Turkey Tendon Rope _M", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTP05J", productName: "Gootoe - Turkey Tendon Rope _L", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTS01J", productName: "Gootoe - Turkey Tendon Strip", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTS03J", productName: "Gootoe - Turkey Tendon Stick_M", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTZ01J", productName: "Gootoe - Turkey Tendon Pretzel_S", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTZ03J", productName: "Gootoe - Turkey Tendon Pretzel_M", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "GTA01J", productName: "Gootoe - Turkey Tendon Braid", boxSize: "58.5*34.5*35", perCarton: 100, perPack: null, perBox: null, perPallet: 12, country: "TW" },
-  { productCode: "KTB01J", productName: "Natural Turkey Tendon Bone_S", boxSize: "58.5*34.5*35", perCarton: 320, perPack: null, perBox: 40, perPallet: 12, country: "TW" },
-  { productCode: "KTB03J", productName: "Natural Turkey Tendon Bone_ M", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "KTB05J", productName: "Natural Turkey Tendon Bone_L", boxSize: "58.5*34.5*35", perCarton: 80, perPack: null, perBox: 10, perPallet: 12, country: "TW" },
-  { productCode: "KTB06J", productName: "Natural Turkey Tendon Lollipop", boxSize: "58.5*34.5*35", perCarton: 320, perPack: null, perBox: 40, perPallet: 12, country: "TW" },
-  { productCode: "TTR01J", productName: "Natural Turkey Tendon Ring_ S", boxSize: "58.5*34.5*35", perCarton: 320, perPack: null, perBox: 40, perPallet: 12, country: "TW" },
-  { productCode: "TTR03J", productName: "Natural Turkey Tendon Ring_ M", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "TTR05J", productName: "Natural Turkey Tendon Ring_ L", boxSize: "58.5*34.5*35", perCarton: 80, perPack: null, perBox: 10, perPallet: 12, country: "TW" },
-  { productCode: "TRP01J", productName: "Natural Turkey Tendon Rope_ S", boxSize: "58.5*34.5*35", perCarton: 320, perPack: null, perBox: 40, perPallet: 12, country: "TW" },
-  { productCode: "TRP03J", productName: "Natural Turkey Tendon Rope_ M", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "TRP05J", productName: "Natural Turkey Tendon Rope_ L", boxSize: "58.5*34.5*35", perCarton: 80, perPack: null, perBox: 10, perPallet: 12, country: "TW" },
-  { productCode: "TTS05J", productName: "Natural Turkey Tendon Strip", boxSize: "58.5*34.5*35", perCarton: 80, perPack: null, perBox: 10, perPallet: 12, country: "TW" },
-  { productCode: "TTA01J", productName: "Turkey Tendon Rice Stick", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "TTA02J", productName: "Turkey Tendon Chicken Stick", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "TTA03J", productName: "Turkey Tendon Thin Stick", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "TTA04J", productName: "Turkey Tendon Pumpkin Strip", boxSize: "58.5*34.5*35", perCarton: 160, perPack: null, perBox: 20, perPallet: 12, country: "TW" },
-  { productCode: "GRB01AM", productName: "Gootoe - Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "GRB01J", productName: "Gootoe - Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "ART01AM", productName: "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "ART01J", productName: "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g", boxSize: "48*38*28", perCarton: 130, perPack: null, perBox: null, perPallet: 21, country: "TW" },
-  { productCode: "1VFAD053A0", productName: "", boxSize: "50*40*30", perCarton: 110, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFBD053A0", productName: "", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFBD015A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFCD017A0", productName: "", boxSize: "50*40*30", perCarton: 36, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFRD055A0", productName: "", boxSize: "50*40*30", perCarton: 60, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFRD015A0", productName: "", boxSize: "50*40*30", perCarton: 50, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFSD013A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GFTD033A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GFTD035A0", productName: "", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GFTD043A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GFTD045A0", productName: "", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GFTD061A0", productName: "", boxSize: "50*40*30", perCarton: 60, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GSDD023A0", productName: "", boxSize: "50*40*30", perCarton: 80, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GSDD033A0", productName: "", boxSize: "50*40*30", perCarton: 90, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VDFD011A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GBRD027A0", productName: "", boxSize: "50*40*30", perCarton: 12, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1ABRD016A0", productName: "", boxSize: "50*40*30", perCarton: 14, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFRD058A0", productName: "", boxSize: "50*40*30", perCarton: 16, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFBD018A0", productName: "", boxSize: "50*40*30", perCarton: 20, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFRD018A0", productName: "", boxSize: "50*40*30", perCarton: 16, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1VFAD058A0", productName: "", boxSize: "50*40*30", perCarton: 24, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD026A0", productName: "", boxSize: "50*40*30", perCarton: 18, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD041A0", productName: "", boxSize: "50*40*30", perCarton: 70, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD045A0", productName: "", boxSize: "50*40*30", perCarton: 30, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GBRD041A0", productName: "", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GBRD045A0", productName: "", boxSize: "50*40*30", perCarton: 28, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GQRD016A0", productName: "", boxSize: "50*40*30", perCarton: 18, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "1GCRD036A0", productName: "", boxSize: "50*40*30", perCarton: 18, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "ATR01", productName: "", boxSize: "50*40*30", perCarton: 100, perPack: null, perBox: null, perPallet: 42, country: "VN" },
-  { productCode: "EPD021", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD040", productName: "", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD051", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD060", productName: "", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD011", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD050", productName: "", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD020", productName: "", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD010", productName: "", boxSize: "48*38*28", perCarton: 30, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD041", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EPD061", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD051", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD041", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD021", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD011", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "EZD061", productName: "", boxSize: "48*38*28", perCarton: 18, perPack: null, perBox: null, perPallet: 36, country: "TW" },
-  { productCode: "1HGCC015A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1HGCC025A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1HGCC035A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1HGCC045A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1HGRD015A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRC015A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRC025A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRC035A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRC045A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRC055A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRD015A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRD025A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRD035A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRD045A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1MGRD055A0", productName: "", boxSize: "32.5*23*6.1", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1AGHC015A0", productName: "", boxSize: "28.5*19.65*8.2", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1AGHC025A0", productName: "", boxSize: "28.5*19.65*8.2", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1AGHC035A0", productName: "", boxSize: "28.5*19.65*8.2", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" },
-  { productCode: "1AGHC045A0", productName: "", boxSize: "28.5*19.65*8.2", perCarton: 24, perPack: null, perBox: null, perPallet: 100, country: "VN" }
+  {
+    "productCode": "1GBRD019A0",
+    "productName": "Gootoe - Buffalo Bites Bone Shaped - 1.5lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 9,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GBRD029A0",
+    "productName": "Gootoe - Buffalo Bites Stick (Large) - 1.5lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD010A0",
+    "productName": "A freschi Air-Dried Dog Food-Turkey Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD170A0",
+    "productName": "A freschi Air-Dried Dog Food-Turkey & Salmon Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD073A0",
+    "productName": "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 1lb",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD075A0",
+    "productName": "A Freschi Air-dried Dog Food-Chicken & Salmon Recipe , 2.2lb",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD070A0",
+    "productName": "A Freschi  Air-dried Dog Food-Chicken & Salmon Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD063A0",
+    "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 1lb",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD065A0",
+    "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 2.2lb",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD060A0",
+    "productName": "A Freschi  Air-dried Dog Food-Chicken Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD473A0",
+    "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 1lb",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD475A0",
+    "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 2.2lb",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD470A0",
+    "productName": "A Freschi srl Air-dried Dog Food - Buffalo & Salmon Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD463A0",
+    "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 1lb",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD465A0",
+    "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 2.2lb",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD460A0",
+    "productName": "A Freschi srl  Air-dried Dog Food - Buffalo & Chicken Recipe , 0.9oz",
+    "boxSize": "50*40*30",
+    "perCarton": 250,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VADD063A0",
+    "productName": "VITADAY - Air-Dried Dog Food - Chicken Recipe - Stomach Support Formula - 454g",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VADD073A0",
+    "productName": "VITADAY - Air-Dried Dog Food - Chicken & Mackerels Recipe - Joint Support Formula - 454g",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD017A0",
+    "productName": "Gootoe - Chicken Fillet Jerky - 1lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 9,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD027A0",
+    "productName": "Gootoe - Chicken Breast Jerky - 1lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 11,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD037A0",
+    "productName": "Gootoe - Chicken Chips - 1lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 9,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GQRD017A0",
+    "productName": "Gootoe - Soft Chicken Breast Strips - 1lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 10,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GQRD027A0",
+    "productName": "Gootoe - Soft Chicken Sticks - 1lb (Pack of 3)",
+    "boxSize": "50*40*30",
+    "perCarton": 11,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GSDD011A0",
+    "productName": "GooToE Chicken Breast Wrapped Salmon Sticks , 6oz",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GSDD015A0",
+    "productName": "GooToE Chicken Breast Wrapped Salmon Sticks , 1.5lb",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD005A0",
+    "productName": "GooToE Chicken Breast Wrapped Sticks , 6oz",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD004A0",
+    "productName": "GooToE Chicken Breast Wrapped Sticks , 1.5lb",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1ABRD001A0",
+    "productName": "A Freschi  Buffalo Jerky Dog Treats , 4oz",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1ABRD002A0",
+    "productName": "A Freschi  Buffalo Jerky Dog Treats , 12oz",
+    "boxSize": "50*40*30",
+    "perCarton": 42,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1ABRD003A0",
+    "productName": "A Freschi  Buffalo Strips , 4oz",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1ABRD004A0",
+    "productName": "A Freschi  Buffalo Strips , 12oz",
+    "boxSize": "50*40*30",
+    "perCarton": 48,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD011A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Skin & Coat Care - 150g",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD021A0",
+    "productName": "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - 150g",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD031A0",
+    "productName": "Healthy Moment - Functional Dog Treat-Joint Care - 150g",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD041A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Eyes Care - 150g",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD051A0",
+    "productName": "Healthy Moment - Functional Dog Treat-Heart Health Care - 150g",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD017A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Skin & Coat Care - Box",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD027A0",
+    "productName": "Healthy Moment - Functional Dog Treat- Gastrointestinal Care - Box",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD037A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Joint Care - Box",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD047A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Eyes Care - Box",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MHTD057A0",
+    "productName": "Healthy Moment - Functional Dog Treat - Heart Health Care - Box",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 6,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA11AM",
+    "productName": "AFreschi-Classic Turkey Tendon Thin Stick (100g /pk)；AFK package (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA12AM",
+    "productName": "AFreschi-Classic Turkey Tendon Braided Stick(100g /pk)；AFK package (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA13AM",
+    "productName": "AFreschi-Classic Turkey Tendon Slice (100g /pk)；AFK package (100 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA14AM",
+    "productName": "AFreschi-Classic Turkey Tendon Flake(100g /pk)；AFK package (80 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA21AM",
+    "productName": "AFreschi-Soft Turkey Tendon & Pumpkin strip (100g /pk)；AFK package (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA22AM",
+    "productName": "AFreschi-Soft Turkey Tendon Strip (100g /pk)；AFK package (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA31AM",
+    "productName": "AFreschi-Wrapped Turkey Tendon with Chicken Stick (100g /pk)；AFK package (100 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA32AM",
+    "productName": "AFreschi-Wrapped Turkey Tendon with Brown Rice Stick(100g /pk)；AFK package (100 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA25AM",
+    "productName": "AFreschi-Classic Turkey Tendon Coil-L(85g /pk)；AFK package (70 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFA135AM",
+    "productName": "AFreschi-Classic Turkey Tendon Coil-S(85g /pk)；AFK package (70 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTS01",
+    "productName": "Gootoe - Turkey Tendon Strip (85g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTR01",
+    "productName": "Gootoe - Turkey Tendon Ring_S(72g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTB01",
+    "productName": "Gootoe - Turkey Tendon Bone_S(72g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTP01",
+    "productName": "Gootoe - Turkey Tendon Rope_S(72g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTZ01",
+    "productName": "Gootoe - Turkey Tendon Pretzel_S(72g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTA01",
+    "productName": "Gootoe - Turkey Tendon Braid_S(90g x 120)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTC01",
+    "productName": "Gootoe - Sliced Turkey Tendon (85g x 120)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTR03",
+    "productName": "Gootoe - Turkey Tendon Ring_M(90g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTB03",
+    "productName": "Gootoe - Turkey Tendon Bone_M(90g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTP03",
+    "productName": "Gootoe - Turkey Tendon Rope_M(90g x 100)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTS03",
+    "productName": "Gootoe - Turkey Tendon Stick_M(90g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTZ03",
+    "productName": "Gootoe - Turkey Tendon Pretzel_M(90g x 120)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTB05",
+    "productName": "Gootoe - Turkey Tendon Bone_L(100g x 100)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTP05",
+    "productName": "Gootoe - Turkey Tendon Rope_L(100g x 100)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTB07",
+    "productName": "Gootoe - Turkey tendon lolipop 15g x 5pcs (75g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSF01",
+    "productName": "Soft Turkey Tendon Strip with Pumpkin (85g x 150)",
+    "boxSize": "50*40*30",
+    "perCarton": 150,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSF02",
+    "productName": "Soft Turkey Tendon Strip (85g x 150)",
+    "boxSize": "50*40*30",
+    "perCarton": 150,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTSL01",
+    "productName": "Gootoe - Turkey Tendon Strip (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTRL01",
+    "productName": "Gootoe - Turkey Tendon Ring_S (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTPL01",
+    "productName": "Gootoe - Turkey Tendon Rope_S (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTBL01",
+    "productName": "Gootoe - Turkey Tendon Bone_S (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTAL01",
+    "productName": "Gootoe - Turkey Tendon Braid_S (454g x 38)",
+    "boxSize": "50*40*40",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTCL01",
+    "productName": "Gootoe - Turkey Tendon Sliced (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTRL03",
+    "productName": "Gootoe - Turkey Tendon Ring_M (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTPL03",
+    "productName": "Gootoe - Turkey Tendon Rope_M (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTBL03",
+    "productName": "Gootoe - Turkey Tendon Bone_M (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTZL03",
+    "productName": "Gootoe - Turkey Tendon Pretzel_M (454g x 30)",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTPL05",
+    "productName": "Gootoe - Turkey Tendon Rope_L (454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTBL05",
+    "productName": "Gootoe - Turkey Tendon Bone_L(454g x 30)",
+    "boxSize": "50*40*40",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSFL01",
+    "productName": "Soft Turkey Tendon Strip with Pumpkin (454g x 38)",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSFL02",
+    "productName": "Soft Turkey Tendon Strip (454g x 38)",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATS01",
+    "productName": "Natural Turkey Tendon Strip (100g)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATB01",
+    "productName": "Afreschi srl - Natural Turkey Tendon Bone_S(72g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATR01AM",
+    "productName": "Afreschi srl - Natural Turkey Tendon Ring_S(72g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATP01",
+    "productName": "Afreschi srl - Natural Turkey Tendon Rope_S(72g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATZ01",
+    "productName": "Afreschi srl - Natural Turkey Tendon Pretzel_S(72g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATA01",
+    "productName": "Afreschi srl - Natural Turkey Tendon Braid(90g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATB03",
+    "productName": "Afreschi srl - Natural Turkey Tendon Bone_M(90g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATR03",
+    "productName": "Afreschi srl - Natural Turkey Tendon Ring_M(90g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATP03",
+    "productName": "Afreschi srl - Natural Turkey Tendon Rope_M(90g)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATZ03",
+    "productName": "Afreschi srl - Natural Turkey Tendon Pretzel_M(90g)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATB05",
+    "productName": "Afreschi srl - Natural Turkey Tendon Bone_L(100g)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATP05",
+    "productName": "Afreschi srl- Natural Turkey Tendon Rope_L(100g)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATAL01",
+    "productName": "Afreschi Natural Turkey Tendon Braid 8oz (GTA01:227g x 42)",
+    "boxSize": "50*40*30",
+    "perCarton": 42,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB01AM",
+    "productName": "Natural Turkey Tendon Bone_S (40 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP01AM",
+    "productName": "Natural Turkey Tendon Rope_S (40 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR01AM",
+    "productName": "Natural Turkey Tendon Ring_S (40 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ01AM",
+    "productName": "Natural Turkey Tendon Pretzel_S (40 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB03AM",
+    "productName": "Natural Turkey Tendon Bone_M (20 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP03AM",
+    "productName": "Natural Turkey Tendon Rope_M (20 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR03AM",
+    "productName": "Natural Turkey Tendon Ring_M (20 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ03AM",
+    "productName": "Natural Turkey Tendon Pretzel-M (20 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP05AM",
+    "productName": "Natural Turkey Tendon Rope_L (10 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB05AM",
+    "productName": "Natural Turkey Tendon Bone_L (10 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR05AM",
+    "productName": "Natural Turkey Tendon Ring_L (10 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ05AM",
+    "productName": "Natural Turkey Tendon Pretzel_L (10 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTS05AM",
+    "productName": "Natural Turkey Tendon Strip (10 units /box ; 8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB06AM",
+    "productName": "Natural Turkey Tendon Lollipop (40 units；8 boxes /CTN)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB01AM-4",
+    "productName": "Natural Turkey Tendon Bone_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR01AM-4",
+    "productName": "Natural Turkey Tendon Ring_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP01AM-4",
+    "productName": "Natural Turkey Tendon Rope_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ01AM-4",
+    "productName": "Natural Turkey Tendon Pretzel_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB03AM-2",
+    "productName": "Natural Turkey Tendon Bone_M (80 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": 2,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP03AM-2",
+    "productName": "Natural Turkey Tendon Rope_M (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 2,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR03AM-2",
+    "productName": "Natural Turkey Tendon Ring_M (80 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": 2,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ03AM-2",
+    "productName": "Natural Turkey Tendon Pretzel_M (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 2,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB05AM-1",
+    "productName": "Natural Turkey Tendon Bone_L (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRP05AM-1",
+    "productName": "Natural Turkey Tendon Rope_L (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTR05AM-1",
+    "productName": "Natural Turkey Tendon Ring_L (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZ05AM-1",
+    "productName": "Natural Turkey Tendon Pretzel_L (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTS05AM-1",
+    "productName": "Natural Turkey Tendon Strip (100 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTB06AM-4",
+    "productName": "Natural Turkey Tendon Lollipop (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTBL01",
+    "productName": "Afreschi Natural Turkey Tendon Bone 8oz_S-15g (227g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTRL01",
+    "productName": "Afreschi Natural Turkey Tendon Ring 8oz_S-12g (227g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZL01",
+    "productName": "Afreschi Natural Turkey Tendon Pretzel 8oz_S-12g (227g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRPL01",
+    "productName": "Afreschi Natural Turkey Tendon Rope 8oz_S-12g (227g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTBL03",
+    "productName": "Afreschi Natural Turkey Tendon Bone 10oz_M-36g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTRL03",
+    "productName": "Afreschi Natural Turkey Tendon Ring 10oz_M-36g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZL03",
+    "productName": "Afreschi Natural Turkey Tendon Pretzel 10oz_M-36g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRPL03",
+    "productName": "Afreschi Natural Turkey Tendon Rope 10oz_M-36g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTRL05",
+    "productName": "Afreschi Natural Turkey Tendon Ring 10oz_L-72g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TRPL05",
+    "productName": "Afreschi Natural Turkey Tendon Rope 10oz_L-72g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TPZL05",
+    "productName": "Afreschi Natural Turkey Tendon Pretzel 10oz_L-72g (285g x 36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "KTBL05",
+    "productName": "Afreschi Natural Turkey Tendon Bone 10oz_L-72g (285g x 30)",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "TTSL05",
+    "productName": "Afreschi Natural Turkey Tendon Strip 10oz (285g x 30)",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFML01",
+    "productName": "AFreschi Turkey Tendon Variety Pack 8oz_Small (227gx36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFML03",
+    "productName": "AFreschi Turkey Tendon Variety Pack 10oz_Medium (285gx36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AFML05",
+    "productName": "AFreschi Turkey Tendon Variety Pack 10oz_Large (285gx36)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASF01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Soft Sticks (170g x 100)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ABM01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (170g x 110)",
+    "boxSize": "50*40*30",
+    "perCarton": 110,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATN01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Star Bites (170g x 80)",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASA01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Mini Bars (170g x 80)",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ADT03",
+    "productName": "Natural Dental Treats-Real Turkey Meat (1kg x20 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATJ01",
+    "productName": "Afreschi - Natural Turkey Jerky 4oz (113gx110)",
+    "boxSize": "50*40*30",
+    "perCarton": 110,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTT01",
+    "productName": "Gootoe Turkey Tendon Twists 5oz_Small (142g*120)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "GTT03",
+    "productName": "Gootoe Turkey Tendon Twists 5oz_Medium (142g*120)",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASFL01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Soft Sticks (454g)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ABML01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Sticks_β-Carotene added (454g)",
+    "boxSize": "50*40*30",
+    "perCarton": 42,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATNL01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Star Bites (454g)",
+    "boxSize": "50*40*30",
+    "perCarton": 42,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASAL01",
+    "productName": "A Freschi Srl – Natural Turkey Treats Mini Bars (454g)",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATJL01",
+    "productName": "A Freschi Srl – Natural Turkey Jerky (12oz-340g)",
+    "boxSize": "50*40*30",
+    "perCarton": 42,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCBL01",
+    "productName": "Gootoe - Chicken Fillet Jerky 454gx30",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCBL02",
+    "productName": "Gootoe - Chicken Jerky Breast 454gx36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCBL03",
+    "productName": "Gootoe - Chicken Chips 454gx28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSCL01",
+    "productName": "Gootoe - Soft Chicken Breast Strips 454gx36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSCL02",
+    "productName": "Gootoe - Soft Chicken Sticks 454gx36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSCL03",
+    "productName": "Gootoe - Soft Chicken Dental Chews with Chlorophyll, 1.5lb (681gx28)",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSCL04",
+    "productName": "Gootoe - Soft Chicken Knots 454gx30",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GSCL05",
+    "productName": "Gootoe - Soft Chicken Jerky Cuts 454gx36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL01",
+    "productName": "Gootoe - Chicken Sticks 1.5lb-681gx28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL02",
+    "productName": "Gootoe - Chicken Sticks With Chicken Liver 1.5lb-681gx28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL03",
+    "productName": "Gootoe - Chicken Sticks With Sweet Potato 1.5lb-681gx28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL04",
+    "productName": "Gootoe - Chicken Mini Sticks 1.5lb-681gx22",
+    "boxSize": "50*40*30",
+    "perCarton": 22,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL05",
+    "productName": "Gootoe - Chicken Roll 12oz-340gx24",
+    "boxSize": "50*40*30",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GCTL06",
+    "productName": "Gootoe - Chicken Dipped Sticks 1.5lb-681gx28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBS01",
+    "productName": "Gootoe - Buffalo Bites Stick _S (70units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBS03",
+    "productName": "Gootoe - Buffalo Bites Stick _L (70 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBB01",
+    "productName": "Gootoe - Buffalo Bites Bone Shaped (60 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 60,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBSL01",
+    "productName": "Gootoe - Buffalo Bites Stick (small) (S) 1.5lb-681g",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBSL03",
+    "productName": "Gootoe - Buffalo Bites Stick (Large) (L) 1.5lb-681g",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "GBBL01",
+    "productName": "Gootoe - Buffalo Bites Bone Shaped 1.5lb-681g",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AWD010",
+    "productName": "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-454g",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AWD011",
+    "productName": "AFreschi Air-Dried Dog Food - USA Turkey Recipe(W-shaped)-1kg",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AWD070",
+    "productName": "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-454g",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "AWD071",
+    "productName": "AFreschi Air - Dried Dog Food - Turkey & Salmon Recipe(W-shaped)-1kg",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VTS01-1",
+    "productName": "Turkey Tendon Strip (100 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VTB01-4",
+    "productName": "Turkey Tendon Bone_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VTR01-4",
+    "productName": "Turkey Tendon Ring_S (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VTB05-1",
+    "productName": "Turkey Tendon Bone_L (120 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VTB06-4",
+    "productName": "Turkey Tendon Lollipop (90 units /CTN)",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": 4,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "HDR01AM",
+    "productName": "Herz_ Turkey Tendon_Duo-Protein_Ring (S) (85g)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "HDP01AM",
+    "productName": "Herz_ Turkey Tendon_Duo-Protein_Rope(S)(85g)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "HDS03AM",
+    "productName": "Herz_ Turkey Tendon_Duo-Protein_Strip(85g)",
+    "boxSize": "50*40*30",
+    "perCarton": 120,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACBL01",
+    "productName": "AFreschi - Natural Chicken Fillet Jerky 454g*30",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACBL02",
+    "productName": "AFreschi - Natural Chicken Breast Jerky 454g*36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACBL03",
+    "productName": "AFreschi - Natural Chicken Chips 454g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASCL01",
+    "productName": "AFreschi - Natural Soft Chicken Breast Strips 454g*36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASCL02",
+    "productName": "AFreschi - Natural Soft Chicken Sticks 454g*36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASCL03",
+    "productName": "AFreschi - Natural Soft Chicken Dental Chews with Chlorophyll 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASCL04",
+    "productName": "AFreschi - Natural Soft Chicken Knots 454g*30",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ASCL05",
+    "productName": "AFreschi - Natural Soft Chicken Jerky Cuts 454g*36",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL01",
+    "productName": "AFreschi - Natural Chicken Sticks 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL02",
+    "productName": "AFreschi - Natural Chicken Sticks with Chicken Liver 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL03",
+    "productName": "AFreschi - Natural Chicken Sticks with Sweet Potato 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL04",
+    "productName": "AFreschi - Natural Chicken Sticks (Mini) 681g*22",
+    "boxSize": "50*40*30",
+    "perCarton": 22,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL05",
+    "productName": "AFreschi - Natural Chicken Roll 340g*24",
+    "boxSize": "50*40*30",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL06",
+    "productName": "AFreschi - Natural Chicken Dipped Sticks 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL07",
+    "productName": "AFreschi - Natural Chicken Dipped Rice Sticks 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL08",
+    "productName": "AFreschi - Natural Chicken Sliced 681g*24",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL09",
+    "productName": "AFreschi - Natural Chicken Dipped Rice Bone 454g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACTL10",
+    "productName": "AFreschi - Natural Chicken Sticks with Pumpkin 681g*28",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACA01",
+    "productName": "Afreschi - Natural Cat Treats (Chicken & Mackerel) -6oz-170gx100",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACA02",
+    "productName": "Afreschi - Natural Cat Treats (Buffalo& Chicken & Fish) -6oz-170gx100",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ACA03",
+    "productName": "Afreschi - Natural Cat Treats (Turkey & Chicken & Mackerel) -6oz-170gx100",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VBS01",
+    "productName": "Vitaday - Buffalo Treats Stick (Small) 227g*70",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VBS03",
+    "productName": "Vitaday - Buffalo Treats Stick (Medium) 227g*70",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VBB01",
+    "productName": "Vitaday - Buffalo Treats Bone Shaped 227g*60",
+    "boxSize": "50*40*30",
+    "perCarton": 60,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "VBW01",
+    "productName": "Vitaday - Buffalo Treats W Shaped 227g*80",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "EZD011AM",
+    "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (908g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD021AM",
+    "productName": "Herz Grain-Free Australian Lamb Recipe (908g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD041AM",
+    "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (908g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD051AM",
+    "productName": "Herz Grain-Free New Zealand Venison Recipe (908g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD061AM",
+    "productName": "Herz Grain-Free U.S.A. Chicken Recipe (908g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD010AM",
+    "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD020AM",
+    "productName": "Herz Grain-Free Australian Lamb Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD040AM",
+    "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD050AM",
+    "productName": "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD060AM",
+    "productName": "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD010AM-3",
+    "productName": "Herz Grain-Free U.S.A. Turkey Breast Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 90,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD020AM-3",
+    "productName": "Herz Grain-Free Australian Lamb Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 90,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD040AM-3",
+    "productName": "Herz Grain-Free New Zealand Grass-Fed Beef Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 90,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD050AM-3",
+    "productName": "Herz Grain-Free New Zealand Venison Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 90,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD060AM-3",
+    "productName": "Herz Grain-Free U.S.A. Chicken Recipe (100g/Pk)",
+    "boxSize": "48*38*28",
+    "perCarton": 90,
+    "perPack": 3,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD011J",
+    "productName": "Herz Premium Canine Cuisine – Turkey with Duck Liver Recipe, 1kg",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD021J",
+    "productName": "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-1kg",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD041J",
+    "productName": "Premium Canine Cuisine-Beef with Duck Liver Ricipe-1kg",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD061J",
+    "productName": "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-1kg",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD010J",
+    "productName": "Premium Canine Cuisine – Turkey with Duck Liver Recipe-454g",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD020J",
+    "productName": "Premium Canine Cuisine-Lamb with Duck Liver Ricipe-454g",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD040J",
+    "productName": "Premium Canine Cuisine-Beef with Duck Liver Ricipe-454g",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD060J",
+    "productName": "Premium Canine Cuisine-Chicken with Duck Liver Ricipe-454g",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTSL01J",
+    "productName": "Gootoe - Turkey Tendon Strip",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTRL05J",
+    "productName": "Gootoe - Turkey Tendon Ring_L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTPL05J",
+    "productName": "Gootoe - Turkey Tendon Rope_L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTBL05J",
+    "productName": "Gootoe - Turkey Tendon Bone_L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTRL01J",
+    "productName": "Gootoe - Turkey Tendon Ring_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTPL01J",
+    "productName": "Gootoe - Turkey Tendon Rope_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTBL01J",
+    "productName": "Gootoe - Turkey Tendon Bone_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GSF01J",
+    "productName": "Gootoe -Turkey Tendon Pumpkin Strip",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 150,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTR01J",
+    "productName": "Gootoe - Turkey Tendon Ring_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTR03J",
+    "productName": "Gootoe - Turkey Tendon Ring_M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTB01J",
+    "productName": "Gootoe - Turkey Tendon Bone_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTB03J",
+    "productName": "Gootoe - Turkey Tendon Bone_M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTB05J",
+    "productName": "Gootoe - Turkey Tendon Bone_L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTP01J",
+    "productName": "Gootoe - Turkey Tendon Rope_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTP03J",
+    "productName": "Gootoe - Turkey Tendon Rope _M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTP05J",
+    "productName": "Gootoe - Turkey Tendon Rope _L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTS01J",
+    "productName": "Gootoe - Turkey Tendon Strip",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTS03J",
+    "productName": "Gootoe - Turkey Tendon Stick_M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTZ01J",
+    "productName": "Gootoe - Turkey Tendon Pretzel_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTZ03J",
+    "productName": "Gootoe - Turkey Tendon Pretzel_M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GTA01J",
+    "productName": "Gootoe - Turkey Tendon Braid",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "KTB01J",
+    "productName": "Natural Turkey Tendon Bone_S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 320,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "KTB03J",
+    "productName": "Natural Turkey Tendon Bone_ M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "KTB05J",
+    "productName": "Natural Turkey Tendon Bone_L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "KTB06J",
+    "productName": "Natural Turkey Tendon Lollipop",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 320,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTR01J",
+    "productName": "Natural Turkey Tendon Ring_ S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 320,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTR03J",
+    "productName": "Natural Turkey Tendon Ring_ M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTR05J",
+    "productName": "Natural Turkey Tendon Ring_ L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TRP01J",
+    "productName": "Natural Turkey Tendon Rope_ S",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 320,
+    "perPack": null,
+    "perBox": 40,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TRP03J",
+    "productName": "Natural Turkey Tendon Rope_ M",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TRP05J",
+    "productName": "Natural Turkey Tendon Rope_ L",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTS05J",
+    "productName": "Natural Turkey Tendon Strip",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": 10,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTA01J",
+    "productName": "Turkey Tendon Rice Stick",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTA02J",
+    "productName": "Turkey Tendon Chicken Stick",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTA03J",
+    "productName": "Turkey Tendon Thin Stick",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "TTA04J",
+    "productName": "Turkey Tendon Pumpkin Strip",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 160,
+    "perPack": null,
+    "perBox": 20,
+    "perPallet": 12,
+    "country": "TW"
+  },
+  {
+    "productCode": "GRB01AM",
+    "productName": "Gootoe - Veal Rib Bone, 85g",
+    "boxSize": "48*38*28",
+    "perCarton": 130,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "GRB01J",
+    "productName": "Gootoe - Veal Rib Bone, 85g",
+    "boxSize": "48*38*28",
+    "perCarton": 130,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "ART01AM",
+    "productName": "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g",
+    "boxSize": "48*38*28",
+    "perCarton": 130,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "ART01J",
+    "productName": "Afreschi - Turkey Tendon Wrapped Veal Rib Bone, 85g",
+    "boxSize": "48*38*28",
+    "perCarton": 130,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 21,
+    "country": "TW"
+  },
+  {
+    "productCode": "1VFAD053A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 110,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFBD053A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFBD015A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFCD017A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 36,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFRD055A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 60,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFRD015A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 50,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFSD013A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GFTD033A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GFTD035A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GFTD043A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GFTD045A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GFTD061A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 60,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GSDD023A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 80,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GSDD033A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VDFD011A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GBRD027A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 12,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1ABRD016A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 14,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFRD058A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 16,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFBD018A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFRD018A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 16,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFAD058A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD026A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD041A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 70,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD045A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GBRD041A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GBRD045A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 28,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GQRD016A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GCRD036A0",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "ATR01",
+    "productName": "",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "EPD021",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD040",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD051",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD060",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD011",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD050",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD020",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD010",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 30,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD041",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EPD061",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD051",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD041",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD021",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD011",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "EZD061",
+    "productName": "",
+    "boxSize": "48*38*28",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 36,
+    "country": "TW"
+  },
+  {
+    "productCode": "1HGCC015A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1HGCC025A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1HGCC035A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1HGCC045A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1HGRD015A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRC015A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRC025A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRC035A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRC045A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRC055A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRD015A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRD025A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRD035A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRD045A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1MGRD055A0",
+    "productName": "",
+    "boxSize": "32.5*23*6.1",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AGHC015A0",
+    "productName": "",
+    "boxSize": "28.5*19.65*8.2",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AGHC025A0",
+    "productName": "",
+    "boxSize": "28.5*19.65*8.2",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AGHC035A0",
+    "productName": "",
+    "boxSize": "28.5*19.65*8.2",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AGHC045A0",
+    "productName": "",
+    "boxSize": "28.5*19.65*8.2",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 100,
+    "country": "VN"
+  }
 ];
 
-// ============================================================
-// Turkey / Non-Turkey binary classification rules
-// ------------------------------------------------------------
-// Maintenance rule:
-// - Do NOT add turkeyGroup to each product manually.
-// - The system classifies products automatically from productName.
-// - If productName contains "Turkey" => 火雞
-// - Otherwise => 非火雞
-// ============================================================
+// Turkey / Non-Turkey classification remains synchronous for legacy callers.
 (function () {
   function normalizeProductCode(value) {
     return String(value || "").trim().toUpperCase();
@@ -365,7 +3455,6 @@ window.allProductsData = [
   function getProductByCode(productCode) {
     const key = normalizeProductCode(productCode);
     if (!key) return null;
-
     const list = Array.isArray(window.allProductsData) ? window.allProductsData : [];
     return list.find(function (item) {
       return normalizeProductCode(item && item.productCode) === key;
@@ -378,14 +3467,7 @@ window.allProductsData = [
 
   function getTurkeyGroupByCode(productCode) {
     const product = getProductByCode(productCode);
-    if (!product) {
-      return {
-        group: "unknown",
-        groupName: "未對應",
-        product: null
-      };
-    }
-
+    if (!product) return { group: "unknown", groupName: "未對應", product: null };
     const isTurkey = isTurkeyName(product.productName);
     return {
       group: isTurkey ? "turkey" : "non_turkey",
@@ -394,17 +3476,9 @@ window.allProductsData = [
     };
   }
 
-  function isTurkeyProduct(productCode) {
-    return getTurkeyGroupByCode(productCode).group === "turkey";
-  }
-
-  function isNonTurkeyProduct(productCode) {
-    return getTurkeyGroupByCode(productCode).group === "non_turkey";
-  }
-
   window.normalizeProductCode = window.normalizeProductCode || normalizeProductCode;
   window.getProductByCode = window.getProductByCode || getProductByCode;
   window.getTurkeyGroupByCode = getTurkeyGroupByCode;
-  window.isTurkeyProduct = isTurkeyProduct;
-  window.isNonTurkeyProduct = isNonTurkeyProduct;
+  window.isTurkeyProduct = function (productCode) { return getTurkeyGroupByCode(productCode).group === "turkey"; };
+  window.isNonTurkeyProduct = function (productCode) { return getTurkeyGroupByCode(productCode).group === "non_turkey"; };
 })();

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -9,6 +9,7 @@ import {
   formatAppVersion,
   replaceAppVersionToken,
 } from './release-version.mjs';
+import { compileSupplyProductData } from './compile-product-catalog.mjs';
 import { runtimeFiles, sha256File } from './site-contract.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -55,10 +56,14 @@ fs.rmSync(output, { recursive: true, force: true });
 fs.mkdirSync(output, { recursive: true });
 
 for (const relativePath of runtimeFiles) {
-  const source = path.join(repoRoot, relativePath);
-  if (!fs.statSync(source).isFile()) throw new Error(`Missing deploy source: ${relativePath}`);
   const destination = path.join(output, relativePath);
   fs.mkdirSync(path.dirname(destination), { recursive: true });
+  if (relativePath === 'product-data.js') {
+    fs.writeFileSync(destination, compileSupplyProductData());
+    continue;
+  }
+  const source = path.join(repoRoot, relativePath);
+  if (!fs.statSync(source).isFile()) throw new Error(`Missing deploy source: ${relativePath}`);
   fs.copyFileSync(source, destination);
 }
 

--- a/scripts/compile-product-catalog.mjs
+++ b/scripts/compile-product-catalog.mjs
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { compileCatalog } from '../catalog/product-catalog.js';
+import {
+  renderSupplyProductData,
+  supplyCatalogAdapter,
+} from '../catalog/supply-catalog-adapter.js';
+
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const canonicalCatalogPath = path.join(repoRoot, 'catalog', 'product-catalog.json');
+export const checkedSupplySnapshotPath = path.join(repoRoot, 'product-data.js');
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    error.message = `Cannot read product catalog ${filePath}: ${error.message}`;
+    throw error;
+  }
+}
+
+export function compileSupplyProductData({ catalogPath = canonicalCatalogPath } = {}) {
+  const canonicalCatalog = readJson(catalogPath);
+  const projection = compileCatalog(canonicalCatalog, supplyCatalogAdapter);
+  return renderSupplyProductData(projection);
+}
+
+export function writeSupplyProductData({
+  catalogPath = canonicalCatalogPath,
+  outputPath = checkedSupplySnapshotPath,
+} = {}) {
+  const generated = compileSupplyProductData({ catalogPath });
+  fs.mkdirSync(path.dirname(outputPath), { recursive:true });
+  fs.writeFileSync(outputPath, generated);
+  return outputPath;
+}
+
+export function checkSupplyProductData({
+  catalogPath = canonicalCatalogPath,
+  outputPath = checkedSupplySnapshotPath,
+} = {}) {
+  const expected = compileSupplyProductData({ catalogPath });
+  const actual = fs.readFileSync(outputPath, 'utf8');
+  if (actual !== expected) {
+    throw new Error(`${path.relative(repoRoot, outputPath)} is stale; run npm run catalog:build`);
+  }
+  return outputPath;
+}
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return null;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+function main() {
+  const outputPath = path.resolve(readOption('--out') || checkedSupplySnapshotPath);
+  const catalogPath = path.resolve(readOption('--catalog') || canonicalCatalogPath);
+  if (process.argv.includes('--check')) {
+    checkSupplyProductData({ catalogPath, outputPath });
+    console.log(`Verified ${path.relative(repoRoot, outputPath)} against ${path.relative(repoRoot, catalogPath)}`);
+    return;
+  }
+  writeSupplyProductData({ catalogPath, outputPath });
+  console.log(`Generated ${path.relative(repoRoot, outputPath)} from ${path.relative(repoRoot, catalogPath)}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/compile-product-master-workbook.mjs
+++ b/scripts/compile-product-master-workbook.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import * as XLSX from 'xlsx';
+
+import {
+  catalogFromProductMasterRows,
+  ORDER_SKU_PACKAGING_SHEET,
+  PRODUCT_MASTER_SHEET,
+} from '../catalog/product-master-workbook.js';
+
+function options(argv) {
+  const values = { check:false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (key === '--check') {
+      values.check = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || !value || value.startsWith('--')) throw new Error(`Invalid option near ${key || 'end of command'}`);
+    values[key.slice(2)] = value;
+    index += 1;
+  }
+  return values;
+}
+
+const args = options(process.argv.slice(2));
+if (!args.input || !args.output) throw new Error('Required options: --input <xlsx> --output <catalog.json>');
+
+const workbook = XLSX.read(fs.readFileSync(path.resolve(args.input)), { type:'buffer', cellDates:true });
+const sheet = workbook.Sheets[PRODUCT_MASTER_SHEET];
+if (!sheet) throw new Error(`Workbook is missing ${PRODUCT_MASTER_SHEET}`);
+const orderSkuSheet = workbook.Sheets[ORDER_SKU_PACKAGING_SHEET];
+if (!orderSkuSheet) throw new Error(`Workbook is missing ${ORDER_SKU_PACKAGING_SHEET}`);
+const rows = XLSX.utils.sheet_to_json(sheet, { header:1, defval:null, raw:true });
+const orderSkuRows = XLSX.utils.sheet_to_json(orderSkuSheet, { header:1, defval:null, raw:true });
+const catalog = catalogFromProductMasterRows(rows, orderSkuRows);
+const generated = `${JSON.stringify(catalog, null, 2)}\n`;
+const outputPath = path.resolve(args.output);
+
+if (args.check) {
+  if (fs.readFileSync(outputPath, 'utf8') !== generated) {
+    throw new Error(`${args.output} is stale relative to ${args.input}`);
+  }
+  console.log(`Verified ${args.output} against ${args.input}`);
+} else {
+  fs.mkdirSync(path.dirname(outputPath), { recursive:true });
+  fs.writeFileSync(outputPath, generated);
+  console.log(`Compiled ${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases from ${args.input} into ${args.output}`);
+}

--- a/shared/coverage-indicator.css
+++ b/shared/coverage-indicator.css
@@ -1,11 +1,27 @@
 .coverageMeter {
   --coverage-fill: 0%;
   --coverage-target: 49.3151%;
+  --coverage-accent-rgb: 142, 142, 147;
+  --coverage-status-color: #5f6673;
   display: grid;
-  gap: 4px;
-  min-width: 132px;
-  max-width: 190px;
-  color: #334155;
+  gap: 5px;
+  min-width: 138px;
+  max-width: 184px;
+  padding: 6px 8px 7px;
+  color: #344054;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 13px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.82) 0%,
+    rgba(248, 250, 252, 0.56) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    0 1px 2px rgba(15, 23, 42, 0.04),
+    0 5px 14px rgba(15, 23, 42, 0.06);
+  -webkit-backdrop-filter: saturate(145%) blur(12px);
+  backdrop-filter: saturate(145%) blur(12px);
 }
 
 .coverageMeter__summary {
@@ -17,60 +33,112 @@
 }
 
 .coverageMeter__value {
-  color: #0f172a;
-  font-size: 0.82rem;
+  color: #101828;
+  font-size: 0.8rem;
+  font-weight: 720;
+  letter-spacing: -0.01em;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
 .coverageMeter__status {
-  font-size: 0.68rem;
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  color: var(--coverage-status-color);
+  font-size: 0.64rem;
+  font-weight: 720;
+  letter-spacing: -0.005em;
   text-align: right;
+}
+
+.coverageMeter__status::before {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: rgba(var(--coverage-accent-rgb), 0.84);
+  box-shadow:
+    0 0 0 2px rgba(var(--coverage-accent-rgb), 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.58);
+  content: "";
 }
 
 .coverageMeter__track {
   position: relative;
-  height: 11px;
+  height: 10px;
   overflow: hidden;
-  border: 1px solid #94a3b8;
+  border: 1px solid rgba(71, 84, 103, 0.14);
   border-radius: 999px;
-  background: #e2e8f0;
-  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.18);
+  background: linear-gradient(
+    180deg,
+    rgba(226, 232, 240, 0.76) 0%,
+    rgba(248, 250, 252, 0.9) 100%
+  );
+  box-shadow:
+    inset 0 1px 2px rgba(15, 23, 42, 0.12),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.82),
+    0 1px 0 rgba(255, 255, 255, 0.68);
 }
 
 .coverageMeter__fill {
+  position: relative;
   display: block;
   width: var(--coverage-fill);
   height: 100%;
   border-radius: inherit;
-  background: #94a3b8;
-  transition: width 180ms ease;
+  background: linear-gradient(
+    180deg,
+    rgba(var(--coverage-accent-rgb), 0.42) 0%,
+    rgba(var(--coverage-accent-rgb), 0.58) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.54),
+    0 1px 4px rgba(var(--coverage-accent-rgb), 0.16);
+  transition: width 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.coverageMeter__fill::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.34) 0%,
+    rgba(255, 255, 255, 0.06) 52%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  content: "";
+  pointer-events: none;
 }
 
 .coverageMeter__targetMarker {
   position: absolute;
-  top: -1px;
-  bottom: -1px;
+  z-index: 2;
+  top: 1px;
+  bottom: 1px;
   left: var(--coverage-target);
-  width: 2px;
-  background: rgba(15, 23, 42, 0.48);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.58);
+  width: 1px;
+  background: rgba(15, 23, 42, 0.38);
+  box-shadow:
+    -1px 0 0 rgba(255, 255, 255, 0.48),
+    1px 0 0 rgba(255, 255, 255, 0.48);
 }
 
 .coverageMeter--low {
-  --coverage-accent-rgb: 234, 179, 8;
-  --coverage-status-color: #854d0e;
+  --coverage-accent-rgb: 255, 159, 10;
+  --coverage-status-color: #8a4b00;
 }
 
 .coverageMeter--healthy {
-  --coverage-accent-rgb: 34, 197, 94;
+  --coverage-accent-rgb: 48, 209, 88;
   --coverage-status-color: #166534;
 }
 
 .coverageMeter--excess {
-  --coverage-accent-rgb: 239, 68, 68;
-  --coverage-status-color: #991b1b;
+  --coverage-accent-rgb: 255, 69, 58;
+  --coverage-status-color: #9f2019;
 }
 
 .coverageMeter--low .coverageMeter__fill,
@@ -78,12 +146,14 @@
 .coverageMeter--excess .coverageMeter__fill {
   background: linear-gradient(
     180deg,
-    rgba(var(--coverage-accent-rgb), 0.56) 0%,
-    rgba(var(--coverage-accent-rgb), 0.74) 100%
+    rgba(var(--coverage-accent-rgb), 0.72) 0%,
+    rgba(var(--coverage-accent-rgb), 0.58) 52%,
+    rgba(var(--coverage-accent-rgb), 0.7) 100%
   );
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.46),
-    inset 0 -1px 0 rgba(15, 23, 42, 0.12);
+    inset 0 1px 0 rgba(255, 255, 255, 0.58),
+    inset 0 -1px 0 rgba(15, 23, 42, 0.08),
+    0 1px 5px rgba(var(--coverage-accent-rgb), 0.2);
 }
 
 .coverageMeter--low .coverageMeter__status,
@@ -92,8 +162,46 @@
   color: var(--coverage-status-color);
 }
 
-.coverageMeter--neutral .coverageMeter__status { color: #64748b; }
+.coverageMeter--neutral .coverageMeter__status { color: var(--coverage-status-color); }
+
+@media (prefers-contrast: more) {
+  .coverageMeter {
+    border-color: rgba(15, 23, 42, 0.34);
+    background: rgba(255, 255, 255, 0.94);
+  }
+
+  .coverageMeter__track { border-color: rgba(15, 23, 42, 0.42); }
+  .coverageMeter__status { font-weight: 800; }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .coverageMeter__fill { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .coverageMeter {
+    color: CanvasText;
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .coverageMeter__value,
+  .coverageMeter__status { color: CanvasText; }
+
+  .coverageMeter__status::before,
+  .coverageMeter__fill {
+    background: Highlight;
+    box-shadow: none;
+  }
+
+  .coverageMeter__track {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  .coverageMeter__targetMarker { background: CanvasText; box-shadow: none; }
 }

--- a/shared/coverage-indicator.js
+++ b/shared/coverage-indicator.js
@@ -66,7 +66,7 @@ function renderTrack(model) {
 export function renderCoverageMeter(options = {}) {
   const model = buildCoverageMeterModel(options);
   const noDataAria = model.hasValue ? '' : ' role="group" aria-label="可售天數：無資料"';
-  return `<div class="coverageMeter coverageMeter--${model.band}" data-band="${model.band}" data-assessment="${model.assessment}"${noDataAria}><div class="coverageMeter__summary"><strong class="coverageMeter__value">${model.valueText}</strong><span class="coverageMeter__status">${model.statusText}</span></div>${renderTrack(model)}</div>`;
+  return `<div class="coverageMeter coverageMeter--${model.band}" data-band="${model.band}" data-assessment="${model.assessment}" data-thresholds="${TARGET_DAYS}-${MAXIMUM_DAYS}"${noDataAria}><div class="coverageMeter__summary"><strong class="coverageMeter__value">${model.valueText}</strong><span class="coverageMeter__status">${model.statusText}</span></div>${renderTrack(model)}</div>`;
 }
 
 const browserInterface = Object.freeze({

--- a/tests/browser/browser-helpers.mjs
+++ b/tests/browser/browser-helpers.mjs
@@ -449,14 +449,14 @@ async function expectCoverageMeter(cell, {
     return { backgroundColor:style.backgroundColor, backgroundImage:style.backgroundImage };
   });
   const expectedAccent = {
-    yellow:'rgba(234, 179, 8, 0.56)',
-    green:'rgba(34, 197, 94, 0.56)',
-    red:'rgba(239, 68, 68, 0.56)',
+    yellow:'rgba(255, 159, 10, 0.72)',
+    green:'rgba(48, 209, 88, 0.72)',
+    red:'rgba(255, 69, 58, 0.72)',
   }[fillColor];
   expect(expectedAccent).toBeTruthy();
   expect(fillStyle.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   expect(fillStyle.backgroundImage).toContain(expectedAccent);
-  expect(fillStyle.backgroundImage).toContain('0.74');
+  expect(fillStyle.backgroundImage).toContain('0.58');
   expect(fillStyle.backgroundImage).not.toContain('repeating');
 }
 

--- a/tests/browser/public-acceptance.spec.mjs
+++ b/tests/browser/public-acceptance.spec.mjs
@@ -52,8 +52,8 @@ test('public sanitized data flows through planning, shared navigation, three gro
   await page.locator('.workspaceNavTab[data-workspace="analysis"]').click();
   await page.locator('#otherToolsDetails > summary').click();
   await page.locator('.toolTab[data-panel="suggestedDiscontinuedPanel"]').click();
-  await expect(page.locator('#suggestedDiscontinuedCount')).toHaveText('10');
-  await expect(page.locator('#suggestedDiscontinuedWrap tbody tr')).toHaveCount(10);
+  await expect(page.locator('#suggestedDiscontinuedCount')).toHaveText('9');
+  await expect(page.locator('#suggestedDiscontinuedWrap tbody tr')).toHaveCount(9);
   const ttsSuggestion = page.locator('#suggestedDiscontinuedWrap tbody tr').filter({ hasText:'TTS05AM-1' });
   await expect(ttsSuggestion).toHaveCount(1);
   await expect(ttsSuggestion).toContainText('420 天');

--- a/tests/browser/workspace-accessibility.spec.mjs
+++ b/tests/browser/workspace-accessibility.spec.mjs
@@ -134,10 +134,10 @@ test('keyboard alone operates Order groups and exact pallet stepping', async ({ 
   await expect(pallet).toBeFocused();
   await expect(pallet).toHaveValue('0.33');
   await page.keyboard.press('ArrowUp');
-  await expect(pallet).toHaveValue('1.33');
-  await expect.poll(async () => (await readOrderDraft(page)).rowsByProductSku.GTSL01.quantities.orderDraft).toBe(1344);
+  await expect(pallet).toHaveValue('1.37');
+  await expect.poll(async () => (await readOrderDraft(page)).rowsByProductSku.GTSL01.quantities.orderDraft).toBe(1236);
   await page.keyboard.press('ArrowDown');
-  await expect(pallet).toHaveValue('0.33');
+  await expect(pallet).toHaveValue('0.37');
   await expect.poll(async () => {
     const row = (await readOrderDraft(page)).rowsByProductSku.GTSL01;
     return { quantity:row.quantities.orderDraft, mode:row.pallet.mode, authoritativeField:row.pallet.authoritativeField };

--- a/tests/coverage-indicator.test.mjs
+++ b/tests/coverage-indicator.test.mjs
@@ -38,16 +38,36 @@ test('coverage meter fill is proportional to days over the 365 day track', () =>
   assert.equal(Object.isFrozen(model), true);
 });
 
-test('yellow, green, and red bands share one translucent finish without special patterns', () => {
+test('yellow, green, and red bands share one Apple-style translucent finish without special patterns', () => {
   for (const band of ['low', 'healthy', 'excess']) {
     assert.match(coverageCss, new RegExp(`\\.coverageMeter--${band} \\{[^}]*--coverage-accent-rgb:[^}]*--coverage-status-color:`, 's'));
   }
 
   const sharedFill = coverageCss.match(/\.coverageMeter--low \.coverageMeter__fill,\s*\.coverageMeter--healthy \.coverageMeter__fill,\s*\.coverageMeter--excess \.coverageMeter__fill \{([^}]*)\}/s);
   assert.ok(sharedFill, 'all three colored bands should use one shared fill rule');
-  assert.match(sharedFill[1], /linear-gradient\(\s*180deg,\s*rgba\(var\(--coverage-accent-rgb\), 0\.56\) 0%,\s*rgba\(var\(--coverage-accent-rgb\), 0\.74\) 100%\s*\)/s);
+  assert.match(sharedFill[1], /linear-gradient\(\s*180deg,/s);
+  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.72\)/);
+  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.58\)/);
   assert.match(sharedFill[1], /box-shadow:/);
   assert.doesNotMatch(coverageCss, /repeating-linear-gradient|repeating-radial-gradient/);
+});
+
+test('coverage meter uses a compact glass surface with restrained highlights and accessible fallbacks', () => {
+  const meterRule = coverageCss.match(/\.coverageMeter \{([^}]*)\}/s);
+  assert.ok(meterRule);
+  assert.match(meterRule[1], /background:\s*linear-gradient/);
+  assert.match(meterRule[1], /border:\s*1px solid rgba\(/);
+  assert.match(meterRule[1], /backdrop-filter:\s*saturate\(/);
+  assert.match(meterRule[1], /box-shadow:/);
+
+  const trackRule = coverageCss.match(/\.coverageMeter__track \{([^}]*)\}/s);
+  assert.ok(trackRule);
+  assert.match(trackRule[1], /border-radius:\s*999px/);
+  assert.match(trackRule[1], /inset 0 1px/);
+
+  assert.match(coverageCss, /\.coverageMeter__fill::after/);
+  assert.match(coverageCss, /@media \(forced-colors: active\)/);
+  assert.match(coverageCss, /@media \(prefers-reduced-motion: reduce\)/);
 });
 
 test('unavailable assessment is neutral while retaining its finite value', () => {
@@ -85,6 +105,7 @@ test('rendered meter keeps numeric and status text alongside accessible meter se
   const healthy = renderCoverageMeter({ coverageDays:180 });
   assert.match(healthy, /class="coverageMeter coverageMeter--healthy"/);
   assert.match(healthy, /data-band="healthy"/);
+  assert.match(healthy, /data-thresholds="180-365"/);
   assert.match(healthy, />180\.0 天</);
   assert.match(healthy, />健康範圍 180–365 天</);
   assert.match(healthy, /role="meter"/);

--- a/tests/product-catalog.test.mjs
+++ b/tests/product-catalog.test.mjs
@@ -1,0 +1,594 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+
+import {
+  CatalogValidationError,
+  compileCatalog,
+  orderGroupForOrderSku,
+  validateCatalog,
+} from '../catalog/product-catalog.js';
+import {
+  renderSupplyProductData,
+  supplyCatalogAdapter,
+} from '../catalog/supply-catalog-adapter.js';
+import {
+  catalogFromProductMasterRows,
+  ORDER_SKU_PACKAGING_HEADERS,
+  PRODUCT_MASTER_HEADERS,
+} from '../catalog/product-master-workbook.js';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+function workbookRows(dataRows) {
+  return [
+    ['JAM 美國產品共用主檔'],
+    [],
+    ['Schema Version', 2, 'Catalog Version', '2026-08-25'],
+    [],
+    PRODUCT_MASTER_HEADERS,
+    ...dataRows,
+  ];
+}
+
+function workbookAliasRows(dataRows = [workbookAliasRow()]) {
+  return [
+    ['JAM Order SKU 專屬箱規'],
+    [],
+    ['Schema Version', 2, 'Catalog Version', '2026-08-25'],
+    [],
+    ORDER_SKU_PACKAGING_HEADERS,
+    ...dataRows,
+  ];
+}
+
+function workbookAliasRow(overrides = {}) {
+  const values = {
+    orderSku:'7GTPD013AB', canonicalProductSku:'GTP01', lifecycle:'核准',
+    version:'fba-2026-08-25', effectiveFrom:'2026-08-25', effectiveTo:null, current:'是', orderUnit:'單品',
+    unitsPerCarton:100, unitsPerPack:null, unitsPerBox:null, cartonsPerPallet:null,
+    length:50.8, width:40.64, height:30.48, grossWeightKg:null, grossWeightLb:21,
+    sourceSheet:'初始共用主檔', sourceRow:null,
+    ...overrides,
+  };
+  return [
+    values.orderSku, values.canonicalProductSku, values.lifecycle,
+    values.version, values.effectiveFrom, values.effectiveTo, values.current, values.orderUnit,
+    values.unitsPerCarton, values.unitsPerPack, values.unitsPerBox, values.cartonsPerPallet,
+    values.length, values.width, values.height, values.grossWeightKg, values.grossWeightLb,
+    values.sourceSheet, values.sourceRow, '', '',
+  ];
+}
+
+function workbookProductRow(overrides = {}) {
+  const values = {
+    productSku:'GTP01', productName:'Gootoe Turkey Tendon Rope', origin:'越南', factory:'越南', aliases:'7GTPD013AB',
+    version:'2026-08-25', effectiveFrom:'2026-08-25', effectiveTo:null, current:'是', orderUnit:'單品',
+    unitsPerCarton:100, unitsPerPack:null, unitsPerBox:null, cartonsPerPallet:42,
+    length:50, width:40, height:30, grossWeightKg:10, grossWeightLb:22,
+    lifecycle:'正常', sourceSheet:'AMZ 所有SKU', sourceRow:6,
+    ...overrides,
+  };
+  return [
+    values.productSku, values.productName, values.origin, values.factory, values.aliases,
+    values.version, values.effectiveFrom, values.effectiveTo, values.current, values.orderUnit,
+    values.unitsPerCarton, values.unitsPerPack, values.unitsPerBox, values.cartonsPerPallet,
+    values.length, values.width, values.height, values.grossWeightKg, values.grossWeightLb,
+    values.lifecycle, values.sourceSheet, values.sourceRow, '', '',
+  ];
+}
+
+function fixture(overrides = {}) {
+  return {
+    schemaVersion: 2,
+    catalogVersion: '2026-08-25',
+    products: [
+      {
+        productSku: 'GTP01',
+        productName: 'Gootoe Turkey Tendon Rope',
+        origin: 'VN',
+        standardFactory: 'VN',
+        lifecycle: 'active',
+        approvedOrderSkus: ['GTP01', '7GTPD013AB'],
+        packagingVersions: [
+          {
+            version: '2026-08-25',
+            effectiveFrom: '2026-08-25',
+            effectiveTo: null,
+            unitsPerCarton: 100,
+            cartonsPerPallet: 42,
+            cartonDimensionsCm: [50, 40, 30],
+            grossWeightLb: 22,
+            orderUnit: { kind: 'single', units: 1 },
+          },
+        ],
+      },
+      {
+        productSku: 'EZD011AM',
+        productName: 'Herz Turkey Recipe',
+        origin: 'TW',
+        standardFactory: 'TW',
+        lifecycle: 'active',
+        approvedOrderSkus: ['EZD011AM'],
+        packagingVersions: [
+          {
+            version: '2026-08-25',
+            effectiveFrom: '2026-08-25',
+            effectiveTo: null,
+            unitsPerCarton: 18,
+            cartonsPerPallet: 36,
+            cartonDimensionsCm: [48, 38, 28],
+            grossWeightLb: 41,
+            orderUnit: { kind: 'single', units: 1 },
+          },
+        ],
+      },
+    ],
+    orderSkuAliases: [
+      {
+        orderSku:'7GTPD013AB',
+        canonicalProductSku:'GTP01',
+        lifecycle:'approved',
+        packagingVersions:[
+          {
+            version:'fba-2026-08-25',
+            effectiveFrom:'2026-08-25',
+            effectiveTo:null,
+            unitsPerCarton:90,
+            cartonsPerPallet:null,
+            cartonDimensionsCm:[50.8, 40.64, 30.48],
+            grossWeightKg:null,
+            grossWeightLb:21,
+            orderUnit:{ kind:'single', units:1 },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test('compiler validates once and projects the synchronous Supply compatibility interface', () => {
+  const projected = compileCatalog(fixture(), supplyCatalogAdapter);
+
+  assert.deepEqual(projected.meta, { schemaVersion:2, catalogVersion:'2026-08-25' });
+  assert.deepEqual(projected.equivalentSkuPairs, [['GTP01', '7GTPD013AB']]);
+  assert.deepEqual(projected.products[0], {
+    productCode:'GTP01',
+    productName:'Gootoe Turkey Tendon Rope',
+    boxSize:'50*40*30',
+    perCarton:100,
+    perPack:null,
+    perBox:null,
+    perPallet:42,
+    country:'VN',
+  });
+
+  const context = { window:{} };
+  vm.createContext(context);
+  vm.runInContext(renderSupplyProductData(projected), context);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context.window.SUPPLY_PRODUCT_CATALOG_META)),
+    { schemaVersion:2, catalogVersion:'2026-08-25' },
+  );
+  assert.equal(context.window.allProductsData[0].productCode, 'GTP01');
+  assert.equal(context.window.SUPPLY_EQUIVALENT_SKU_PAIRS[0][1], '7GTPD013AB');
+  assert.equal(context.window.getProductByCode('gtp01').productCode, 'GTP01');
+});
+
+test('origin and standard factory are independent while 7-prefixed Order SKUs route to Subcontract', () => {
+  const catalog = fixture();
+  catalog.products[0].origin = 'KH';
+  catalog.products[0].standardFactory = 'VN';
+
+  const validated = validateCatalog(catalog);
+  assert.equal(validated.products[0].origin, 'KH');
+  assert.equal(validated.products[0].standardFactory, 'VN');
+  assert.equal(orderGroupForOrderSku('7GTPD013AB', 'VN'), 'subcontract');
+  assert.equal(orderGroupForOrderSku('GTP01', 'VN'), 'vietnam');
+  assert.equal(orderGroupForOrderSku('EZD011AM', 'TW'), 'taiwan');
+
+  catalog.products[0].origin = null;
+  assert.equal(validateCatalog(catalog).products[0].origin, null);
+});
+
+test('packaging versions require effective dates, do not overlap, and expose exactly one current version', () => {
+  const catalog = fixture();
+  catalog.products[0].packagingVersions = [
+    {
+      ...catalog.products[0].packagingVersions[0],
+      version:'2025-01-01',
+      effectiveFrom:'2025-01-01',
+      effectiveTo:'2026-08-24',
+      unitsPerCarton:90,
+    },
+    catalog.products[0].packagingVersions[0],
+  ];
+  assert.equal(validateCatalog(catalog).products[0].currentPackaging.unitsPerCarton, 100);
+
+  catalog.products[0].packagingVersions[0].effectiveTo = null;
+  assert.throws(
+    () => validateCatalog(catalog),
+    error => error instanceof CatalogValidationError && /exactly one current packaging version/.test(error.message),
+  );
+
+  catalog.products[0].packagingVersions[0].effectiveTo = '2026-08-30';
+  assert.throws(
+    () => validateCatalog(catalog),
+    error => error instanceof CatalogValidationError && /packaging date ranges overlap/.test(error.message),
+  );
+});
+
+test('Order SKU Alias owns its packaging while approved ownership stays on the canonical Product SKU', () => {
+  const validated = validateCatalog(fixture());
+  const alias = validated.orderSkuAliases[0];
+
+  assert.equal(alias.orderSku, '7GTPD013AB');
+  assert.equal(alias.canonicalProductSku, 'GTP01');
+  assert.equal(alias.lifecycle, 'approved');
+  assert.equal(alias.currentPackaging.unitsPerCarton, 90);
+  assert.deepEqual(alias.currentPackaging.cartonDimensionsCm, [50.8, 40.64, 30.48]);
+  assert.equal(validated.products[0].currentPackaging.unitsPerCarton, 100);
+});
+
+test('Order SKU Alias validation rejects invalid owners, duplicate aliases, and ambiguous current packaging', () => {
+  const missingApproval = fixture();
+  missingApproval.products[0].approvedOrderSkus = ['GTP01'];
+  assert.throws(
+    () => validateCatalog(missingApproval),
+    error => error instanceof CatalogValidationError && /must be listed in GTP01\.approvedOrderSkus/.test(error.message),
+  );
+
+  const duplicate = fixture();
+  duplicate.orderSkuAliases.push(structuredClone(duplicate.orderSkuAliases[0]));
+  assert.throws(
+    () => validateCatalog(duplicate),
+    error => error instanceof CatalogValidationError && /orderSku duplicates 7GTPD013AB/.test(error.message),
+  );
+
+  const twoCurrent = fixture();
+  twoCurrent.orderSkuAliases[0].packagingVersions.push({
+    ...structuredClone(twoCurrent.orderSkuAliases[0].packagingVersions[0]),
+    version:'duplicate-current',
+    effectiveFrom:'2026-08-26',
+  });
+  assert.throws(
+    () => validateCatalog(twoCurrent),
+    error => error instanceof CatalogValidationError && /exactly one current packaging version/.test(error.message),
+  );
+});
+
+test('unmapped legacy aliases have no guessed owner and 7-prefixed Product SKUs are rejected', () => {
+  const catalog = fixture();
+  catalog.orderSkuAliases.push({
+    orderSku:'7VTSD913AB',
+    canonicalProductSku:null,
+    lifecycle:'unmapped-legacy',
+    packagingVersions:[{
+      version:'fba-2026-08-25',
+      effectiveFrom:'2026-08-25',
+      effectiveTo:null,
+      unitsPerCarton:10,
+      cartonsPerPallet:null,
+      cartonDimensionsCm:[50.8, 40.64, 30.48],
+      grossWeightKg:null,
+      grossWeightLb:24,
+      orderUnit:{ kind:'single', units:1 },
+    }],
+  });
+  assert.equal(validateCatalog(catalog).orderSkuAliases[1].canonicalProductSku, null);
+
+  catalog.orderSkuAliases[1].canonicalProductSku = 'GTP01';
+  assert.throws(
+    () => validateCatalog(catalog),
+    error => error instanceof CatalogValidationError && /must be null for an unmapped-legacy alias/.test(error.message),
+  );
+
+  const falselyUnmapped = fixture();
+  falselyUnmapped.orderSkuAliases[0].canonicalProductSku = null;
+  falselyUnmapped.orderSkuAliases[0].lifecycle = 'unmapped-legacy';
+  assert.throws(
+    () => validateCatalog(falselyUnmapped),
+    error => error instanceof CatalogValidationError && /is already approved by GTP01/.test(error.message),
+  );
+
+  const sevenProduct = fixture();
+  sevenProduct.products[1].productSku = '7LEGACY';
+  sevenProduct.products[1].approvedOrderSkus = ['7LEGACY'];
+  assert.throws(
+    () => validateCatalog(sevenProduct),
+    error => error instanceof CatalogValidationError && /must not be 7-prefixed/.test(error.message),
+  );
+});
+
+test('approved Order SKU alternatives must be 7-prefixed so Supply and FBA share one alias set', () => {
+  const catalog = fixture();
+  catalog.products[1].approvedOrderSkus.push('LEGACY-ALT');
+
+  assert.throws(
+    () => validateCatalog(catalog),
+    error => error instanceof CatalogValidationError
+      && /approvedOrderSkus alternative LEGACY-ALT must be 7-prefixed/.test(error.message),
+  );
+});
+
+test('canonical public catalog rejects fields outside the explicit allowlist', () => {
+  for (const [field, value] of [
+    ['cost', 4.2],
+    ['supplier', 'private factory'],
+    ['inventory', 100],
+  ]) {
+    const catalog = fixture();
+    catalog.products[0][field] = value;
+    assert.throws(
+      () => validateCatalog(catalog),
+      error => error instanceof CatalogValidationError && error.message.includes(`unsupported field ${field}`),
+      field,
+    );
+  }
+});
+
+test('ProductMasterTable rows compile into the canonical catalog without relying on row overwrite order', () => {
+  const catalog = catalogFromProductMasterRows(workbookRows([
+    workbookProductRow({
+      version:'supply-2026-07-19',
+      effectiveFrom:'2026-07-19',
+      effectiveTo:'2026-08-24',
+      current:'否',
+      unitsPerCarton:90,
+    }),
+    workbookProductRow(),
+  ]), workbookAliasRows());
+
+  assert.equal(catalog.products.length, 1);
+  assert.deepEqual(catalog.products[0].approvedOrderSkus, ['GTP01', '7GTPD013AB']);
+  assert.deepEqual(catalog.products[0].packagingVersions.map(item => item.unitsPerCarton), [90, 100]);
+  assert.equal(catalog.products[0].origin, 'VN');
+  assert.equal(catalog.products[0].standardFactory, 'VN');
+  assert.equal(catalog.orderSkuAliases[0].orderSku, '7GTPD013AB');
+  assert.equal(catalog.orderSkuAliases[0].packagingVersions[0].unitsPerCarton, 100);
+});
+
+test('OrderSkuPackagingTable supports approved and unmapped legacy rows without changing product ownership', () => {
+  const catalog = catalogFromProductMasterRows(
+    workbookRows([workbookProductRow()]),
+    workbookAliasRows([
+      workbookAliasRow(),
+      workbookAliasRow({
+        orderSku:'7VTSD913AB', canonicalProductSku:'', lifecycle:'未映射舊品號',
+        unitsPerCarton:10, grossWeightLb:24,
+      }),
+    ]),
+  );
+
+  assert.deepEqual(catalog.products[0].approvedOrderSkus, ['GTP01', '7GTPD013AB']);
+  assert.deepEqual(
+    catalog.orderSkuAliases.map(alias => [alias.orderSku, alias.canonicalProductSku, alias.lifecycle]),
+    [
+      ['7GTPD013AB', 'GTP01', 'approved'],
+      ['7VTSD913AB', null, 'unmapped-legacy'],
+    ],
+  );
+});
+
+test('workbook compiler rejects inconsistent product facts, invalid current markers, and shared aliases', () => {
+  assert.throws(
+    () => catalogFromProductMasterRows(workbookRows([
+      workbookProductRow({ effectiveTo:'2026-08-24', current:'否' }),
+      workbookProductRow({ version:'2026-08-26', effectiveFrom:'2026-08-25', productName:'changed' }),
+    ]), workbookAliasRows()),
+    /changes stable fields/,
+  );
+  assert.throws(
+    () => catalogFromProductMasterRows(workbookRows([workbookProductRow({ current:'否' })]), workbookAliasRows()),
+    /current version and effective date end disagree/,
+  );
+  assert.throws(
+    () => catalogFromProductMasterRows(workbookRows([
+      workbookProductRow(),
+      workbookProductRow({ productSku:'GTP02', version:'2026-08-25.2' }),
+    ]), workbookAliasRows()),
+    /reuses 7GTPD013AB/,
+  );
+});
+
+test('workbook compiler keeps unknown origin separate and requires a factory only for active products', () => {
+  const incomplete = catalogFromProductMasterRows(workbookRows([
+    workbookProductRow({
+      productName:'',
+      origin:'待補',
+      factory:'待補',
+      aliases:'',
+      lifecycle:'資料待補',
+      unitsPerCarton:null,
+      cartonsPerPallet:null,
+      length:null,
+      width:null,
+      height:null,
+    }),
+  ]), workbookAliasRows([]));
+  assert.equal(incomplete.products[0].origin, null);
+  assert.equal(incomplete.products[0].standardFactory, null);
+  assert.equal(incomplete.products[0].packagingVersions[0].unitsPerCarton, null);
+  assert.equal(incomplete.products[0].packagingVersions[0].cartonsPerPallet, null);
+  assert.equal(incomplete.products[0].packagingVersions[0].cartonDimensionsCm, null);
+
+  assert.throws(
+    () => catalogFromProductMasterRows(workbookRows([
+      workbookProductRow({ factory:'待補' }),
+    ]), workbookAliasRows()),
+    /standardFactory must be known for an active product/,
+  );
+
+  assert.throws(
+    () => catalogFromProductMasterRows(workbookRows([
+      workbookProductRow({ cartonsPerPallet:null }),
+    ]), workbookAliasRows()),
+    /cartonsPerPallet must be known unless the product is incomplete/,
+  );
+});
+
+test('checked canonical catalog and generated Supply snapshot stay in sync', () => {
+  const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+  const expected = renderSupplyProductData(compileCatalog(canonical, supplyCatalogAdapter));
+  const actual = fs.readFileSync(path.join(repoRoot, 'product-data.js'), 'utf8');
+
+  assert.equal(actual, expected);
+  assert.equal(canonical.schemaVersion, 2);
+  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.match(canonical.catalogVersion, /^\d{4}-\d{2}-\d{2}(?:\.\d+)?$/);
+});
+
+test('migration preserves 15 legacy Supply packages and makes the FBA 2026-08-25 rows current', () => {
+  const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+  const expectedUnits = new Map(Object.entries({
+    '1ABRD002A0':[36, 42],
+    GTAL01:[30, 38],
+    GTB05:[90, 100],
+    GTBL01:[26, 30],
+    GTBL03:[28, 30],
+    GTBL05:[24, 30],
+    GTCL01:[28, 30],
+    GTP03:[90, 100],
+    GTP05:[90, 100],
+    GTPL01:[24, 30],
+    GTPL03:[24, 30],
+    GTPL05:[24, 30],
+    GTRL01:[22, 30],
+    GTRL03:[28, 30],
+    GTSL01:[24, 30],
+  }));
+  const versioned = canonical.products.filter(product => product.packagingVersions.length > 1);
+
+  assert.equal(versioned.length, expectedUnits.size);
+  for (const product of versioned) {
+    const [historical, current] = product.packagingVersions;
+    assert.deepEqual(
+      [historical.unitsPerCarton, current.unitsPerCarton],
+      expectedUnits.get(product.productSku),
+      product.productSku,
+    );
+    assert.equal(historical.effectiveFrom, '2026-07-19', product.productSku);
+    assert.equal(historical.effectiveTo, '2026-08-24', product.productSku);
+    assert.equal(current.effectiveFrom, '2026-08-25', product.productSku);
+    assert.equal(current.effectiveTo, null, product.productSku);
+    assert.equal(current.source.sheet, 'AMZ 所有SKU', product.productSku);
+  }
+
+  const gtp03 = versioned.find(product => product.productSku === 'GTP03');
+  assert.deepEqual(gtp03.packagingVersions[1].cartonDimensionsCm, [58.5, 34.5, 35]);
+  assert.equal(gtp03.packagingVersions[1].cartonsPerPallet, 36);
+  assert.equal(gtp03.packagingVersions[1].grossWeightLb, 26.455471462185308);
+
+  const unknownOrigin = canonical.products.find(product => product.productSku === '1AWDD010A0');
+  assert.equal(unknownOrigin.standardFactory, 'VN');
+  assert.equal(unknownOrigin.origin, null);
+});
+
+test('canonical union retains 25 FBA-only Product SKUs without exposing incomplete rows to Supply', () => {
+  const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+  const expectedFbaOnly = [
+    '1AWDD773A0', '1AWDD775A0', '1AXXD001A0', '1AXXD002A0', '1GLTD011A0',
+    '1GXXD001A0', '1GXXD002A0', '1VFPD010A0', '1VFPD018A0', '1VFPD050A0',
+    '1VFPD058A0', '1VFRD010A0', '1VFSD010A0', '1VFSD018A0', 'ED011AM',
+    'EZD010', 'EZD010-3', 'EZD020', 'EZD020-3', 'EZD040', 'EZD040-3',
+    'EZD050', 'EZD050-3', 'EZD060', 'EZD060-3',
+  ];
+  const bySku = new Map(canonical.products.map(product => [product.productSku, product]));
+
+  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.equal(canonical.products.length, 360);
+  for (const productSku of expectedFbaOnly) {
+    const product = bySku.get(productSku);
+    assert.ok(product, productSku);
+    assert.equal(product.productName, '', productSku);
+    assert.equal(product.origin, null, productSku);
+    assert.equal(product.standardFactory, null, productSku);
+    assert.equal(product.lifecycle, 'incomplete', productSku);
+    assert.deepEqual(product.approvedOrderSkus, [productSku], productSku);
+    assert.equal(product.packagingVersions[0].cartonsPerPallet, null, productSku);
+  }
+
+  const projected = compileCatalog(canonical, supplyCatalogAdapter);
+  assert.equal(projected.products.length, 335);
+  assert.equal(projected.products.some(product => expectedFbaOnly.includes(product.productCode)), false);
+
+  const airDried = bySku.get('1AWDD773A0').packagingVersions[0];
+  assert.equal(airDried.unitsPerCarton, 38);
+  assert.deepEqual(airDried.cartonDimensionsCm, [50.8, 40.64, 30.48]);
+  assert.equal(airDried.grossWeightLb, 43);
+
+  const aliasLikeProduct = bySku.get('ED011AM').packagingVersions[0];
+  assert.equal(aliasLikeProduct.unitsPerCarton, null);
+  assert.equal(aliasLikeProduct.cartonDimensionsCm, null);
+  assert.equal(aliasLikeProduct.grossWeightLb, null);
+});
+
+test('FBA HEAD positive-weight baseline remains complete in canonical current packaging', () => {
+  const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+  const currentPackaging = new Map(canonical.products.map(product => [
+    product.productSku,
+    product.packagingVersions.find(packaging => packaging.effectiveTo === null),
+  ]));
+  const positiveWeights = [...currentPackaging.values()]
+    .filter(packaging => typeof packaging.grossWeightLb === 'number' && packaging.grossWeightLb > 0);
+
+  // Derived from FBA HEAD 07cf8cd after BUILTIN_CATALOG_ADDITIONS overwrites BUILTIN_CATALOG.
+  assert.equal(positiveWeights.length, 269);
+  assert.equal(currentPackaging.get('AFA12AM').grossWeightLb, 34);
+  assert.equal(currentPackaging.get('VBS03').grossWeightLb, 40);
+  assert.equal(currentPackaging.get('GTB03').grossWeightLb, 26);
+});
+
+test('schema v2 retains the 27 FBA legacy 7-SKU packages plus the initialized ATS01 alias', () => {
+  const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+  const validated = validateCatalog(canonical);
+  const expectedFba = {
+    '7ATRD013AB':[100, 21], '7ATSD010AB':[100, 24], '7ATSD017AB':[30, 22], '7ATSD019AB':[8, 22],
+    '7GTBD013AB':[100, 21], '7GTBD017AB':[26, 30], '7GTBD037AB':[28, 32], '7GTBD053AB':[90, 25],
+    '7GTBD057AB':[24, 27], '7GTPD013AB':[100, 21], '7GTPD017AB':[24, 27], '7GTPD037AB':[24, 27],
+    '7GTPD053AB':[90, 25], '7GTPD057AB':[24, 27], '7GTRD013AB':[100, 21], '7GTRD017AB':[22, 25],
+    '7GTRD037AB':[28, 32], '7GTSD013AB':[100, 24], '7GTSD017AB':[24, 24], '7VTBD015AB':[50, 17],
+    '7VTBD410AB':[90, 18], '7VTRD015AB':[50, 17], '7VTRD215AB':[25, 18], '7VTSD013AB':[100, 24],
+    '7VTSD017AB':[24, 29], '7VTSD513AB':[20, 24], '7VTSD913AB':[10, 24],
+  };
+  const aliases = new Map(validated.orderSkuAliases.map(alias => [alias.orderSku, alias]));
+  const products = new Map(validated.products.map(product => [product.productSku, product]));
+
+  assert.equal(canonical.schemaVersion, 2);
+  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.equal(aliases.size, 28);
+  assert.equal(validated.orderSkuAliases.filter(alias => alias.lifecycle === 'approved').length, 22);
+  assert.deepEqual(
+    validated.orderSkuAliases.filter(alias => alias.lifecycle === 'unmapped-legacy').map(alias => alias.orderSku).sort(),
+    ['7VTBD015AB', '7VTRD015AB', '7VTRD215AB', '7VTSD017AB', '7VTSD513AB', '7VTSD913AB'],
+  );
+
+  for (const [orderSku, [unitsPerCarton, grossWeightLb]] of Object.entries(expectedFba)) {
+    const alias = aliases.get(orderSku);
+    assert.ok(alias, orderSku);
+    assert.equal(alias.currentPackaging.unitsPerCarton, unitsPerCarton, orderSku);
+    assert.deepEqual(alias.currentPackaging.cartonDimensionsCm, [50.8, 40.64, 30.48], orderSku);
+    assert.equal(alias.currentPackaging.grossWeightLb, grossWeightLb, orderSku);
+  }
+
+  const fbaBackedMapped = validated.orderSkuAliases.filter(alias => alias.lifecycle === 'approved'
+    && alias.orderSku !== '7ATSD011AB');
+  assert.equal(fbaBackedMapped.length, 21);
+  assert.equal(fbaBackedMapped.filter(alias => {
+    const owner = products.get(alias.canonicalProductSku).currentPackaging;
+    return alias.currentPackaging.unitsPerCarton !== owner.unitsPerCarton
+      || JSON.stringify(alias.currentPackaging.cartonDimensionsCm) !== JSON.stringify(owner.cartonDimensionsCm)
+      || alias.currentPackaging.grossWeightLb !== owner.grossWeightLb;
+  }).length, 21);
+
+  const ats = aliases.get('7ATSD011AB');
+  const atsOwner = products.get('ATS01');
+  assert.equal(ats.canonicalProductSku, 'ATS01');
+  assert.equal(ats.currentPackaging.unitsPerCarton, atsOwner.currentPackaging.unitsPerCarton);
+  assert.deepEqual(ats.currentPackaging.cartonDimensionsCm, atsOwner.currentPackaging.cartonDimensionsCm);
+  assert.equal(ats.currentPackaging.grossWeightLb, null);
+  assert.equal(atsOwner.currentPackaging.grossWeightLb, 26);
+});


### PR DESCRIPTION
## 內容
- 以版本化 canonical catalog 統一 Supply 與 FBA 產品資料來源
- 分離 Product SKU 與 7 字頭 Order SKU Alias 專屬箱規
- 保留歷史包裝、實際產地與標準下單廠別
- 將 coverage 改為 Apple 風半透明玻璃樣式，維持 180 / 365 天門檻
- 增加 Excel 雙表匯入、資料完整性與防退化驗證

## 驗證
- 258/258 Node tests
- 13/13 Playwright browser tests
- catalog check、build、dist hash 驗證通過
- Excel 360 Product SKU、28 aliases 可 byte-identical roundtrip
- FBA 舊 307 lookup 無 SKU、箱入、尺寸或重量遺失

Closes #68