### PR TITLE
Import shared product catalog from raw workbook

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,3 +71,7 @@ _Avoid_: Half-pallet rule, arbitrary decimal
 **Workspace Snapshot**:
 The raw uploaded source files, pasted H10 text, metadata, and small workspace preferences retained in the current browser so the workspace can be reconstructed after refresh.
 _Avoid_: Cloud backup, exported order
+
+**Shared Product Catalog**:
+The normalized SKU, origin, carton, pallet, and weight facts parsed from the operator's existing raw product-information workbook and stored under one same-origin browser key for Supply and FBA. It overlays each site's checked-in fallback without requiring an extra maintenance worksheet.
+_Avoid_: ProductMasterTable, cloud product database, cross-site fetch

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Only `dist/` is deployable. Repository files, tests, documentation, credentials,
 
 ## Shared product catalog
 
-Supply and FBA are generated from one versioned Excel product master. The workbook contract, public-data boundary, validation rules, and two-site release flow are documented in [docs/product-catalog.md](docs/product-catalog.md).
+The normal maintenance path is the existing raw product-information workbook. Drop it into Supply's main upload area or FBA's product-database updater; the browser reads `AMZ 所有SKU`, `2026`, and `罐頭`, stores one same-origin catalog locally, and both tools use it after refresh. No extra `產品主檔` worksheet is required.
 
-```sh
-npm run catalog:import -- --input <workbook.xlsx> --output catalog/product-catalog.json
-npm run catalog:build
-npm run catalog:check
-```
-
-`catalog/product-catalog.json` and `product-data.js` are generated release artifacts. Do not maintain either file by hand.
+The checked-in canonical catalog and site-specific snapshots remain release-time fallbacks. They are generated artifacts, not another workbook the operator must maintain. See [docs/product-catalog.md](docs/product-catalog.md).

--- a/docs/adr/0003-use-one-versioned-product-catalog.md
+++ b/docs/adr/0003-use-one-versioned-product-catalog.md
@@ -1,5 +1,7 @@
 # Use one versioned product catalog
 
+Operator-maintenance portion superseded by ADR 0004. The canonical schema and per-site fallback design remain in force.
+
 Supply and FBA will treat the same Excel workbook and its `ProductMasterTable` plus `OrderSkuPackagingTable` as the only manually maintained product source, validate them into one versioned canonical catalog, and fan out project-specific snapshots at build time. The canonical JSON and site-specific JavaScript are generated release artifacts, not additional manual sources. This keeps runtime callers synchronous and independent of network, cache, and cross-repository availability while making `schemaVersion` and `catalogVersion` explicit release contracts.
 
 ## Consequences

--- a/docs/adr/0004-import-the-existing-raw-product-workbook.md
+++ b/docs/adr/0004-import-the-existing-raw-product-workbook.md
@@ -1,0 +1,14 @@
+# Import the existing raw product workbook
+
+The normal operator workflow will accept the existing product-information Excel directly. Supply and FBA recognize `AMZ 所有SKU`, `2026`, and `罐頭`, normalize their public packaging fields into one versioned same-origin browser payload, and keep that payload after refresh. The first complete duplicate row wins so a stale alternate carton row cannot overwrite the current row.
+
+This supersedes ADR 0003's requirement that the operator maintain added `產品主檔` and `下單品號箱規` worksheets. The canonical schema, Product SKU versus Order SKU Alias distinction, public-field allowlist, and checked-in per-site fallbacks remain. The extra workbook sheets and compiler may remain as release/migration tooling, but they are not the maintenance interface.
+
+## Consequences
+
+- Jasper maintains the original workbook only and can upload it from either website.
+- Both pages share `jspusa:shared-product-catalog:v1` because they are served from the same `jspusa.github.io` origin.
+- The raw file itself is never uploaded to GitHub Pages or another server; only the normalized public packaging payload stays in that browser.
+- Missing raw values do not erase complete built-in values. New non-7 SKU rows enter Supply only when origin, carton quantity, carton dimensions, and cartons per pallet are usable; FBA may still use partial rows and its existing repair flow.
+- 7-prefixed rows update FBA packaging only. Existing confirmed alias ownership remains in the checked-in canonical fallback and is never guessed from the raw SKU spelling.
+- Removing browser data or choosing “restore built-in” returns both tools to their checked-in snapshots.

--- a/docs/product-catalog.md
+++ b/docs/product-catalog.md
@@ -1,8 +1,10 @@
-# 共用產品主檔規格
+# 共用產品資料規格
 
-Supply 與 FBA 使用同一份 Excel 的 `產品主檔` 與 `下單品號箱規` 工作表作為唯一人工維護來源。Canonical JSON、Supply 的 `product-data.js` 與 FBA 的 snapshot 都是生成檔，不得手動修改。
+日常維護只使用既有產品資訊原始 Excel，不要求新增 `產品主檔` 或 `下單品號箱規`。把原始檔丟到 Supply 或 FBA 後，兩站會讀取 `AMZ 所有SKU`、`2026`、`罐頭`，將可公開的產品箱規保存在同一個瀏覽器的 `jspusa:shared-product-catalog:v1`，並共同套用到各自的內建備援。
 
-## ProductMasterTable
+下列 ProductMasterTable／OrderSkuPackagingTable 是內建版本發布與資料遷移的 canonical schema，不是 Jasper 平常要維護的 Excel 工作表。Canonical JSON、Supply 的 `product-data.js` 與 FBA snapshot 仍不得手動修改。
+
+## 內建備援：ProductMasterTable
 
 表頭固定在第 5 列；每一列代表一個 Product SKU 的一個包裝版本。
 
@@ -25,7 +27,7 @@ Supply 與 FBA 使用同一份 Excel 的 `產品主檔` 與 `下單品號箱規`
 | 資料來源工作表／來源列 | 初次轉換與衝突稽核證據 |
 | 備註／發布檢查 | 維護說明與公式檢查結果；只有 `⚠` 會阻止發布，未知產地與資料待補會誠實標示但不假造資料 |
 
-## OrderSkuPackagingTable
+## 內建備援：OrderSkuPackagingTable
 
 `下單品號箱規` 表頭同樣固定在第 5 列；每列代表一個 7 字頭 Order SKU Alias 的一個包裝版本。箱入數、尺寸與重量只有在 Order SKU 層級真實不同時才放這裡；不會複製需求、庫存或 coverage。
 
@@ -57,13 +59,17 @@ Supply 與 FBA 使用同一份 Excel 的 `產品主檔` 與 `下單品號箱規`
 
 公開 catalog 只允許 Product SKU、品名、產地、標準下單廠別、核准 Order SKU、包裝版本、箱規、箱重、棧板數與生命週期。成本、報價、供應商、聯絡方式、庫存、銷速、open orders、Order Draft、憑證與原始 Excel 檔不得進入 GitHub Pages artifact。
 
-## 發布流程
+## 日常維護流程
 
-1. 在 Excel 的 `ProductMasterTable` 維護產品包裝，並在 `OrderSkuPackagingTable` 維護 7 字頭專屬箱規；新增資料列時使用 Excel 表格列，發布檢查會以動態表格範圍計算。
-2. 執行 `npm run catalog:import -- --input <xlsx> --output catalog/product-catalog.json`。
-3. 確認兩張表的發布檢查都沒有 `⚠`，再檢查 old → new 差異與 catalog 測試；`可發布 · 產地待補` 與 `資料待補（僅 FBA）` 是允許發布的誠實狀態。
-4. 執行 `npm run catalog:build` 生成 Supply 的同步 legacy adapter。
-5. 在 FBA 專案執行 `npm run generate:catalog -- --source ../Supply/catalog/product-catalog.json`。
-6. 兩站各自完成測試、build、Pages 部署與 live catalogVersion/hash 驗證後，才可宣稱同步發布完成。
+1. 照原本方式更新產品資訊原始 Excel；不要新增額外工作表。
+2. 在 Supply「資料」頁把它和 JAM／H10／JSP 一起丟入，或到 FBA「備用：更新產品資訊資料庫」單獨上傳。
+3. 系統會自動辨識三張工作表、保存第一筆完整的重複 SKU，並顯示讀取 SKU 數量與衝突數。
+4. 重新整理、切換 Supply／FBA 後仍會使用同一份資料；按「恢復內建備援」才會移除。
+
+原始 Excel 不會上傳至 GitHub 或伺服器。瀏覽器共用資料只含 SKU、產地、箱入數、紙箱尺寸、箱／棧板、箱毛重、來源工作表與來源列；缺值不會清掉內建完整值。
+
+## 內建備援發布流程
+
+需要把新資料固化成所有瀏覽器的預設值時，才執行 canonical 匯入、old → new 差異檢查、`npm run catalog:build`、FBA 投影、兩站測試與 Pages 發布。平常上傳原始檔不需要走這套開發流程。
 
 兩個網站在 runtime 都使用各自已驗證的本地 snapshot，不會互相 fetch，因此其中一站暫時無法連線不會拖垮另一站。更新失敗時保留上一個已發布版本。

--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@
     .downloadLinks { display:flex; flex-wrap:wrap; gap:7px; margin-bottom:12px; }
     .downloadLinkChip { display:inline-flex; align-items:center; gap:5px; padding:7px 10px; border:1px solid #dbeafe; border-radius:999px; background:#eff6ff; color:#1d4ed8; font-size:12px; font-weight:800; text-decoration:none; }
     .downloadLinkChip:hover { border-color:#60a5fa; background:#dbeafe; }
-    .uploadStatusRow { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; margin-top:11px; }
+    .uploadStatusRow { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; margin-top:11px; }
     .uploadStatus { display:flex; align-items:center; gap:7px; min-height:38px; padding:8px 10px; border-radius:12px; background:#f1f5f9; color:#64748b; font-size:11px; font-weight:800; }
     .uploadStatus::before { content:""; width:8px; height:8px; border-radius:50%; background:#f59e0b; flex:0 0 auto; }
     .uploadStatus.ready { background:#ecfdf5; color:#166534; }
@@ -567,6 +567,7 @@
       .heroActions button { flex: 1; }
       .controlDock { position: static; border-radius: 22px; }
       .controlGroup, .togglePill { width: 100%; justify-content: space-between; }
+      .uploadStatusRow { grid-template-columns:repeat(2,minmax(0,1fr)); }
       .subGrid { grid-template-columns: 1fr; }
       .card summary { flex-direction: column; align-items: flex-start; gap: 12px; }
       .summary-actions { width: 100%; }
@@ -892,22 +893,24 @@
 
           <div class="uploadWorkspace">
             <section class="uploadPrimaryPanel">
-              <div class="uploadPanelTitle"><h3><i class="fa-solid fa-cloud-arrow-up"></i> 三個檔案一起丟這裡</h3><span class="pill">自動分類</span></div>
+              <div class="uploadPanelTitle"><h3><i class="fa-solid fa-cloud-arrow-up"></i> 四個原始檔一起丟這裡</h3><span class="pill">自動分類</span></div>
               <div class="downloadLinks" aria-label="下載來源">
                 <a class="downloadLinkChip" href="https://24466647-my.sharepoint.com/:x:/g/personal/hongren_petlifeco_com/ER_jNs_oIg9JlOmxXlpGb6sBG3yRl9Zd7gzqAfH_q3WL1A?CID=bbf41374-a2d3-7260-37b3-d7bdd684d58e&amp;e=ocBSqj" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-file-excel"></i> 1. JAM 訂單</a>
                 <a class="downloadLinkChip" href="https://members.helium10.com/inventory-management/restock-suggestions-new/index?accountId=1547156136" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-chart-line"></i> 2. H10</a>
                 <a class="downloadLinkChip" href="https://24466647.sharepoint.com/:x:/r/sites/Cloud/Shared%2520Documents/%E7%8F%8D%E9%A3%9F%E5%A0%A1%2520-%2520%E5%85%B1%E7%94%A8/JSP%2520Amrica/Inventory%2520update%2520with%2520expiration%2520date%2520-%2520temporary%2520file.xlsx?d=wdb6b7635090543b0b4433ce8572b2c4a&amp;e=4%3ab1c52cfb6a554376882e5c1e30fa2339&amp;sharingv2=true&amp;fromShare=true&amp;at=9" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-warehouse"></i> 3. JSP 庫存</a>
+                <a class="downloadLinkChip" href="https://24466647-my.sharepoint.com/:x:/r/personal/hongren_petlifeco_com/_layouts/15/Doc.aspx?sourcedoc=%7BE5CC3B4A-0A68-44FC-B4BA-8A535837639D%7D&amp;file=20260324%25u7f8e%25u570b%25u7522%25u54c1%25u8cc7%25u8a0a%20JAM%20chuy%25u1ec3n%20%25u0111%25u00e0i%20loan.xlsx&amp;fromShare=true&amp;action=default&amp;mobileredirect=true" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-boxes-stacked"></i> 4. 產品資訊</a>
               </div>
               <label class="fileDropZone masterUploadZone">
                 <input type="file" id="masterFileInput" multiple accept=".xlsx,.xls,.csv,.txt" />
                 <i class="fa-solid fa-cloud-arrow-up dropIcon"></i>
-                <span>點擊選檔，或一次拖入 JAM／H10／JSP</span>
+                <span>點擊選檔，或一次拖入 JAM／H10／JSP／產品資訊</span>
                 <span class="dropSub">不用照順序，系統會自動辨識</span>
               </label>
               <div class="uploadStatusRow">
                 <div class="uploadStatus" id="uploadStatusJam">JAM 等待檔案</div>
                 <div class="uploadStatus" id="uploadStatusH10">H10 等待檔案</div>
                 <div class="uploadStatus" id="uploadStatusJsp">JSP 等待檔案</div>
+                <div class="uploadStatus" id="uploadStatusCatalog">產品資料使用內建版</div>
               </div>
               <div class="jamMetaBox" id="masterMetaBox" style="margin-top:10px;">尚未使用總檔案上傳。</div>
               <div class="jamMetaBox workspaceSnapshotState" id="workspaceSnapshotState" role="status" aria-live="polite">公開版原始資料只會保存在這個瀏覽器。</div>
@@ -958,6 +961,14 @@
                   <div class="row" style="justify-content:flex-end;"><button type="button" class="secondary" id="btnParseJspInventory">重新讀取</button></div>
                   <div class="jamMetaBox" id="jspMetaBox">尚未讀取 JSP 庫存檔。</div>
                   <details class="manualInputDetails"><summary>手動輸入備援 <span>展開</span></summary><div class="manualInputBody"><textarea id="inputUSJsp" placeholder="SKU + 總數"></textarea></div></details>
+                </div>
+              </div>
+              <div class="subCard">
+                <div class="subCardHeader">Supply／FBA 共用產品資訊</div>
+                <div class="subCardContent">
+                  <label class="fileDropZone"><input type="file" id="productCatalogInput" accept=".xlsx,.xlsm,.xls" /><i class="fa-solid fa-boxes-stacked dropIcon"></i><span>直接上傳原始產品資訊 Excel</span></label>
+                  <div class="row" style="justify-content:flex-end;"><button type="button" class="secondary" id="btnResetProductCatalog">恢復內建備援</button></div>
+                  <div class="jamMetaBox" id="productCatalogMetaBox">尚未上傳原始檔，目前使用內建產品資料。</div>
                 </div>
               </div>
             </div>
@@ -1332,6 +1343,7 @@
 
   <script src="./vendor/xlsx.full.min.js"></script>
   <script src="./product-data.js"></script>
+  <script src="./shared/shared-product-catalog.js"></script>
   <script type="module" src="./shared/legacy-planning-adapter.js"></script>
   <script type="module" src="./shared/order-draft-state.js"></script>
   <script type="module" src="./shared/workspace-snapshot.js"></script>
@@ -1460,6 +1472,70 @@
     let workspaceClearInProgress = false;
 
     const productMap = new Map(allProducts.map(p => [normalizeSkuKey(p.productCode), p]));
+    const builtInProducts = (window.SUPPLY_BUILTIN_PRODUCT_DATA || allProducts).map(product => ({ ...product }));
+    const sharedCatalogApi = window.JSPSharedProductCatalog;
+
+    function activeSharedProductCatalog() {
+      return sharedCatalogApi?.loadFromStorage(localStorage) || null;
+    }
+
+    function rebuildProductMap() {
+      productMap.clear();
+      allProducts.forEach(product => productMap.set(normalizeSkuKey(product.productCode), product));
+    }
+
+    function renderSharedProductCatalogMeta(payload = activeSharedProductCatalog(), result = null) {
+      const meta = document.getElementById('productCatalogMetaBox');
+      if (meta) {
+        if (!payload) meta.textContent = `目前使用內建產品資料（${builtInProducts.length} 個品號）。上傳一次原始檔後，重新整理仍會保留。`;
+        else {
+          const updated = new Date(payload.updatedAt).toLocaleString('zh-TW', { hour12:false });
+          const extra = result ? `；Supply 更新 ${result.updated}、新增 ${result.added}` : '';
+          meta.textContent = `已共用：${payload.sourceFile} · ${payload.records.length} 個 SKU · ${updated}${extra}`;
+        }
+      }
+      const status = document.getElementById('uploadStatusCatalog');
+      if (status) {
+        status.classList.add('ready');
+        status.textContent = payload ? '產品資料 已共用原始檔' : '產品資料 內建備援';
+      }
+    }
+
+    async function parseSharedProductCatalogFile(file, existingWorkbook = null) {
+      if (!file) throw new Error('請先選擇產品資訊 Excel');
+      if (!sharedCatalogApi || typeof XLSX === 'undefined') throw new Error('產品資料讀取元件尚未準備完成，請重新整理');
+      const workbook = existingWorkbook || XLSX.read(await file.arrayBuffer(), { type:'array', cellDates:false });
+      let payload = sharedCatalogApi.createPayload(workbook, XLSX, { sourceFile:file.name });
+      payload = sharedCatalogApi.saveToStorage(payload, localStorage);
+      allProducts.splice(0, allProducts.length, ...builtInProducts.map(product => ({ ...product })));
+      const result = sharedCatalogApi.applyToSupplyProducts(allProducts, payload);
+      rebuildProductMap();
+      window.SUPPLY_SHARED_PRODUCT_CATALOG_META = Object.freeze({
+        sourceFile:payload.sourceFile,
+        updatedAt:payload.updatedAt,
+        records:payload.records.length,
+        added:result.added,
+        updated:result.updated,
+      });
+      renderSharedProductCatalogMeta(payload, result);
+      if (!workspaceBatching) buildTables();
+      updateWorkflowUi();
+      showTip(`產品資料已保存並與 FBA 共用（${payload.records.length} 個 SKU）`, 'success');
+      return { payload, result };
+    }
+
+    function resetSharedProductCatalog() {
+      sharedCatalogApi?.removeFromStorage(localStorage);
+      allProducts.splice(0, allProducts.length, ...builtInProducts.map(product => ({ ...product })));
+      rebuildProductMap();
+      delete window.SUPPLY_SHARED_PRODUCT_CATALOG_META;
+      const input = document.getElementById('productCatalogInput');
+      if (input) input.value = '';
+      renderSharedProductCatalogMeta(null);
+      buildTables();
+      updateWorkflowUi();
+      showTip('已恢復內建產品資料；FBA 也會使用內建備援', 'success');
+    }
     const h10El = document.getElementById('inputH10');
     const ordersEl = document.getElementById('inputOrders');
     const usAmzEl = document.getElementById('inputUSAmz');
@@ -1535,6 +1611,7 @@
       setUploadStatus('uploadStatusJam', jamReady, 'JAM 已代入', 'JAM 等待檔案');
       setUploadStatus('uploadStatusH10', h10Ready, 'H10 已代入', 'H10 等待檔案');
       setUploadStatus('uploadStatusJsp', jspReady, 'JSP 已代入', 'JSP 等待檔案');
+      renderSharedProductCatalogMeta();
       const issueCount = Array.isArray(window.latestDecisionExport?.issues) ? window.latestDecisionExport.issues.length : (typeof latestDecisionExport !== 'undefined' ? latestDecisionExport.issues.length : 0);
       setHealthStatus('healthIssues', issueCount ? 'bad' : (h10Ready ? 'ready' : 'warn'), h10Ready ? `${issueCount} 筆` : '等待計算');
       workspaceUiController?.renderToday();
@@ -2690,12 +2767,13 @@
 
     async function autoClassifyAndReadFiles(fileList, options = {}) {
       const files = Array.from(fileList || []);
-      if (!files.length) return { files: [], results: [], recognizedTypes: [], classifiedSources: [], failedCount: 0, unrecognizedCount: 0 };
+      if (!files.length) return { files: [], results: [], recognizedTypes: [], classifiedSources: [], catalogFiles: [], failedCount: 0, unrecognizedCount: 0 };
       const sourceObservedOn = Object.prototype.hasOwnProperty.call(options, 'sourceObservedOn') ? options.sourceObservedOn : getPlanningAsOfDate();
       const sourceSelectedAt = options.sourceSelectedAt || new Date().toISOString();
       const results = [];
       const recognizedTypes = new Set();
       const classifiedSources = [];
+      const catalogFiles = [];
       const h10TextParts = [];
       let failedCount = 0;
       let unrecognizedCount = 0;
@@ -2739,6 +2817,14 @@
           const { workbook, rows } = await readWorkbookRowsFromFile(file);
           const sheetNames = workbook?.SheetNames || [];
           const firstRowsText = rows.slice(0, 8).flat().map(v => String(v ?? '')).join(' ');
+
+          if (sharedCatalogApi?.isRawWorkbook(workbook)) {
+            const imported = await parseSharedProductCatalogFile(file, workbook);
+            recognizedTypes.add('catalog');
+            catalogFiles.push(file);
+            results.push(`${file.name} → Supply／FBA 共用產品資料（${imported.payload.records.length} 個 SKU）`);
+            continue;
+          }
 
           if (sheetNames.some(name => String(name).includes('美國總表')) || firstRowsText.includes('尚未到美國倉庫')) {
             await parseJamExcelFile(file);
@@ -2790,7 +2876,7 @@
       if (!workspaceBatching) buildTables();
       updateWorkflowUi();
       if (!options.silent) showTip(`總檔案上傳已處理 ${files.length} 個檔案`, failedCount || unrecognizedCount ? 'error' : 'success');
-      return { files, results, recognizedTypes: Array.from(recognizedTypes), classifiedSources, failedCount, unrecognizedCount };
+      return { files, results, recognizedTypes: Array.from(recognizedTypes), classifiedSources, catalogFiles, failedCount, unrecognizedCount };
     }
 
     const BOSS_REQUIRED_FILE_TYPES = [
@@ -3434,7 +3520,8 @@
 
     function rememberBossFiles(files, analysis) {
       if (!IS_BOSS_PORTAL) return;
-      bossPendingFiles = Array.from(files || []);
+      const localOnlyCatalogFiles = new Set(analysis?.catalogFiles || []);
+      bossPendingFiles = Array.from(files || []).filter(file => !localOnlyCatalogFiles.has(file));
       bossPendingAnalysis = analysis || null;
       const recognized = new Set(analysis?.recognizedTypes || []);
       const missing = BOSS_REQUIRED_FILE_TYPES.filter(item => !recognized.has(item.key));
@@ -3648,6 +3735,8 @@
               await parseAndRememberWorkspaceFile(input.id, firstFile, parseAmzInventoryFile);
             } else if (input.id === 'jspInventoryInput') {
               await parseAndRememberWorkspaceFile(input.id, firstFile, parseJspInventoryFile);
+            } else if (input.id === 'productCatalogInput') {
+              await parseSharedProductCatalogFile(firstFile);
             } else if (input.id === 'salesBusinessReportInput') {
               await parseAndRememberWorkspaceFile(input.id, firstFile, parseSalesBusinessReportFile);
             } else {
@@ -3674,12 +3763,15 @@
     document.getElementById('jamExcelInput')?.addEventListener('change', () => handleFileAutoRead('jamExcelInput', parseJamExcelFile, "請先選擇 JAM Excel 檔案"));
     document.getElementById('amzInventoryInput')?.addEventListener('change', () => handleFileAutoRead('amzInventoryInput', parseAmzInventoryFile, "請先選擇 H10 檔案"));
     document.getElementById('jspInventoryInput')?.addEventListener('change', () => handleFileAutoRead('jspInventoryInput', parseJspInventoryFile, "請先選擇 JSP 庫存檔"));
+    document.getElementById('productCatalogInput')?.addEventListener('change', event => parseSharedProductCatalogFile(event.target.files?.[0]).catch(error => { console.error(error); showTip(error.message || '產品資料讀取失敗', 'error'); }));
+    document.getElementById('btnResetProductCatalog')?.addEventListener('click', resetSharedProductCatalog);
     document.getElementById('masterFileInput')?.addEventListener('change', (event) => handleMasterFileSelection(event.target.files));
     document.getElementById('salesBusinessReportInput')?.addEventListener('change', () => handleFileAutoRead('salesBusinessReportInput', parseSalesBusinessReportFile, '請先選擇 Business Report / 銷售額檔案'));
     document.getElementById('bossSaveSnapshot')?.addEventListener('click', saveBossSnapshot);
     document.getElementById('bossReloadSnapshot')?.addEventListener('click', () => loadBossSnapshot({ scrollToTree:false }));
     if (hideDiscontinuedFilterEl) hideDiscontinuedFilterEl.checked = true;
     setupFileDropZones();
+    renderSharedProductCatalogMeta();
 
     function showSkuJamBreakdown(sku) {
       const key = getCanonicalSku(sku);

--- a/scripts/site-contract.mjs
+++ b/scripts/site-contract.mjs
@@ -13,6 +13,7 @@ export const runtimeFiles = Object.freeze([
   'shared/order-draft-state.js',
   'shared/planning-velocity-history.js',
   'shared/planning-velocity.js',
+  'shared/shared-product-catalog.js',
   'shared/supply-planner.js',
   'shared/workspace-navigation.js',
   'shared/workspace-snapshot.js',

--- a/shared/shared-product-catalog.js
+++ b/shared/shared-product-catalog.js
@@ -1,0 +1,329 @@
+(function initSharedProductCatalog(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (!root) return;
+  root.JSPSharedProductCatalog = api;
+  if (Array.isArray(root.allProductsData)) {
+    root.SUPPLY_BUILTIN_PRODUCT_DATA = root.allProductsData.map(product => ({ ...product }));
+    const payload = api.loadFromStorage(root.localStorage);
+    if (payload) {
+      const result = api.applyToSupplyProducts(root.allProductsData, payload);
+      root.SUPPLY_SHARED_PRODUCT_CATALOG_META = Object.freeze({
+        sourceFile:payload.sourceFile,
+        updatedAt:payload.updatedAt,
+        records:payload.records.length,
+        added:result.added,
+        updated:result.updated,
+      });
+    }
+  }
+})(typeof globalThis === 'object' ? globalThis : this, function sharedProductCatalogFactory() {
+  'use strict';
+
+  const STORAGE_KEY = 'jspusa:shared-product-catalog:v1';
+  const SCHEMA_VERSION = 1;
+  const WANTED_SHEETS = new Set(['AMZ所有SKU', '2026', '罐頭']);
+  const ORIGINS = new Map([
+    ['台灣', 'TW'], ['TW', 'TW'],
+    ['越南', 'VN'], ['VN', 'VN'],
+    ['柬埔寨', 'KH'], ['KH', 'KH'],
+    ['其他', 'OTHER'], ['OTHER', 'OTHER'],
+  ]);
+
+  function text(value) {
+    return value === null || value === undefined ? '' : String(value).trim();
+  }
+
+  function normalizeSku(value) {
+    return text(value).toUpperCase();
+  }
+
+  function normalizeHeader(value) {
+    return text(value).replace(/[\s\u3000\r\n]+/g, '').toLowerCase();
+  }
+
+  function normalizeSheet(value) {
+    return text(value).replace(/[\s\u3000]+/g, '');
+  }
+
+  function positiveNumber(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value > 0 ? value : null;
+    const match = text(value).replace(/,/g, '').match(/-?\d+(?:\.\d+)?/);
+    if (!match) return null;
+    const number = Number(match[0]);
+    return Number.isFinite(number) && number > 0 ? number : null;
+  }
+
+  function parseDimensionsCm(value) {
+    const values = text(value).replace(/,/g, '.').match(/\d+(?:\.\d+)?/g)?.slice(0, 3).map(Number) || [];
+    return values.length === 3 && values.every(number => Number.isFinite(number) && number > 0) ? values : null;
+  }
+
+  function originCode(value) {
+    return ORIGINS.get(text(value).toUpperCase()) || null;
+  }
+
+  function findColumn(headers, tests) {
+    for (let index = 0; index < headers.length; index += 1) {
+      const header = normalizeHeader(headers[index]);
+      if (tests.some(test => typeof test === 'string' ? header.includes(normalizeHeader(test)) : test.test(header))) return index;
+    }
+    return -1;
+  }
+
+  function headerLayout(name, rows) {
+    let headerRow = -1;
+    let sku = -1;
+    for (let row = 0; row < Math.min(rows.length, 8); row += 1) {
+      const index = (rows[row] || []).findIndex(value => normalizeHeader(value) === 'sku');
+      if (index >= 0) { headerRow = row; sku = index; break; }
+    }
+    if (headerRow < 0) return null;
+    const upper = rows[Math.max(0, headerRow - 1)] || [];
+    const lower = rows[headerRow] || [];
+    const combined = Array.from({ length:Math.max(upper.length, lower.length) }, (_, index) => `${upper[index] ?? ''}|${lower[index] ?? ''}`);
+    const normalizedName = normalizeSheet(name);
+    const fallback = normalizedName === 'AMZ所有SKU'
+      ? { origin:2, quantity:4, dimensions:17, pallet:18, weightKg:21, weightLb:22 }
+      : normalizedName === '2026'
+        ? { origin:2, quantity:4, dimensions:12, pallet:13, weightKg:16, weightLb:17 }
+        : { origin:-1, quantity:3, dimensions:12, pallet:-1, weightKg:15, weightLb:16 };
+    const found = {
+      origin:findColumn(combined, ['產地']),
+      quantity:findColumn(combined, ['包數/箱', '罐數/箱', 'goi/thung', 'lon/thung']),
+      dimensions:findColumn(combined, ['紙箱規格', 'quycachthung']),
+      pallet:findColumn(combined, ['箱/棧板', '棧板/箱']),
+      weightLb:findColumn(combined, [/(每箱產品的毛重|紙箱毛重|gw\/箱|gw\/thung).*\|.*lb/i, /gw.*\(lb\)/i]),
+      weightKg:findColumn(combined, [/(每箱產品的毛重|紙箱毛重|gw\/箱|gw\/thung).*\|.*kg/i, /gw.*kg/i]),
+    };
+    for (const key of Object.keys(found)) if (found[key] < 0) found[key] = fallback[key];
+    return { headerRow, sku, ...found };
+  }
+
+  function recordScore(record) {
+    return Number(Boolean(record.origin))
+      + Number(Boolean(record.unitsPerCarton))
+      + Number(Boolean(record.cartonsPerPallet))
+      + (record.cartonDimensionsCm ? 3 : 0)
+      + Number(Boolean(record.grossWeightLb));
+  }
+
+  function coreComplete(record) {
+    return Boolean(record.unitsPerCarton && record.cartonDimensionsCm && record.grossWeightLb);
+  }
+
+  function comparableRecord(record) {
+    return JSON.stringify([
+      record.origin,
+      record.unitsPerCarton,
+      record.cartonsPerPallet,
+      record.cartonDimensionsCm,
+      record.grossWeightLb,
+    ]);
+  }
+
+  function isRawWorkbook(workbook) {
+    return Boolean(workbook?.SheetNames?.some(name => WANTED_SHEETS.has(normalizeSheet(name))));
+  }
+
+  function createPayload(workbook, xlsx, options = {}) {
+    if (!xlsx?.utils?.sheet_to_json) throw new Error('Excel 讀取元件尚未準備完成');
+    const matchedSheets = (workbook?.SheetNames || []).filter(name => WANTED_SHEETS.has(normalizeSheet(name)));
+    if (!matchedSheets.length) throw new Error('找不到「AMZ 所有SKU」、「2026」或「罐頭」工作表');
+    const bySku = new Map();
+    let skipped = 0;
+    let duplicateConflicts = 0;
+
+    for (const name of matchedSheets) {
+      const rows = xlsx.utils.sheet_to_json(workbook.Sheets[name], { header:1, defval:'', raw:true });
+      const layout = headerLayout(name, rows);
+      if (!layout) { skipped += Math.max(0, rows.length - 2); continue; }
+      for (let rowIndex = layout.headerRow + 1; rowIndex < rows.length; rowIndex += 1) {
+        const row = rows[rowIndex] || [];
+        const sku = normalizeSku(row[layout.sku]);
+        if (!/^[0-9A-Z][0-9A-Z-]{2,19}$/.test(sku)) continue;
+        const weightLb = positiveNumber(row[layout.weightLb]);
+        const weightKg = positiveNumber(row[layout.weightKg]);
+        const record = {
+          sku,
+          origin:layout.origin >= 0 ? originCode(row[layout.origin]) : null,
+          unitsPerCarton:positiveNumber(row[layout.quantity]),
+          cartonsPerPallet:layout.pallet >= 0 ? positiveNumber(row[layout.pallet]) : null,
+          cartonDimensionsCm:parseDimensionsCm(row[layout.dimensions]),
+          grossWeightLb:weightLb || (weightKg ? weightKg * 2.2046226218 : null),
+          sourceSheet:text(name),
+          sourceRow:rowIndex + 1,
+        };
+        if (!coreComplete(record)) skipped += 1;
+        const existing = bySku.get(sku);
+        if (!existing) { bySku.set(sku, record); continue; }
+        if (comparableRecord(existing) !== comparableRecord(record)) duplicateConflicts += 1;
+        if ((!coreComplete(existing) && coreComplete(record)) || (!coreComplete(existing) && recordScore(record) > recordScore(existing))) {
+          bySku.set(sku, record);
+        }
+      }
+    }
+
+    return validatePayload({
+      schemaVersion:SCHEMA_VERSION,
+      sourceFile:text(options.sourceFile || '產品資訊 Excel').slice(0, 200),
+      updatedAt:options.updatedAt || new Date().toISOString(),
+      matchedSheets:matchedSheets.map(text),
+      stats:{ skipped, duplicateConflicts },
+      records:[...bySku.values()],
+    });
+  }
+
+  function nullablePositive(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const number = Number(value);
+    if (!Number.isFinite(number) || number <= 0) throw new Error('共用產品資料含有無效數值');
+    return number;
+  }
+
+  function validatePayload(payload) {
+    if (!payload || Number(payload.schemaVersion) !== SCHEMA_VERSION || !Array.isArray(payload.records) || payload.records.length > 5000) {
+      throw new Error('共用產品資料格式不相容');
+    }
+    const seen = new Set();
+    const records = payload.records.map(item => {
+      const sku = normalizeSku(item?.sku);
+      if (!/^[0-9A-Z][0-9A-Z-]{2,19}$/.test(sku) || seen.has(sku)) throw new Error(`共用產品資料含有重複或無效 SKU：${sku || '(空白)'}`);
+      seen.add(sku);
+      const dimensions = item.cartonDimensionsCm == null ? null : item.cartonDimensionsCm.map(nullablePositive);
+      if (dimensions && (dimensions.length !== 3 || dimensions.some(value => value === null))) throw new Error(`${sku} 的紙箱尺寸不完整`);
+      const origin = item.origin == null ? null : text(item.origin).toUpperCase();
+      if (origin && !['TW', 'VN', 'KH', 'OTHER'].includes(origin)) throw new Error(`${sku} 的產地無法辨識`);
+      return {
+        sku,
+        origin,
+        unitsPerCarton:nullablePositive(item.unitsPerCarton),
+        cartonsPerPallet:nullablePositive(item.cartonsPerPallet),
+        cartonDimensionsCm:dimensions,
+        grossWeightLb:nullablePositive(item.grossWeightLb),
+        sourceSheet:text(item.sourceSheet).slice(0, 100),
+        sourceRow:Number.isInteger(Number(item.sourceRow)) && Number(item.sourceRow) > 0 ? Number(item.sourceRow) : null,
+      };
+    });
+    return {
+      schemaVersion:SCHEMA_VERSION,
+      sourceFile:text(payload.sourceFile || '產品資訊 Excel').slice(0, 200),
+      updatedAt:Number.isNaN(Date.parse(payload.updatedAt)) ? new Date().toISOString() : new Date(payload.updatedAt).toISOString(),
+      matchedSheets:Array.isArray(payload.matchedSheets) ? payload.matchedSheets.map(name => text(name).slice(0, 100)) : [],
+      stats:{
+        skipped:Math.max(0, Number(payload.stats?.skipped) || 0),
+        duplicateConflicts:Math.max(0, Number(payload.stats?.duplicateConflicts) || 0),
+      },
+      records,
+    };
+  }
+
+  function saveToStorage(payload, storage) {
+    const validated = validatePayload(payload);
+    if (!storage?.setItem) throw new Error('這個瀏覽器無法保存共用產品資料');
+    storage.setItem(STORAGE_KEY, JSON.stringify(validated));
+    return validated;
+  }
+
+  function loadFromStorage(storage) {
+    if (!storage?.getItem) return null;
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      return raw ? validatePayload(JSON.parse(raw)) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function removeFromStorage(storage) {
+    storage?.removeItem?.(STORAGE_KEY);
+  }
+
+  function applyToFbaCatalog(baseCatalog, payload) {
+    const validated = validatePayload(payload);
+    const catalog = { ...(baseCatalog || {}) };
+    let added = 0;
+    let updated = 0;
+    for (const record of validated.records) {
+      const existing = catalog[record.sku] || {};
+      const next = { ...existing };
+      if (record.unitsPerCarton) next.units = Math.round(record.unitsPerCarton);
+      if (record.cartonDimensionsCm) {
+        [next.length, next.width, next.height] = record.cartonDimensionsCm.map(value => Math.round(value / 2.54));
+      }
+      if (record.grossWeightLb) next.weight = Math.round(record.grossWeightLb);
+      next.source = `${validated.sourceFile} · ${record.sourceSheet}`;
+      catalog[record.sku] = next;
+      if (Object.hasOwn(baseCatalog || {}, record.sku)) updated += 1;
+      else added += 1;
+    }
+    return { catalog, added, updated, total:Object.keys(catalog).length };
+  }
+
+  function formatDimension(value) {
+    return String(Math.round(value * 100) / 100);
+  }
+
+  function supplyCountry(origin) {
+    if (origin === 'TW') return 'TW';
+    if (origin === 'VN' || origin === 'KH') return 'VN';
+    if (origin === 'OTHER') return 'Others';
+    return '';
+  }
+
+  function applyToSupplyProducts(products, payload) {
+    const validated = validatePayload(payload);
+    const next = (Array.isArray(products) ? products : []).map(product => ({ ...product }));
+    const bySku = new Map(next.map((product, index) => [normalizeSku(product?.productCode), index]));
+    let added = 0;
+    let updated = 0;
+    let skipped = 0;
+    for (const record of validated.records) {
+      if (record.sku.startsWith('7')) continue;
+      const index = bySku.get(record.sku);
+      if (index !== undefined) {
+        const product = next[index];
+        if (record.unitsPerCarton) product.perCarton = Math.round(record.unitsPerCarton);
+        if (record.cartonsPerPallet) product.perPallet = record.cartonsPerPallet;
+        if (record.cartonDimensionsCm) product.boxSize = record.cartonDimensionsCm.map(formatDimension).join('*');
+        const country = supplyCountry(record.origin);
+        if (country) product.country = country;
+        updated += 1;
+        continue;
+      }
+      const country = supplyCountry(record.origin);
+      if (!record.unitsPerCarton || !record.cartonsPerPallet || !record.cartonDimensionsCm || !country) {
+        skipped += 1;
+        continue;
+      }
+      const product = {
+        productCode:record.sku,
+        productName:record.sku,
+        boxSize:record.cartonDimensionsCm.map(formatDimension).join('*'),
+        perCarton:Math.round(record.unitsPerCarton),
+        perPack:null,
+        perBox:null,
+        perPallet:record.cartonsPerPallet,
+        country,
+      };
+      bySku.set(record.sku, next.length);
+      next.push(product);
+      added += 1;
+    }
+    if (Array.isArray(products)) products.splice(0, products.length, ...next);
+    return { products:next, added, updated, skipped };
+  }
+
+  return {
+    STORAGE_KEY,
+    SCHEMA_VERSION,
+    isRawWorkbook,
+    createPayload,
+    validatePayload,
+    saveToStorage,
+    loadFromStorage,
+    removeFromStorage,
+    applyToFbaCatalog,
+    applyToSupplyProducts,
+  };
+});

--- a/tests/browser/public-smoke.spec.mjs
+++ b/tests/browser/public-smoke.spec.mjs
@@ -36,7 +36,7 @@ test('public workspace navigation, legacy URL, history, and bounded layout are r
   await page.goto('/#today');
   await waitForSupplyApp(page);
   await expect(page).toHaveURL(/#recommendations$/);
-  await expect(page.locator('input[type="file"]')).toHaveCount(5);
+  await expect(page.locator('input[type="file"]')).toHaveCount(6);
   for (const input of await page.locator('input[type="file"]').all()) await expect(input).toHaveValue('');
   await expect(page.locator('#todayWorkspaceSummary button')).toHaveCount(1);
   await expect(page.locator('#todayWorkspaceSummary')).toBeVisible();

--- a/tests/browser/shared-product-catalog.spec.mjs
+++ b/tests/browser/shared-product-catalog.spec.mjs
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import XLSX from 'xlsx';
+
+import {
+  freezeBrowserTime,
+  installOfflineAssetRoutes,
+  monitorBrowserErrors,
+  waitForSupplyApp,
+} from './browser-helpers.mjs';
+
+function rawProductWorkbook() {
+  const top = Array(23).fill('');
+  const headers = Array(23).fill('');
+  top[2] = '產地'; top[4] = '包數/箱'; top[17] = '紙箱規格'; top[18] = '箱/棧板'; top[21] = '每箱產品的毛重';
+  headers[1] = 'SKU'; headers[22] = 'GW (lb)';
+  const known = Array(23).fill('');
+  const added = Array(23).fill('');
+  known[1] = 'GTP03'; known[2] = '越南'; known[4] = 101; known[17] = '58.5*34.5*35'; known[18] = 36; known[22] = 26.5;
+  added[1] = 'NEW01'; added[2] = '台灣'; added[4] = 24; added[17] = '48*38*28'; added[18] = 30; added[22] = 29;
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([top, headers, known, added]), 'AMZ 所有SKU');
+  return XLSX.write(workbook, { type:'buffer', bookType:'xlsx' });
+}
+
+test('raw product workbook persists and overlays Supply without added master worksheets', async ({ page, context }) => {
+  await freezeBrowserTime(page);
+  const unexpectedRequests = [];
+  await installOfflineAssetRoutes(context, unexpectedRequests);
+  const browserErrors = monitorBrowserErrors(page);
+
+  await page.goto('/#data');
+  await waitForSupplyApp(page);
+  await page.locator('#masterFileInput').setInputFiles({
+    name:'raw-products.xlsx',
+    mimeType:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    buffer:rawProductWorkbook(),
+  });
+
+  await expect(page.locator('#masterMetaBox')).toContainText('Supply／FBA 共用產品資料');
+  await expect(page.locator('#uploadStatusCatalog')).toHaveText('產品資料 已共用原始檔');
+  await expect(page.locator('#productCatalogMetaBox')).toContainText('raw-products.xlsx');
+  await expect.poll(() => page.evaluate(() => window.getProductByCode('GTP03')?.perCarton)).toBe(101);
+  await expect.poll(() => page.evaluate(() => window.getProductByCode('NEW01')?.country)).toBe('TW');
+  await expect.poll(() => page.evaluate(() => {
+    const payload = JSON.parse(localStorage.getItem('jspusa:shared-product-catalog:v1') || 'null');
+    return payload?.records?.length;
+  })).toBe(2);
+
+  await page.reload();
+  await waitForSupplyApp(page);
+  await expect(page.locator('#productCatalogMetaBox')).toContainText('raw-products.xlsx');
+  await expect.poll(() => page.evaluate(() => window.getProductByCode('GTP03')?.perCarton)).toBe(101);
+  await expect.poll(() => page.evaluate(() => window.getProductByCode('NEW01')?.perPallet)).toBe(30);
+
+  await page.locator('.uploadAdvancedDetails > summary').click();
+  await page.locator('#btnResetProductCatalog').click();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('jspusa:shared-product-catalog:v1'))).toBeNull();
+  await expect.poll(() => page.evaluate(() => window.getProductByCode('NEW01'))).toBeNull();
+  await expect(page.locator('#productCatalogMetaBox')).toContainText('目前使用內建產品資料');
+
+  expect(unexpectedRequests).toEqual([]);
+  expect(browserErrors).toEqual([]);
+});

--- a/tests/shared-product-catalog.test.mjs
+++ b/tests/shared-product-catalog.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+await import(`../shared/shared-product-catalog.js?test=${Date.now()}`);
+const api = globalThis.JSPSharedProductCatalog;
+
+function rawWorkbook() {
+  const top = Array(23).fill('');
+  const headers = Array(23).fill('');
+  top[2] = '產地';
+  top[4] = '包數/箱';
+  top[17] = '紙箱規格';
+  top[18] = '箱/棧板';
+  top[21] = '每箱產品的毛重';
+  headers[1] = 'SKU';
+  headers[22] = 'GW (lb)';
+  const newer = Array(23).fill('');
+  const stale = Array(23).fill('');
+  const added = Array(23).fill('');
+  const alias = Array(23).fill('');
+  newer[1] = 'GTP03'; newer[2] = '越南'; newer[4] = 100; newer[17] = '58.5*34.5*35'; newer[18] = 36; newer[22] = 26.46;
+  stale[1] = 'GTP03'; stale[2] = '越南'; stale[4] = 90; stale[17] = '50*40*30'; stale[18] = 42; stale[22] = 24;
+  added[1] = 'NEW01'; added[2] = '台灣'; added[4] = 24; added[17] = '48*38*28'; added[18] = 30; added[22] = 29;
+  alias[1] = '7GTPD013AB'; alias[2] = '越南'; alias[4] = 90; alias[17] = '50*40*30'; alias[18] = 42; alias[22] = 25;
+  return {
+    SheetNames:['AMZ 所有SKU'],
+    Sheets:{ 'AMZ 所有SKU':{ rows:[top, headers, newer, stale, added, alias] } },
+  };
+}
+
+const xlsx = { utils:{ sheet_to_json:sheet => sheet.rows } };
+
+test('raw workbook parser keeps the first complete duplicate and reads origin and pallet count', () => {
+  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z' });
+  const gtp03 = payload.records.find(record => record.sku === 'GTP03');
+
+  assert.equal(payload.records.length, 3);
+  assert.equal(payload.stats.duplicateConflicts, 1);
+  assert.deepEqual(gtp03, {
+    sku:'GTP03', origin:'VN', unitsPerCarton:100, cartonsPerPallet:36,
+    cartonDimensionsCm:[58.5, 34.5, 35], grossWeightLb:26.46,
+    sourceSheet:'AMZ 所有SKU', sourceRow:3,
+  });
+});
+
+test('one browser payload overlays Supply, excludes 7-prefixed aliases, and persists safely', () => {
+  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z' });
+  const storage = new Map();
+  const browserStorage = {
+    getItem:key => storage.get(key) || null,
+    setItem:(key, value) => storage.set(key, value),
+    removeItem:key => storage.delete(key),
+  };
+  api.saveToStorage(payload, browserStorage);
+  const restored = api.loadFromStorage(browserStorage);
+  const products = [{
+    productCode:'GTP03', productName:'Turkey Tendon', boxSize:'50*40*30',
+    perCarton:90, perPack:null, perBox:null, perPallet:42, country:'VN',
+  }];
+  const result = api.applyToSupplyProducts(products, restored);
+
+  assert.equal(result.updated, 1);
+  assert.equal(result.added, 1);
+  assert.equal(products.length, 2);
+  assert.equal(products[0].productName, 'Turkey Tendon');
+  assert.equal(products[0].perCarton, 100);
+  assert.equal(products[0].perPallet, 36);
+  assert.equal(products[0].boxSize, '58.5*34.5*35');
+  assert.deepEqual(products[1], {
+    productCode:'NEW01', productName:'NEW01', boxSize:'48*38*28',
+    perCarton:24, perPack:null, perBox:null, perPallet:30, country:'TW',
+  });
+  assert.equal(products.some(product => product.productCode.startsWith('7')), false);
+});
+
+test('FBA overlay preserves built-in fields when the raw row leaves a value blank', () => {
+  const payload = api.validatePayload({
+    schemaVersion:1,
+    sourceFile:'raw.xlsx',
+    updatedAt:'2026-08-28T00:00:00Z',
+    records:[{
+      sku:'PARTIAL01', origin:'VN', unitsPerCarton:24, cartonsPerPallet:null,
+      cartonDimensionsCm:null, grossWeightLb:null, sourceSheet:'2026', sourceRow:8,
+    }],
+  });
+  const result = api.applyToFbaCatalog({
+    PARTIAL01:{ units:20, length:20, width:16, height:12, weight:30, source:'內建' },
+  }, payload);
+
+  assert.deepEqual(result.catalog.PARTIAL01, {
+    units:24, length:20, width:16, height:12, weight:30, source:'raw.xlsx · 2026',
+  });
+});

--- a/tests/site-artifact.test.mjs
+++ b/tests/site-artifact.test.mjs
@@ -67,6 +67,7 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'shared/order-draft-state.js',
     'shared/planning-velocity-history.js',
     'shared/planning-velocity.js',
+    'shared/shared-product-catalog.js',
     'shared/supply-planner.js',
     'shared/workspace-navigation.js',
     'shared/workspace-snapshot.js',
@@ -92,6 +93,7 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'shared/order-draft-state.js',
     'shared/planning-velocity-history.js',
     'shared/planning-velocity.js',
+    'shared/shared-product-catalog.js',
     'shared/supply-planner.js',
     'shared/workspace-navigation.js',
     'shared/workspace-snapshot.js',
@@ -99,7 +101,7 @@ test('site build emits the exact deterministic deployment artifact', t => {
     'vendor/LICENSE.sheetjs.txt',
     'vendor/xlsx.full.min.js',
   ]);
-  assert.equal(Object.keys(manifest.files).length, 17);
+  assert.equal(Object.keys(manifest.files).length, 18);
   for (const relativePath of Object.keys(manifest.files)) {
     assert.match(manifest.files[relativePath], /^[a-f0-9]{64}$/);
     assert.equal(manifest.files[relativePath], sha256(path.join(firstDist, relativePath)));
@@ -131,7 +133,7 @@ test('artifact verifier accepts a complete unmodified site build', t => {
 
   const verified = runNode(verifyScript, ['--dir', dist, '--revision', 'verified-revision']);
   assert.equal(verified.status, 0, verified.stderr || verified.stdout);
-  assert.match(verified.stdout, /Verified 17 hashed site files for verified-revision/);
+  assert.match(verified.stdout, /Verified 18 hashed site files for verified-revision/);
 });
 
 test('artifact verifier rejects repository-only or unexpected files', t => {


### PR DESCRIPTION
Summary:
- accept the existing raw product workbook directly
- persist one same-origin catalog shared with FBA
- restore it after refresh and retain built-in fallback

Validation:
- npm test (261 passed)
- npm run build
- npm run verify:dist
- npm run test:browser (14 passed)