### PR TITLE
Bake raw product catalog into Supply

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,10 @@ _Avoid_: Half-pallet rule, arbitrary decimal
 The raw uploaded source files, pasted H10 text, metadata, and small workspace preferences retained in the current browser so the workspace can be reconstructed after refresh.
 _Avoid_: Cloud backup, exported order
 
-**Shared Product Catalog**:
-The normalized SKU, origin, carton, pallet, and weight facts parsed from the operator's existing raw product-information workbook and stored under one same-origin browser key for Supply and FBA. It overlays each site's checked-in fallback without requiring an extra maintenance worksheet.
-_Avoid_: ProductMasterTable, cloud product database, cross-site fetch
+**Built-in Product Catalog**:
+The released SKU, origin, carton, pallet, weight, and confirmed Order SKU Alias facts compiled from the existing raw product-information workbook and embedded independently in Supply and FBA. It is the normal product source and requires neither an extra maintenance worksheet nor a routine browser upload.
+_Avoid_: Browser product database, ProductMasterTable, cross-site fetch
+
+**Temporary Product Override**:
+A same-origin browser copy of raw public packaging facts used only to test an unpublished product-data change. It never becomes the maintained source and expires when the Built-in Product Catalog version changes.
+_Avoid_: Shared Product Catalog, daily product upload, master data

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Only `dist/` is deployable. Repository files, tests, documentation, credentials,
 
 ## Shared product catalog
 
-The normal maintenance path is the existing raw product-information workbook. Drop it into Supply's main upload area or FBA's product-database updater; the browser reads `AMZ 所有SKU`, `2026`, and `罐頭`, stores one same-origin catalog locally, and both tools use it after refresh. No extra `產品主檔` worksheet is required.
+Supply and FBA normally use product data compiled into each site. Jasper maintains only the existing raw product-information workbook; a release imports `AMZ 所有SKU`, `2026`, and `罐頭` directly, updates the canonical catalog, and generates both built-in snapshots. No extra `產品主檔` worksheet and no routine browser upload are required.
 
-The checked-in canonical catalog and site-specific snapshots remain release-time fallbacks. They are generated artifacts, not another workbook the operator must maintain. See [docs/product-catalog.md](docs/product-catalog.md).
+The browser upload remains available only as a temporary pre-release override and is invalidated when a newer built-in catalog ships. See [docs/product-catalog.md](docs/product-catalog.md).

--- a/catalog/product-catalog.json
+++ b/catalog/product-catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-28.3",
+  "catalogVersion": "2026-08-28.4",
   "products": [
     {
       "productSku": "1GBRD019A0",
@@ -873,7 +873,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 42,
           "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
@@ -883,6 +883,28 @@
           ],
           "grossWeightKg": 16.9,
           "grossWeightLb": 37.25812230924431,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 209
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 42,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 37,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -1859,7 +1881,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -1869,6 +1891,28 @@
           ],
           "grossWeightKg": 12,
           "grossWeightLb": 26.455471462185308,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 6
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 26,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -1972,7 +2016,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -1982,6 +2026,28 @@
           ],
           "grossWeightKg": 13,
           "grossWeightLb": 28.660094084034085,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 28
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2025,7 +2091,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -2035,6 +2101,28 @@
           ],
           "grossWeightKg": 13,
           "grossWeightLb": 28.660094084034085,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 24
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 36,
+          "cartonDimensionsCm": [
+            58.5,
+            34.5,
+            35
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2168,7 +2256,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2178,6 +2266,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 39
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2221,7 +2331,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2231,6 +2341,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 46
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2274,7 +2406,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2284,6 +2416,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 41
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2327,7 +2481,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2337,6 +2491,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 44
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2379,7 +2555,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 38,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2389,6 +2565,28 @@
           ],
           "grossWeightKg": 20,
           "grossWeightLb": 44.09245243697551,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 21
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 38,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 44,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2431,7 +2629,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2441,6 +2639,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 19
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2484,7 +2704,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2494,6 +2714,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 16
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2537,7 +2779,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2547,6 +2789,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 12
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2590,7 +2854,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2600,6 +2864,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 14
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2673,7 +2959,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2683,6 +2969,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 26
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -2726,7 +3034,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
@@ -2736,6 +3044,28 @@
           ],
           "grossWeightKg": 16,
           "grossWeightLb": 35.27396194958041,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 30
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            40
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 35,
           "orderUnit": {
             "kind": "single",
             "units": 1
@@ -8515,10 +8845,10 @@
     },
     {
       "productSku": "1VFAD053A0",
-      "productName": "",
+      "productName": "1VFAD053A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFAD053A0"
       ],
@@ -8545,10 +8875,10 @@
     },
     {
       "productSku": "1VFBD053A0",
-      "productName": "",
+      "productName": "1VFBD053A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFBD053A0"
       ],
@@ -8575,10 +8905,10 @@
     },
     {
       "productSku": "1VFBD015A0",
-      "productName": "",
+      "productName": "1VFBD015A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFBD015A0"
       ],
@@ -8605,10 +8935,10 @@
     },
     {
       "productSku": "1VFCD017A0",
-      "productName": "",
+      "productName": "1VFCD017A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFCD017A0"
       ],
@@ -8635,10 +8965,10 @@
     },
     {
       "productSku": "1VFRD055A0",
-      "productName": "",
+      "productName": "1VFRD055A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFRD055A0"
       ],
@@ -8665,10 +8995,10 @@
     },
     {
       "productSku": "1VFRD015A0",
-      "productName": "",
+      "productName": "1VFRD015A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFRD015A0"
       ],
@@ -8695,10 +9025,10 @@
     },
     {
       "productSku": "1VFSD013A0",
-      "productName": "",
+      "productName": "1VFSD013A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFSD013A0"
       ],
@@ -8725,10 +9055,10 @@
     },
     {
       "productSku": "1GFTD033A0",
-      "productName": "",
+      "productName": "1GFTD033A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GFTD033A0"
       ],
@@ -8755,10 +9085,10 @@
     },
     {
       "productSku": "1GFTD035A0",
-      "productName": "",
+      "productName": "1GFTD035A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GFTD035A0"
       ],
@@ -8785,10 +9115,10 @@
     },
     {
       "productSku": "1GFTD043A0",
-      "productName": "",
+      "productName": "1GFTD043A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GFTD043A0"
       ],
@@ -8815,10 +9145,10 @@
     },
     {
       "productSku": "1GFTD045A0",
-      "productName": "",
+      "productName": "1GFTD045A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GFTD045A0"
       ],
@@ -8845,10 +9175,10 @@
     },
     {
       "productSku": "1GFTD061A0",
-      "productName": "",
+      "productName": "1GFTD061A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GFTD061A0"
       ],
@@ -8875,10 +9205,10 @@
     },
     {
       "productSku": "1GSDD023A0",
-      "productName": "",
+      "productName": "1GSDD023A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GSDD023A0"
       ],
@@ -8905,10 +9235,10 @@
     },
     {
       "productSku": "1GSDD033A0",
-      "productName": "",
+      "productName": "1GSDD033A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GSDD033A0"
       ],
@@ -8935,10 +9265,10 @@
     },
     {
       "productSku": "1VDFD011A0",
-      "productName": "",
+      "productName": "1VDFD011A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VDFD011A0"
       ],
@@ -8965,10 +9295,10 @@
     },
     {
       "productSku": "1GBRD027A0",
-      "productName": "",
+      "productName": "1GBRD027A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GBRD027A0"
       ],
@@ -8995,10 +9325,10 @@
     },
     {
       "productSku": "1ABRD016A0",
-      "productName": "",
+      "productName": "1ABRD016A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1ABRD016A0"
       ],
@@ -9025,10 +9355,10 @@
     },
     {
       "productSku": "1VFRD058A0",
-      "productName": "",
+      "productName": "1VFRD058A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFRD058A0"
       ],
@@ -9055,10 +9385,10 @@
     },
     {
       "productSku": "1VFBD018A0",
-      "productName": "",
+      "productName": "1VFBD018A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFBD018A0"
       ],
@@ -9085,10 +9415,10 @@
     },
     {
       "productSku": "1VFRD018A0",
-      "productName": "",
+      "productName": "1VFRD018A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFRD018A0"
       ],
@@ -9115,10 +9445,10 @@
     },
     {
       "productSku": "1VFAD058A0",
-      "productName": "",
+      "productName": "1VFAD058A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFAD058A0"
       ],
@@ -9145,10 +9475,10 @@
     },
     {
       "productSku": "1GCRD026A0",
-      "productName": "",
+      "productName": "1GCRD026A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GCRD026A0"
       ],
@@ -9175,10 +9505,10 @@
     },
     {
       "productSku": "1GCRD041A0",
-      "productName": "",
+      "productName": "1GCRD041A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GCRD041A0"
       ],
@@ -9205,10 +9535,10 @@
     },
     {
       "productSku": "1GCRD045A0",
-      "productName": "",
+      "productName": "1GCRD045A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GCRD045A0"
       ],
@@ -9235,10 +9565,10 @@
     },
     {
       "productSku": "1GBRD041A0",
-      "productName": "",
+      "productName": "1GBRD041A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GBRD041A0"
       ],
@@ -9265,10 +9595,10 @@
     },
     {
       "productSku": "1GBRD045A0",
-      "productName": "",
+      "productName": "1GBRD045A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GBRD045A0"
       ],
@@ -9295,10 +9625,10 @@
     },
     {
       "productSku": "1GQRD016A0",
-      "productName": "",
+      "productName": "1GQRD016A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GQRD016A0"
       ],
@@ -9325,10 +9655,10 @@
     },
     {
       "productSku": "1GCRD036A0",
-      "productName": "",
+      "productName": "1GCRD036A0",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GCRD036A0"
       ],
@@ -9355,10 +9685,10 @@
     },
     {
       "productSku": "ATR01",
-      "productName": "",
+      "productName": "ATR01",
       "origin": "VN",
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "ATR01",
         "7ATRD013AB"
@@ -9386,10 +9716,10 @@
     },
     {
       "productSku": "EPD021",
-      "productName": "",
+      "productName": "EPD021",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD021"
       ],
@@ -9397,7 +9727,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9411,15 +9741,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 153
+          }
         }
       ]
     },
     {
       "productSku": "EPD040",
-      "productName": "",
+      "productName": "EPD040",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD040"
       ],
@@ -9427,7 +9779,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9441,15 +9793,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 154
+          }
         }
       ]
     },
     {
       "productSku": "EPD051",
-      "productName": "",
+      "productName": "EPD051",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD051"
       ],
@@ -9457,7 +9831,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9471,15 +9845,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 155
+          }
         }
       ]
     },
     {
       "productSku": "EPD060",
-      "productName": "",
+      "productName": "EPD060",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD060"
       ],
@@ -9487,7 +9883,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9501,15 +9897,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 156
+          }
         }
       ]
     },
     {
       "productSku": "EPD011",
-      "productName": "",
+      "productName": "EPD011",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD011"
       ],
@@ -9517,7 +9935,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9531,15 +9949,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 157
+          }
         }
       ]
     },
     {
       "productSku": "EPD050",
-      "productName": "",
+      "productName": "EPD050",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD050"
       ],
@@ -9547,7 +9987,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9561,15 +10001,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 158
+          }
         }
       ]
     },
     {
       "productSku": "EPD020",
-      "productName": "",
+      "productName": "EPD020",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD020"
       ],
@@ -9577,7 +10039,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9591,15 +10053,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 159
+          }
         }
       ]
     },
     {
       "productSku": "EPD010",
-      "productName": "",
+      "productName": "EPD010",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD010"
       ],
@@ -9607,7 +10091,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9621,15 +10105,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 36,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 160
+          }
         }
       ]
     },
     {
       "productSku": "EPD041",
-      "productName": "",
+      "productName": "EPD041",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD041"
       ],
@@ -9637,7 +10143,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9651,15 +10157,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 161
+          }
         }
       ]
     },
     {
       "productSku": "EPD061",
-      "productName": "",
+      "productName": "EPD061",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EPD061"
       ],
@@ -9667,7 +10195,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9681,15 +10209,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 45,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 162
+          }
         }
       ]
     },
     {
       "productSku": "EZD051",
-      "productName": "",
+      "productName": "EZD051",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EZD051"
       ],
@@ -9697,7 +10247,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9711,15 +10261,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 169
+          }
         }
       ]
     },
     {
       "productSku": "EZD041",
-      "productName": "",
+      "productName": "EZD041",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EZD041"
       ],
@@ -9727,7 +10299,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9741,15 +10313,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 170
+          }
         }
       ]
     },
     {
       "productSku": "EZD021",
-      "productName": "",
+      "productName": "EZD021",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EZD021"
       ],
@@ -9757,7 +10351,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9771,15 +10365,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 171
+          }
         }
       ]
     },
     {
       "productSku": "EZD011",
-      "productName": "",
+      "productName": "EZD011",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EZD011"
       ],
@@ -9787,7 +10403,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9801,15 +10417,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 172
+          }
         }
       ]
     },
     {
       "productSku": "EZD061",
-      "productName": "",
+      "productName": "EZD061",
       "origin": "TW",
       "standardFactory": "TW",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "EZD061"
       ],
@@ -9817,7 +10455,7 @@
         {
           "version": "2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 18,
           "cartonsPerPallet": 36,
           "cartonDimensionsCm": [
@@ -9831,15 +10469,37 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 18,
+          "cartonsPerPallet": 30,
+          "cartonDimensionsCm": [
+            48,
+            38,
+            28
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 41,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "AMZ 所有SKU",
+            "row": 173
+          }
         }
       ]
     },
     {
       "productSku": "1HGCC015A0",
-      "productName": "",
+      "productName": "1HGCC015A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1HGCC015A0"
       ],
@@ -9866,10 +10526,10 @@
     },
     {
       "productSku": "1HGCC025A0",
-      "productName": "",
+      "productName": "1HGCC025A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1HGCC025A0"
       ],
@@ -9896,10 +10556,10 @@
     },
     {
       "productSku": "1HGCC035A0",
-      "productName": "",
+      "productName": "1HGCC035A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1HGCC035A0"
       ],
@@ -9926,10 +10586,10 @@
     },
     {
       "productSku": "1HGCC045A0",
-      "productName": "",
+      "productName": "1HGCC045A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1HGCC045A0"
       ],
@@ -9956,10 +10616,10 @@
     },
     {
       "productSku": "1HGRD015A0",
-      "productName": "",
+      "productName": "1HGRD015A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1HGRD015A0"
       ],
@@ -9986,10 +10646,10 @@
     },
     {
       "productSku": "1MGRC015A0",
-      "productName": "",
+      "productName": "1MGRC015A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRC015A0"
       ],
@@ -10016,10 +10676,10 @@
     },
     {
       "productSku": "1MGRC025A0",
-      "productName": "",
+      "productName": "1MGRC025A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRC025A0"
       ],
@@ -10046,10 +10706,10 @@
     },
     {
       "productSku": "1MGRC035A0",
-      "productName": "",
+      "productName": "1MGRC035A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRC035A0"
       ],
@@ -10076,10 +10736,10 @@
     },
     {
       "productSku": "1MGRC045A0",
-      "productName": "",
+      "productName": "1MGRC045A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRC045A0"
       ],
@@ -10106,10 +10766,10 @@
     },
     {
       "productSku": "1MGRC055A0",
-      "productName": "",
+      "productName": "1MGRC055A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRC055A0"
       ],
@@ -10136,10 +10796,10 @@
     },
     {
       "productSku": "1MGRD015A0",
-      "productName": "",
+      "productName": "1MGRD015A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRD015A0"
       ],
@@ -10166,10 +10826,10 @@
     },
     {
       "productSku": "1MGRD025A0",
-      "productName": "",
+      "productName": "1MGRD025A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRD025A0"
       ],
@@ -10196,10 +10856,10 @@
     },
     {
       "productSku": "1MGRD035A0",
-      "productName": "",
+      "productName": "1MGRD035A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRD035A0"
       ],
@@ -10226,10 +10886,10 @@
     },
     {
       "productSku": "1MGRD045A0",
-      "productName": "",
+      "productName": "1MGRD045A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRD045A0"
       ],
@@ -10256,10 +10916,10 @@
     },
     {
       "productSku": "1MGRD055A0",
-      "productName": "",
+      "productName": "1MGRD055A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1MGRD055A0"
       ],
@@ -10286,10 +10946,10 @@
     },
     {
       "productSku": "1AGHC015A0",
-      "productName": "",
+      "productName": "1AGHC015A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AGHC015A0"
       ],
@@ -10316,10 +10976,10 @@
     },
     {
       "productSku": "1AGHC025A0",
-      "productName": "",
+      "productName": "1AGHC025A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AGHC025A0"
       ],
@@ -10346,10 +11006,10 @@
     },
     {
       "productSku": "1AGHC035A0",
-      "productName": "",
+      "productName": "1AGHC035A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AGHC035A0"
       ],
@@ -10376,10 +11036,10 @@
     },
     {
       "productSku": "1AGHC045A0",
-      "productName": "",
+      "productName": "1AGHC045A0",
       "origin": null,
       "standardFactory": "VN",
-      "lifecycle": "incomplete",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AGHC045A0"
       ],
@@ -10406,429 +11066,485 @@
     },
     {
       "productSku": "1AWDD773A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1AWDD773A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AWDD773A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 38,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 43,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 53
           }
         }
       ]
     },
     {
       "productSku": "1AWDD775A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1AWDD775A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AWDD775A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 20,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 48,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 54
           }
         }
       ]
     },
     {
       "productSku": "1AXXD001A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1AXXD001A0",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AXXD001A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 100,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
-            58.42,
-            35.56,
-            35.56
+            58.5,
+            34.5,
+            35
           ],
           "grossWeightKg": null,
           "grossWeightLb": 25,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 5
           }
         }
       ]
     },
     {
       "productSku": "1AXXD002A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1AXXD002A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1AXXD002A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 8,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 36,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 61
           }
         }
       ]
     },
     {
       "productSku": "1GLTD011A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1GLTD011A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GLTD011A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 8,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 21,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 60
           }
         }
       ]
     },
     {
       "productSku": "1GXXD001A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1GXXD001A0",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GXXD001A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 24,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
-            48.26,
-            38.1,
-            27.94
+            48,
+            38,
+            28
           ],
           "grossWeightKg": null,
           "grossWeightLb": 29,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 3
           }
         }
       ]
     },
     {
       "productSku": "1GXXD002A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1GXXD002A0",
+      "origin": "TW",
+      "standardFactory": "TW",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1GXXD002A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 8,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 30,
           "cartonDimensionsCm": [
-            48.26,
-            38.1,
-            27.94
+            48,
+            38,
+            28
           ],
           "grossWeightKg": null,
           "grossWeightLb": 20,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 4
           }
         }
       ]
     },
     {
       "productSku": "1VFPD010A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFPD010A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFPD010A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 90,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 16,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 64
           }
         }
       ]
     },
     {
       "productSku": "1VFPD018A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFPD018A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFPD018A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 16,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 20,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 67
           }
         }
       ]
     },
     {
       "productSku": "1VFPD050A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFPD050A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFPD050A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 100,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 17,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 65
           }
         }
       ]
     },
     {
       "productSku": "1VFPD058A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFPD058A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFPD058A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 12,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 16,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 68
           }
         }
       ]
     },
     {
       "productSku": "1VFRD010A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFRD010A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFRD010A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 100,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 18,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 63
           }
         }
       ]
     },
     {
       "productSku": "1VFSD010A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFSD010A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFSD010A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 100,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 18,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 62
           }
         }
       ]
     },
     {
       "productSku": "1VFSD018A0",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
-      "lifecycle": "incomplete",
+      "productName": "1VFSD018A0",
+      "origin": "VN",
+      "standardFactory": "VN",
+      "lifecycle": "active",
       "approvedOrderSkus": [
         "1VFSD018A0"
       ],
       "packagingVersions": [
         {
-          "version": "2026-08-25",
-          "effectiveFrom": "2026-08-25",
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
           "effectiveTo": null,
           "unitsPerCarton": 18,
-          "cartonsPerPallet": null,
+          "cartonsPerPallet": 42,
           "cartonDimensionsCm": [
-            50.8,
-            40.64,
-            30.48
+            50,
+            40,
+            30
           ],
           "grossWeightKg": null,
           "grossWeightLb": 22,
           "orderUnit": {
             "kind": "single",
             "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 66
           }
         }
       ]
     },
     {
       "productSku": "ED011AM",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "ED011AM",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "ED011AM"
@@ -10852,9 +11568,9 @@
     },
     {
       "productSku": "EZD010",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD010",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD010"
@@ -10878,9 +11594,9 @@
     },
     {
       "productSku": "EZD010-3",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD010-3",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD010-3"
@@ -10904,9 +11620,9 @@
     },
     {
       "productSku": "EZD020",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD020",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD020"
@@ -10930,9 +11646,9 @@
     },
     {
       "productSku": "EZD020-3",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD020-3",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD020-3"
@@ -10956,9 +11672,9 @@
     },
     {
       "productSku": "EZD040",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD040",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD040"
@@ -10982,9 +11698,9 @@
     },
     {
       "productSku": "EZD040-3",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD040-3",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD040-3"
@@ -11008,9 +11724,9 @@
     },
     {
       "productSku": "EZD050",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD050",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD050"
@@ -11034,9 +11750,9 @@
     },
     {
       "productSku": "EZD050-3",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD050-3",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD050-3"
@@ -11060,9 +11776,9 @@
     },
     {
       "productSku": "EZD060",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD060",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD060"
@@ -11086,9 +11802,9 @@
     },
     {
       "productSku": "EZD060-3",
-      "productName": "",
-      "origin": null,
-      "standardFactory": null,
+      "productName": "EZD060-3",
+      "origin": "TW",
+      "standardFactory": "TW",
       "lifecycle": "incomplete",
       "approvedOrderSkus": [
         "EZD060-3"
@@ -11120,7 +11836,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11134,6 +11850,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 88
+          }
         }
       ]
     },
@@ -11145,7 +11883,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11158,6 +11896,28 @@
           "orderUnit": {
             "kind": "single",
             "units": 1
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 84
           }
         }
       ]
@@ -11195,7 +11955,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 30,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11209,6 +11969,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 30,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 86
+          }
         }
       ]
     },
@@ -11220,7 +12002,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 8,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11234,6 +12016,28 @@
             "kind": "box",
             "units": 10
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 8,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 22,
+          "orderUnit": {
+            "kind": "box",
+            "units": 10
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 85
+          }
         }
       ]
     },
@@ -11245,7 +12049,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11259,6 +12063,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 76
+          }
         }
       ]
     },
@@ -11270,7 +12096,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 26,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11284,6 +12110,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 26,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 30,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 77
+          }
         }
       ]
     },
@@ -11295,7 +12143,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 28,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11309,6 +12157,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 71
+          }
         }
       ]
     },
@@ -11320,7 +12190,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 90,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11333,6 +12203,28 @@
           "orderUnit": {
             "kind": "single",
             "units": 1
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 78
           }
         }
       ]
@@ -11345,7 +12237,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11359,6 +12251,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 72
+          }
         }
       ]
     },
@@ -11370,7 +12284,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11384,6 +12298,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 80
+          }
         }
       ]
     },
@@ -11395,7 +12331,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11408,6 +12344,28 @@
           "orderUnit": {
             "kind": "single",
             "units": 1
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 75
           }
         }
       ]
@@ -11420,7 +12378,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11434,6 +12392,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 83
+          }
         }
       ]
     },
@@ -11445,7 +12425,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 90,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11459,6 +12439,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 79
+          }
         }
       ]
     },
@@ -11470,7 +12472,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11484,6 +12486,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 27,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 74
+          }
         }
       ]
     },
@@ -11495,7 +12519,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11509,6 +12533,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 21,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 81
+          }
         }
       ]
     },
@@ -11520,7 +12566,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 22,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11534,6 +12580,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 22,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 25,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 73
+          }
         }
       ]
     },
@@ -11545,7 +12613,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 28,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11559,6 +12627,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 28,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 32,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 82
+          }
         }
       ]
     },
@@ -11570,7 +12660,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11584,6 +12674,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 69
+          }
         }
       ]
     },
@@ -11595,7 +12707,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11609,6 +12721,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 70
+          }
         }
       ]
     },
@@ -11620,7 +12754,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 50,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11634,6 +12768,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 50,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 17,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 32
+          }
         }
       ]
     },
@@ -11645,7 +12801,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 90,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11659,6 +12815,28 @@
             "kind": "pack",
             "units": 4
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 90,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "pack",
+            "units": 4
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 33
+          }
         }
       ]
     },
@@ -11670,7 +12848,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 50,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11684,6 +12862,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 50,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 17,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 34
+          }
         }
       ]
     },
@@ -11695,7 +12895,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 25,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11709,6 +12909,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 25,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 18,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 35
+          }
         }
       ]
     },
@@ -11720,7 +12942,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 100,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11734,6 +12956,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 100,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 36
+          }
         }
       ]
     },
@@ -11745,7 +12989,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 24,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11759,6 +13003,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 24,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 29,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 39
+          }
         }
       ]
     },
@@ -11770,7 +13036,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 20,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11784,6 +13050,28 @@
             "kind": "single",
             "units": 1
           }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 20,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 37
+          }
         }
       ]
     },
@@ -11795,7 +13083,7 @@
         {
           "version": "fba-2026-08-25",
           "effectiveFrom": "2026-08-25",
-          "effectiveTo": null,
+          "effectiveTo": "2026-08-27",
           "unitsPerCarton": 10,
           "cartonsPerPallet": null,
           "cartonDimensionsCm": [
@@ -11808,6 +13096,28 @@
           "orderUnit": {
             "kind": "single",
             "units": 1
+          }
+        },
+        {
+          "version": "2026-08-28.4",
+          "effectiveFrom": "2026-08-28",
+          "effectiveTo": null,
+          "unitsPerCarton": 10,
+          "cartonsPerPallet": 42,
+          "cartonDimensionsCm": [
+            50,
+            40,
+            30
+          ],
+          "grossWeightKg": null,
+          "grossWeightLb": 24,
+          "orderUnit": {
+            "kind": "single",
+            "units": 1
+          },
+          "source": {
+            "sheet": "2026",
+            "row": 38
           }
         }
       ]

--- a/catalog/raw-product-catalog-overlay.js
+++ b/catalog/raw-product-catalog-overlay.js
@@ -1,0 +1,193 @@
+import { validateCatalog } from './product-catalog.js';
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function integerOrNull(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.round(number) : null;
+}
+
+function positiveOrNull(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
+
+function factoryForOrigin(origin) {
+  if (origin === 'TW') return 'TW';
+  if (origin === 'VN' || origin === 'KH') return 'VN';
+  if (origin === 'OTHER') return 'OTHER';
+  return null;
+}
+
+function previousDay(isoDate) {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+}
+
+function currentPackaging(owner) {
+  return owner.packagingVersions.find(packaging => packaging.effectiveTo === null);
+}
+
+function packagingFacts(packaging) {
+  return JSON.stringify([
+    packaging.unitsPerCarton,
+    packaging.cartonsPerPallet,
+    packaging.cartonDimensionsCm,
+    packaging.grossWeightKg,
+    packaging.grossWeightLb,
+    packaging.orderUnit,
+  ]);
+}
+
+function packagingFromRecord(record, existing = null) {
+  const dimensions = Array.isArray(record.cartonDimensionsCm)
+    ? record.cartonDimensionsCm.map(positiveOrNull)
+    : null;
+  const rawWeightLb = positiveOrNull(record.grossWeightLb);
+  return {
+    unitsPerCarton:integerOrNull(record.unitsPerCarton) ?? existing?.unitsPerCarton ?? null,
+    cartonsPerPallet:integerOrNull(record.cartonsPerPallet) ?? existing?.cartonsPerPallet ?? null,
+    cartonDimensionsCm:dimensions?.every(Boolean) ? dimensions : existing?.cartonDimensionsCm ?? null,
+    grossWeightKg:rawWeightLb ? null : existing?.grossWeightKg ?? null,
+    grossWeightLb:rawWeightLb ? Math.round(rawWeightLb) : existing?.grossWeightLb ?? null,
+    orderUnit:existing?.orderUnit ? clone(existing.orderUnit) : { kind:'single', units:1 },
+    source:{ sheet:String(record.sourceSheet), row:Number(record.sourceRow) },
+  };
+}
+
+function replaceCurrentPackaging(owner, record, { catalogVersion, effectiveFrom }) {
+  const existing = currentPackaging(owner);
+  const facts = packagingFromRecord(record, existing);
+  if (existing && packagingFacts(existing) === packagingFacts(facts)) return false;
+
+  const next = {
+    version:catalogVersion,
+    effectiveFrom,
+    effectiveTo:null,
+    ...facts,
+  };
+  if (!existing) {
+    owner.packagingVersions.push(next);
+    return true;
+  }
+  if (existing.effectiveFrom === effectiveFrom) {
+    owner.packagingVersions.splice(owner.packagingVersions.indexOf(existing), 1, next);
+    return true;
+  }
+  existing.effectiveTo = previousDay(effectiveFrom);
+  owner.packagingVersions.push(next);
+  return true;
+}
+
+function productCanBeActive(product) {
+  const packaging = currentPackaging(product);
+  return Boolean(
+    product.productName
+    && product.standardFactory
+    && packaging?.unitsPerCarton
+    && packaging?.cartonsPerPallet
+    && packaging?.cartonDimensionsCm,
+  );
+}
+
+function packagingCanBelongToActiveProduct(packaging) {
+  return Boolean(packaging?.unitsPerCarton && packaging?.cartonsPerPallet && packaging?.cartonDimensionsCm);
+}
+
+function recordCanCreateAlias(record) {
+  return Boolean(record.unitsPerCarton && record.cartonDimensionsCm);
+}
+
+export function overlayRawProductCatalog(canonicalCatalog, rawPayload, options = {}) {
+  const catalogVersion = String(options.catalogVersion || '').trim();
+  const effectiveFrom = String(options.effectiveFrom || catalogVersion.split('.')[0]).trim();
+  if (!/^\d{4}-\d{2}-\d{2}(?:\.\d+)?$/.test(catalogVersion)) throw new Error('Raw catalog overlay requires a dated catalogVersion');
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveFrom)) throw new Error('Raw catalog overlay requires an ISO effectiveFrom date');
+  if (!rawPayload || !Array.isArray(rawPayload.records)) throw new Error('Raw catalog overlay requires normalized records');
+
+  const catalog = clone(canonicalCatalog);
+  catalog.catalogVersion = catalogVersion;
+  const products = new Map(catalog.products.map(product => [product.productSku, product]));
+  const aliases = new Map(catalog.orderSkuAliases.map(alias => [alias.orderSku, alias]));
+  const stats = {
+    addedProducts:0,
+    updatedProducts:0,
+    activatedProducts:0,
+    addedAliases:0,
+    updatedAliases:0,
+    skippedRecords:0,
+  };
+
+  for (const record of rawPayload.records) {
+    const sku = String(record.sku || '').trim().toUpperCase();
+    if (!sku) continue;
+    if (sku.startsWith('7')) {
+      let alias = aliases.get(sku);
+      if (!alias) {
+        if (!recordCanCreateAlias(record)) {
+          stats.skippedRecords += 1;
+          continue;
+        }
+        alias = { orderSku:sku, canonicalProductSku:null, lifecycle:'unmapped-legacy', packagingVersions:[] };
+        catalog.orderSkuAliases.push(alias);
+        aliases.set(sku, alias);
+        replaceCurrentPackaging(alias, record, { catalogVersion, effectiveFrom });
+        stats.addedAliases += 1;
+      } else if (replaceCurrentPackaging(alias, record, { catalogVersion, effectiveFrom })) {
+        stats.updatedAliases += 1;
+      }
+      continue;
+    }
+
+    let product = products.get(sku);
+    if (!product) {
+      const origin = record.origin || null;
+      product = {
+        productSku:sku,
+        productName:sku,
+        origin,
+        standardFactory:factoryForOrigin(origin),
+        lifecycle:'incomplete',
+        approvedOrderSkus:[sku],
+        packagingVersions:[],
+      };
+      replaceCurrentPackaging(product, record, { catalogVersion, effectiveFrom });
+      if (productCanBeActive(product)) product.lifecycle = 'active';
+      catalog.products.push(product);
+      products.set(sku, product);
+      stats.addedProducts += 1;
+      continue;
+    }
+
+    let changed = false;
+    if (record.origin && product.origin !== record.origin) {
+      product.origin = record.origin;
+      changed = true;
+    }
+    if (!product.standardFactory) {
+      const standardFactory = factoryForOrigin(record.origin);
+      if (standardFactory) {
+        product.standardFactory = standardFactory;
+        changed = true;
+      }
+    }
+    if (replaceCurrentPackaging(product, record, { catalogVersion, effectiveFrom })) changed = true;
+    if (product.lifecycle === 'incomplete' && !product.productName) {
+      product.productName = sku;
+      changed = true;
+    }
+    if (product.lifecycle === 'incomplete' && productCanBeActive(product)) {
+      product.lifecycle = 'active';
+      product.packagingVersions = product.packagingVersions.filter(packagingCanBelongToActiveProduct);
+      stats.activatedProducts += 1;
+      changed = true;
+    }
+    if (changed) stats.updatedProducts += 1;
+  }
+
+  validateCatalog(catalog);
+  return { catalog, stats };
+}

--- a/docs/adr/0004-import-the-existing-raw-product-workbook.md
+++ b/docs/adr/0004-import-the-existing-raw-product-workbook.md
@@ -1,5 +1,7 @@
 # Import the existing raw product workbook
 
+Status: Superseded by ADR 0005 for the normal runtime path; retained for temporary pre-release overrides.
+
 The normal operator workflow will accept the existing product-information Excel directly. Supply and FBA recognize `AMZ 所有SKU`, `2026`, and `罐頭`, normalize their public packaging fields into one versioned same-origin browser payload, and keep that payload after refresh. The first complete duplicate row wins so a stale alternate carton row cannot overwrite the current row.
 
 This supersedes ADR 0003's requirement that the operator maintain added `產品主檔` and `下單品號箱規` worksheets. The canonical schema, Product SKU versus Order SKU Alias distinction, public-field allowlist, and checked-in per-site fallbacks remain. The extra workbook sheets and compiler may remain as release/migration tooling, but they are not the maintenance interface.
@@ -7,7 +9,7 @@ This supersedes ADR 0003's requirement that the operator maintain added `產品�
 ## Consequences
 
 - Jasper maintains the original workbook only and can upload it from either website.
-- Both pages share `jspusa:shared-product-catalog:v1` because they are served from the same `jspusa.github.io` origin.
+- Temporary overrides use `jspusa:shared-product-catalog:v2` because both pages are served from the same `jspusa.github.io` origin; they are accepted only when their base catalog version matches the current built-in release.
 - The raw file itself is never uploaded to GitHub Pages or another server; only the normalized public packaging payload stays in that browser.
 - Missing raw values do not erase complete built-in values. New non-7 SKU rows enter Supply only when origin, carton quantity, carton dimensions, and cartons per pallet are usable; FBA may still use partial rows and its existing repair flow.
 - 7-prefixed rows update FBA packaging only. Existing confirmed alias ownership remains in the checked-in canonical fallback and is never guessed from the raw SKU spelling.

--- a/docs/adr/0005-bake-the-raw-workbook-into-each-site.md
+++ b/docs/adr/0005-bake-the-raw-workbook-into-each-site.md
@@ -1,0 +1,3 @@
+# Bake the raw workbook into each site
+
+Jasper maintains only the existing raw product-information workbook, while each released site uses an independently embedded Built-in Product Catalog. The release importer reads `AMZ 所有SKU`, `2026`, and `罐頭` directly, preserves confirmed Product SKU and Order SKU Alias ownership from the canonical catalog, versions changed packaging, and generates both site snapshots. Browser upload remains only a Temporary Product Override because requiring it for normal use makes product availability depend on one browser profile and shifts release maintenance onto the operator.

--- a/docs/product-catalog.md
+++ b/docs/product-catalog.md
@@ -1,8 +1,8 @@
 # 共用產品資料規格
 
-日常維護只使用既有產品資訊原始 Excel，不要求新增 `產品主檔` 或 `下單品號箱規`。把原始檔丟到 Supply 或 FBA 後，兩站會讀取 `AMZ 所有SKU`、`2026`、`罐頭`，將可公開的產品箱規保存在同一個瀏覽器的 `jspusa:shared-product-catalog:v1`，並共同套用到各自的內建備援。
+日常使用直接讀取 Supply 與 FBA 各自內建的產品資料，不需要上傳產品資訊 Excel。Jasper 只維護既有產品資訊原始 Excel，不要求新增 `產品主檔` 或 `下單品號箱規`；發布工具直接讀取 `AMZ 所有SKU`、`2026`、`罐頭`，更新 canonical catalog，再生成兩站的內建版本。
 
-下列 ProductMasterTable／OrderSkuPackagingTable 是內建版本發布與資料遷移的 canonical schema，不是 Jasper 平常要維護的 Excel 工作表。Canonical JSON、Supply 的 `product-data.js` 與 FBA snapshot 仍不得手動修改。
+下列 ProductMasterTable／OrderSkuPackagingTable 是發布內部與資料遷移的 canonical schema，不是 Jasper 平常要維護的 Excel 工作表。Canonical JSON、Supply 的 `product-data.js` 與 FBA snapshot 仍不得手動修改。
 
 ## 內建備援：ProductMasterTable
 
@@ -53,23 +53,28 @@
 - 同一 Order SKU Alias 的包裝有效期間不得重疊，且必須恰有一個現行版本。
 - `approved` alias 的 owner 必須存在且明列該 Order SKU；`unmapped-legacy` alias 的 owner 必須是 `null`。
 - 正常產品必須有品名、標準下單廠別與完整 Supply 包裝資料；資料待補產品可先供具備足夠欄位的 FBA adapter 使用，但不會自動進入 Supply 訂單清單。
-- 任一重複、欄位不完整、版本重疊或 alias 衝突都會阻止生成；不得 first-row-wins、last-row-wins 或猜值。
+- 原始 Excel 的重複 SKU 保留第一筆完整資料；較晚的完整衝突列會列入報告但不覆蓋。Canonical 內的重複、版本重疊或 alias owner 衝突則會阻止生成，不得猜值。
 
 ## 公開邊界
 
 公開 catalog 只允許 Product SKU、品名、產地、標準下單廠別、核准 Order SKU、包裝版本、箱規、箱重、棧板數與生命週期。成本、報價、供應商、聯絡方式、庫存、銷速、open orders、Order Draft、憑證與原始 Excel 檔不得進入 GitHub Pages artifact。
 
-## 日常維護流程
+## Jasper 的維護方式
 
 1. 照原本方式更新產品資訊原始 Excel；不要新增額外工作表。
-2. 在 Supply「資料」頁把它和 JAM／H10／JSP 一起丟入，或到 FBA「備用：更新產品資訊資料庫」單獨上傳。
-3. 系統會自動辨識三張工作表、保存第一筆完整的重複 SKU，並顯示讀取 SKU 數量與衝突數。
-4. 重新整理、切換 Supply／FBA 後仍會使用同一份資料；按「恢復內建備援」才會移除。
+2. 產品資料真的有變更時，將最新 raw Excel 交給發布流程；平常開啟網站不需上傳它。
+3. 發布工具自動辨識三張工作表、保留第一筆完整的重複 SKU、保存已確認的 7 字頭 owner，並產生新 catalog 版本。
+4. Supply 與 FBA 測試、發布完成後，所有瀏覽器直接取得新的內建資料。
 
-原始 Excel 不會上傳至 GitHub 或伺服器。瀏覽器共用資料只含 SKU、產地、箱入數、紙箱尺寸、箱／棧板、箱毛重、來源工作表與來源列；缺值不會清掉內建完整值。
+原始 Excel 不會進入 GitHub Pages artifact。公開內建 catalog 只含允許發布的產品與包裝欄位；缺值不會清掉 canonical 既有完整值。
 
-## 內建備援發布流程
+## 內建資料發布流程
 
-需要把新資料固化成所有瀏覽器的預設值時，才執行 canonical 匯入、old → new 差異檢查、`npm run catalog:build`、FBA 投影、兩站測試與 Pages 發布。平常上傳原始檔不需要走這套開發流程。
+1. 執行 raw 匯入並指定新的 dated catalog version：`npm run catalog:import -- --input <raw.xlsx> --output catalog/product-catalog.json --version <YYYY-MM-DD.N>`。
+2. 檢查 old → new 品號差異、重複衝突、資料待補與 alias owner。
+3. 執行 `npm run catalog:build` 生成 Supply 內建資料，再由 FBA 執行 `npm run generate:catalog -- --source ../Supply/catalog/product-catalog.json`。
+4. 兩站各自完成測試、Pages 部署與 live catalogVersion/hash 驗證後，才宣稱同步發布完成。
 
 兩個網站在 runtime 都使用各自已驗證的本地 snapshot，不會互相 fetch，因此其中一站暫時無法連線不會拖垮另一站。更新失敗時保留上一個已發布版本。
+
+網站仍保留「Temporary Product Override」供發布前用原始檔做臨時測試。它不是日常流程，也不會改寫內建 catalog；當 Built-in Product Catalog 版本更新時，較舊的瀏覽器覆蓋會自動失效。

--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@
     .downloadLinks { display:flex; flex-wrap:wrap; gap:7px; margin-bottom:12px; }
     .downloadLinkChip { display:inline-flex; align-items:center; gap:5px; padding:7px 10px; border:1px solid #dbeafe; border-radius:999px; background:#eff6ff; color:#1d4ed8; font-size:12px; font-weight:800; text-decoration:none; }
     .downloadLinkChip:hover { border-color:#60a5fa; background:#dbeafe; }
-    .uploadStatusRow { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; margin-top:11px; }
+    .uploadStatusRow { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; margin-top:11px; }
     .uploadStatus { display:flex; align-items:center; gap:7px; min-height:38px; padding:8px 10px; border-radius:12px; background:#f1f5f9; color:#64748b; font-size:11px; font-weight:800; }
     .uploadStatus::before { content:""; width:8px; height:8px; border-radius:50%; background:#f59e0b; flex:0 0 auto; }
     .uploadStatus.ready { background:#ecfdf5; color:#166534; }
@@ -567,7 +567,6 @@
       .heroActions button { flex: 1; }
       .controlDock { position: static; border-radius: 22px; }
       .controlGroup, .togglePill { width: 100%; justify-content: space-between; }
-      .uploadStatusRow { grid-template-columns:repeat(2,minmax(0,1fr)); }
       .subGrid { grid-template-columns: 1fr; }
       .card summary { flex-direction: column; align-items: flex-start; gap: 12px; }
       .summary-actions { width: 100%; }
@@ -893,24 +892,22 @@
 
           <div class="uploadWorkspace">
             <section class="uploadPrimaryPanel">
-              <div class="uploadPanelTitle"><h3><i class="fa-solid fa-cloud-arrow-up"></i> 四個原始檔一起丟這裡</h3><span class="pill">自動分類</span></div>
+              <div class="uploadPanelTitle"><h3><i class="fa-solid fa-cloud-arrow-up"></i> 三個檔案一起丟這裡</h3><span class="pill">自動分類</span></div>
               <div class="downloadLinks" aria-label="下載來源">
                 <a class="downloadLinkChip" href="https://24466647-my.sharepoint.com/:x:/g/personal/hongren_petlifeco_com/ER_jNs_oIg9JlOmxXlpGb6sBG3yRl9Zd7gzqAfH_q3WL1A?CID=bbf41374-a2d3-7260-37b3-d7bdd684d58e&amp;e=ocBSqj" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-file-excel"></i> 1. JAM 訂單</a>
                 <a class="downloadLinkChip" href="https://members.helium10.com/inventory-management/restock-suggestions-new/index?accountId=1547156136" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-chart-line"></i> 2. H10</a>
                 <a class="downloadLinkChip" href="https://24466647.sharepoint.com/:x:/r/sites/Cloud/Shared%2520Documents/%E7%8F%8D%E9%A3%9F%E5%A0%A1%2520-%2520%E5%85%B1%E7%94%A8/JSP%2520Amrica/Inventory%2520update%2520with%2520expiration%2520date%2520-%2520temporary%2520file.xlsx?d=wdb6b7635090543b0b4433ce8572b2c4a&amp;e=4%3ab1c52cfb6a554376882e5c1e30fa2339&amp;sharingv2=true&amp;fromShare=true&amp;at=9" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-warehouse"></i> 3. JSP 庫存</a>
-                <a class="downloadLinkChip" href="https://24466647-my.sharepoint.com/:x:/r/personal/hongren_petlifeco_com/_layouts/15/Doc.aspx?sourcedoc=%7BE5CC3B4A-0A68-44FC-B4BA-8A535837639D%7D&amp;file=20260324%25u7f8e%25u570b%25u7522%25u54c1%25u8cc7%25u8a0a%20JAM%20chuy%25u1ec3n%20%25u0111%25u00e0i%20loan.xlsx&amp;fromShare=true&amp;action=default&amp;mobileredirect=true" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-boxes-stacked"></i> 4. 產品資訊</a>
               </div>
               <label class="fileDropZone masterUploadZone">
                 <input type="file" id="masterFileInput" multiple accept=".xlsx,.xls,.csv,.txt" />
                 <i class="fa-solid fa-cloud-arrow-up dropIcon"></i>
-                <span>點擊選檔，或一次拖入 JAM／H10／JSP／產品資訊</span>
+                <span>點擊選檔，或一次拖入 JAM／H10／JSP</span>
                 <span class="dropSub">不用照順序，系統會自動辨識</span>
               </label>
               <div class="uploadStatusRow">
                 <div class="uploadStatus" id="uploadStatusJam">JAM 等待檔案</div>
                 <div class="uploadStatus" id="uploadStatusH10">H10 等待檔案</div>
                 <div class="uploadStatus" id="uploadStatusJsp">JSP 等待檔案</div>
-                <div class="uploadStatus" id="uploadStatusCatalog">產品資料使用內建版</div>
               </div>
               <div class="jamMetaBox" id="masterMetaBox" style="margin-top:10px;">尚未使用總檔案上傳。</div>
               <div class="jamMetaBox workspaceSnapshotState" id="workspaceSnapshotState" role="status" aria-live="polite">公開版原始資料只會保存在這個瀏覽器。</div>
@@ -964,11 +961,11 @@
                 </div>
               </div>
               <div class="subCard">
-                <div class="subCardHeader">Supply／FBA 共用產品資訊</div>
+                <div class="subCardHeader">備用：臨時測試產品資訊</div>
                 <div class="subCardContent">
-                  <label class="fileDropZone"><input type="file" id="productCatalogInput" accept=".xlsx,.xlsm,.xls" /><i class="fa-solid fa-boxes-stacked dropIcon"></i><span>直接上傳原始產品資訊 Excel</span></label>
-                  <div class="row" style="justify-content:flex-end;"><button type="button" class="secondary" id="btnResetProductCatalog">恢復內建備援</button></div>
-                  <div class="jamMetaBox" id="productCatalogMetaBox">尚未上傳原始檔，目前使用內建產品資料。</div>
+                  <label class="fileDropZone"><input type="file" id="productCatalogInput" accept=".xlsx,.xlsm,.xls" /><i class="fa-solid fa-boxes-stacked dropIcon"></i><span>平常不用上傳；僅供發布前臨時測試</span></label>
+                  <div class="row" style="justify-content:flex-end;"><button type="button" class="secondary" id="btnResetProductCatalog">清除臨時測試，恢復內建</button></div>
+                  <div class="jamMetaBox" id="productCatalogMetaBox">目前直接使用程式內建產品資料。</div>
                 </div>
               </div>
             </div>
@@ -1491,13 +1488,13 @@
         else {
           const updated = new Date(payload.updatedAt).toLocaleString('zh-TW', { hour12:false });
           const extra = result ? `；Supply 更新 ${result.updated}、新增 ${result.added}` : '';
-          meta.textContent = `已共用：${payload.sourceFile} · ${payload.records.length} 個 SKU · ${updated}${extra}`;
+          meta.textContent = `臨時測試：${payload.sourceFile} · ${payload.records.length} 個 SKU · ${updated}${extra}`;
         }
       }
       const status = document.getElementById('uploadStatusCatalog');
       if (status) {
         status.classList.add('ready');
-        status.textContent = payload ? '產品資料 已共用原始檔' : '產品資料 內建備援';
+        status.textContent = payload ? '產品資料 臨時測試中' : '產品資料 內建版本';
       }
     }
 
@@ -1505,7 +1502,10 @@
       if (!file) throw new Error('請先選擇產品資訊 Excel');
       if (!sharedCatalogApi || typeof XLSX === 'undefined') throw new Error('產品資料讀取元件尚未準備完成，請重新整理');
       const workbook = existingWorkbook || XLSX.read(await file.arrayBuffer(), { type:'array', cellDates:false });
-      let payload = sharedCatalogApi.createPayload(workbook, XLSX, { sourceFile:file.name });
+      let payload = sharedCatalogApi.createPayload(workbook, XLSX, {
+        sourceFile:file.name,
+        baseCatalogVersion:window.SUPPLY_PRODUCT_CATALOG_META?.catalogVersion || '',
+      });
       payload = sharedCatalogApi.saveToStorage(payload, localStorage);
       allProducts.splice(0, allProducts.length, ...builtInProducts.map(product => ({ ...product })));
       const result = sharedCatalogApi.applyToSupplyProducts(allProducts, payload);
@@ -1520,7 +1520,7 @@
       renderSharedProductCatalogMeta(payload, result);
       if (!workspaceBatching) buildTables();
       updateWorkflowUi();
-      showTip(`產品資料已保存並與 FBA 共用（${payload.records.length} 個 SKU）`, 'success');
+      showTip(`已臨時套用產品資料（${payload.records.length} 個 SKU）；平常仍以內建版本為準`, 'success');
       return { payload, result };
     }
 
@@ -1534,7 +1534,7 @@
       renderSharedProductCatalogMeta(null);
       buildTables();
       updateWorkflowUi();
-      showTip('已恢復內建產品資料；FBA 也會使用內建備援', 'success');
+      showTip('已清除臨時測試並恢復程式內建產品資料', 'success');
     }
     const h10El = document.getElementById('inputH10');
     const ordersEl = document.getElementById('inputOrders');
@@ -2822,7 +2822,7 @@
             const imported = await parseSharedProductCatalogFile(file, workbook);
             recognizedTypes.add('catalog');
             catalogFiles.push(file);
-            results.push(`${file.name} → Supply／FBA 共用產品資料（${imported.payload.records.length} 個 SKU）`);
+            results.push(`${file.name} → 臨時產品測試資料（${imported.payload.records.length} 個 SKU）`);
             continue;
           }
 

--- a/product-data.js
+++ b/product-data.js
@@ -1,7 +1,7 @@
 // Generated from catalog/product-catalog.json. Do not edit by hand.
 window.SUPPLY_PRODUCT_CATALOG_META = Object.freeze({
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-28.3"
+  "catalogVersion": "2026-08-28.4"
 });
 window.SUPPLY_EQUIVALENT_SKU_PAIRS = Object.freeze([
   [
@@ -2816,7 +2816,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFAD053A0",
-    "productName": "",
+    "productName": "1VFAD053A0",
     "boxSize": "50*40*30",
     "perCarton": 110,
     "perPack": null,
@@ -2826,7 +2826,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFBD053A0",
-    "productName": "",
+    "productName": "1VFBD053A0",
     "boxSize": "50*40*30",
     "perCarton": 80,
     "perPack": null,
@@ -2836,7 +2836,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFBD015A0",
-    "productName": "",
+    "productName": "1VFBD015A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -2846,7 +2846,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFCD017A0",
-    "productName": "",
+    "productName": "1VFCD017A0",
     "boxSize": "50*40*30",
     "perCarton": 36,
     "perPack": null,
@@ -2856,7 +2856,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFRD055A0",
-    "productName": "",
+    "productName": "1VFRD055A0",
     "boxSize": "50*40*30",
     "perCarton": 60,
     "perPack": null,
@@ -2866,7 +2866,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFRD015A0",
-    "productName": "",
+    "productName": "1VFRD015A0",
     "boxSize": "50*40*30",
     "perCarton": 50,
     "perPack": null,
@@ -2876,7 +2876,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFSD013A0",
-    "productName": "",
+    "productName": "1VFSD013A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -2886,7 +2886,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GFTD033A0",
-    "productName": "",
+    "productName": "1GFTD033A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -2896,7 +2896,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GFTD035A0",
-    "productName": "",
+    "productName": "1GFTD035A0",
     "boxSize": "50*40*30",
     "perCarton": 28,
     "perPack": null,
@@ -2906,7 +2906,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GFTD043A0",
-    "productName": "",
+    "productName": "1GFTD043A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -2916,7 +2916,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GFTD045A0",
-    "productName": "",
+    "productName": "1GFTD045A0",
     "boxSize": "50*40*30",
     "perCarton": 28,
     "perPack": null,
@@ -2926,7 +2926,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GFTD061A0",
-    "productName": "",
+    "productName": "1GFTD061A0",
     "boxSize": "50*40*30",
     "perCarton": 60,
     "perPack": null,
@@ -2936,7 +2936,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GSDD023A0",
-    "productName": "",
+    "productName": "1GSDD023A0",
     "boxSize": "50*40*30",
     "perCarton": 80,
     "perPack": null,
@@ -2946,7 +2946,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GSDD033A0",
-    "productName": "",
+    "productName": "1GSDD033A0",
     "boxSize": "50*40*30",
     "perCarton": 90,
     "perPack": null,
@@ -2956,7 +2956,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VDFD011A0",
-    "productName": "",
+    "productName": "1VDFD011A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -2966,7 +2966,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GBRD027A0",
-    "productName": "",
+    "productName": "1GBRD027A0",
     "boxSize": "50*40*30",
     "perCarton": 12,
     "perPack": null,
@@ -2976,7 +2976,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1ABRD016A0",
-    "productName": "",
+    "productName": "1ABRD016A0",
     "boxSize": "50*40*30",
     "perCarton": 14,
     "perPack": null,
@@ -2986,7 +2986,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFRD058A0",
-    "productName": "",
+    "productName": "1VFRD058A0",
     "boxSize": "50*40*30",
     "perCarton": 16,
     "perPack": null,
@@ -2996,7 +2996,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFBD018A0",
-    "productName": "",
+    "productName": "1VFBD018A0",
     "boxSize": "50*40*30",
     "perCarton": 20,
     "perPack": null,
@@ -3006,7 +3006,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFRD018A0",
-    "productName": "",
+    "productName": "1VFRD018A0",
     "boxSize": "50*40*30",
     "perCarton": 16,
     "perPack": null,
@@ -3016,7 +3016,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1VFAD058A0",
-    "productName": "",
+    "productName": "1VFAD058A0",
     "boxSize": "50*40*30",
     "perCarton": 24,
     "perPack": null,
@@ -3026,7 +3026,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GCRD026A0",
-    "productName": "",
+    "productName": "1GCRD026A0",
     "boxSize": "50*40*30",
     "perCarton": 18,
     "perPack": null,
@@ -3036,7 +3036,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GCRD041A0",
-    "productName": "",
+    "productName": "1GCRD041A0",
     "boxSize": "50*40*30",
     "perCarton": 70,
     "perPack": null,
@@ -3046,7 +3046,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GCRD045A0",
-    "productName": "",
+    "productName": "1GCRD045A0",
     "boxSize": "50*40*30",
     "perCarton": 30,
     "perPack": null,
@@ -3056,7 +3056,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GBRD041A0",
-    "productName": "",
+    "productName": "1GBRD041A0",
     "boxSize": "50*40*30",
     "perCarton": 100,
     "perPack": null,
@@ -3066,7 +3066,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GBRD045A0",
-    "productName": "",
+    "productName": "1GBRD045A0",
     "boxSize": "50*40*30",
     "perCarton": 28,
     "perPack": null,
@@ -3076,7 +3076,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GQRD016A0",
-    "productName": "",
+    "productName": "1GQRD016A0",
     "boxSize": "50*40*30",
     "perCarton": 18,
     "perPack": null,
@@ -3086,7 +3086,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1GCRD036A0",
-    "productName": "",
+    "productName": "1GCRD036A0",
     "boxSize": "50*40*30",
     "perCarton": 18,
     "perPack": null,
@@ -3096,7 +3096,7 @@ window.allProductsData = [
   },
   {
     "productCode": "ATR01",
-    "productName": "",
+    "productName": "ATR01",
     "boxSize": "50*40*30",
     "perCarton": 100,
     "perPack": null,
@@ -3106,157 +3106,157 @@ window.allProductsData = [
   },
   {
     "productCode": "EPD021",
-    "productName": "",
+    "productName": "EPD021",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD040",
-    "productName": "",
+    "productName": "EPD040",
     "boxSize": "48*38*28",
     "perCarton": 30,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD051",
-    "productName": "",
+    "productName": "EPD051",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD060",
-    "productName": "",
+    "productName": "EPD060",
     "boxSize": "48*38*28",
     "perCarton": 30,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD011",
-    "productName": "",
+    "productName": "EPD011",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD050",
-    "productName": "",
+    "productName": "EPD050",
     "boxSize": "48*38*28",
     "perCarton": 30,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD020",
-    "productName": "",
+    "productName": "EPD020",
     "boxSize": "48*38*28",
     "perCarton": 30,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD010",
-    "productName": "",
+    "productName": "EPD010",
     "boxSize": "48*38*28",
     "perCarton": 30,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD041",
-    "productName": "",
+    "productName": "EPD041",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EPD061",
-    "productName": "",
+    "productName": "EPD061",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EZD051",
-    "productName": "",
+    "productName": "EZD051",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EZD041",
-    "productName": "",
+    "productName": "EZD041",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EZD021",
-    "productName": "",
+    "productName": "EZD021",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EZD011",
-    "productName": "",
+    "productName": "EZD011",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "EZD061",
-    "productName": "",
+    "productName": "EZD061",
     "boxSize": "48*38*28",
     "perCarton": 18,
     "perPack": null,
     "perBox": null,
-    "perPallet": 36,
+    "perPallet": 30,
     "country": "TW"
   },
   {
     "productCode": "1HGCC015A0",
-    "productName": "",
+    "productName": "1HGCC015A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3266,7 +3266,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1HGCC025A0",
-    "productName": "",
+    "productName": "1HGCC025A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3276,7 +3276,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1HGCC035A0",
-    "productName": "",
+    "productName": "1HGCC035A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3286,7 +3286,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1HGCC045A0",
-    "productName": "",
+    "productName": "1HGCC045A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3296,7 +3296,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1HGRD015A0",
-    "productName": "",
+    "productName": "1HGRD015A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3306,7 +3306,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRC015A0",
-    "productName": "",
+    "productName": "1MGRC015A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3316,7 +3316,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRC025A0",
-    "productName": "",
+    "productName": "1MGRC025A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3326,7 +3326,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRC035A0",
-    "productName": "",
+    "productName": "1MGRC035A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3336,7 +3336,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRC045A0",
-    "productName": "",
+    "productName": "1MGRC045A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3346,7 +3346,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRC055A0",
-    "productName": "",
+    "productName": "1MGRC055A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3356,7 +3356,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRD015A0",
-    "productName": "",
+    "productName": "1MGRD015A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3366,7 +3366,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRD025A0",
-    "productName": "",
+    "productName": "1MGRD025A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3376,7 +3376,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRD035A0",
-    "productName": "",
+    "productName": "1MGRD035A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3386,7 +3386,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRD045A0",
-    "productName": "",
+    "productName": "1MGRD045A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3396,7 +3396,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1MGRD055A0",
-    "productName": "",
+    "productName": "1MGRD055A0",
     "boxSize": "32.5*23*6.1",
     "perCarton": 24,
     "perPack": null,
@@ -3406,7 +3406,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1AGHC015A0",
-    "productName": "",
+    "productName": "1AGHC015A0",
     "boxSize": "28.5*19.65*8.2",
     "perCarton": 24,
     "perPack": null,
@@ -3416,7 +3416,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1AGHC025A0",
-    "productName": "",
+    "productName": "1AGHC025A0",
     "boxSize": "28.5*19.65*8.2",
     "perCarton": 24,
     "perPack": null,
@@ -3426,7 +3426,7 @@ window.allProductsData = [
   },
   {
     "productCode": "1AGHC035A0",
-    "productName": "",
+    "productName": "1AGHC035A0",
     "boxSize": "28.5*19.65*8.2",
     "perCarton": 24,
     "perPack": null,
@@ -3436,12 +3436,152 @@ window.allProductsData = [
   },
   {
     "productCode": "1AGHC045A0",
-    "productName": "",
+    "productName": "1AGHC045A0",
     "boxSize": "28.5*19.65*8.2",
     "perCarton": 24,
     "perPack": null,
     "perBox": null,
     "perPallet": 100,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD773A0",
+    "productName": "1AWDD773A0",
+    "boxSize": "50*40*30",
+    "perCarton": 38,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AWDD775A0",
+    "productName": "1AWDD775A0",
+    "boxSize": "50*40*30",
+    "perCarton": 20,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1AXXD001A0",
+    "productName": "1AXXD001A0",
+    "boxSize": "58.5*34.5*35",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "TW"
+  },
+  {
+    "productCode": "1AXXD002A0",
+    "productName": "1AXXD002A0",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GLTD011A0",
+    "productName": "1GLTD011A0",
+    "boxSize": "50*40*30",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1GXXD001A0",
+    "productName": "1GXXD001A0",
+    "boxSize": "48*38*28",
+    "perCarton": 24,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "TW"
+  },
+  {
+    "productCode": "1GXXD002A0",
+    "productName": "1GXXD002A0",
+    "boxSize": "48*38*28",
+    "perCarton": 8,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 30,
+    "country": "TW"
+  },
+  {
+    "productCode": "1VFPD010A0",
+    "productName": "1VFPD010A0",
+    "boxSize": "50*40*30",
+    "perCarton": 90,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFPD018A0",
+    "productName": "1VFPD018A0",
+    "boxSize": "50*40*30",
+    "perCarton": 16,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFPD050A0",
+    "productName": "1VFPD050A0",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFPD058A0",
+    "productName": "1VFPD058A0",
+    "boxSize": "50*40*30",
+    "perCarton": 12,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFRD010A0",
+    "productName": "1VFRD010A0",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFSD010A0",
+    "productName": "1VFSD010A0",
+    "boxSize": "50*40*30",
+    "perCarton": 100,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
+    "country": "VN"
+  },
+  {
+    "productCode": "1VFSD018A0",
+    "productName": "1VFSD018A0",
+    "boxSize": "50*40*30",
+    "perCarton": 18,
+    "perPack": null,
+    "perBox": null,
+    "perPallet": 42,
     "country": "VN"
   }
 ];

--- a/scripts/compile-product-master-workbook.mjs
+++ b/scripts/compile-product-master-workbook.mjs
@@ -9,6 +9,8 @@ import {
   ORDER_SKU_PACKAGING_SHEET,
   PRODUCT_MASTER_SHEET,
 } from '../catalog/product-master-workbook.js';
+import { overlayRawProductCatalog } from '../catalog/raw-product-catalog-overlay.js';
+import '../shared/shared-product-catalog.js';
 
 function options(argv) {
   const values = { check:false };
@@ -31,12 +33,29 @@ if (!args.input || !args.output) throw new Error('Required options: --input <xls
 
 const workbook = XLSX.read(fs.readFileSync(path.resolve(args.input)), { type:'buffer', cellDates:true });
 const sheet = workbook.Sheets[PRODUCT_MASTER_SHEET];
-if (!sheet) throw new Error(`Workbook is missing ${PRODUCT_MASTER_SHEET}`);
 const orderSkuSheet = workbook.Sheets[ORDER_SKU_PACKAGING_SHEET];
-if (!orderSkuSheet) throw new Error(`Workbook is missing ${ORDER_SKU_PACKAGING_SHEET}`);
-const rows = XLSX.utils.sheet_to_json(sheet, { header:1, defval:null, raw:true });
-const orderSkuRows = XLSX.utils.sheet_to_json(orderSkuSheet, { header:1, defval:null, raw:true });
-const catalog = catalogFromProductMasterRows(rows, orderSkuRows);
+let catalog;
+let summary;
+if (sheet && orderSkuSheet) {
+  const rows = XLSX.utils.sheet_to_json(sheet, { header:1, defval:null, raw:true });
+  const orderSkuRows = XLSX.utils.sheet_to_json(orderSkuSheet, { header:1, defval:null, raw:true });
+  catalog = catalogFromProductMasterRows(rows, orderSkuRows);
+  summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases`;
+} else {
+  const rawApi = globalThis.JSPSharedProductCatalog;
+  if (!rawApi?.isRawWorkbook(workbook)) {
+    throw new Error(`Workbook must contain either ${PRODUCT_MASTER_SHEET}/${ORDER_SKU_PACKAGING_SHEET} or AMZ 所有SKU/2026/罐頭`);
+  }
+  const outputPath = path.resolve(args.output);
+  const basePath = path.resolve(args.base || outputPath);
+  if (!fs.existsSync(basePath)) throw new Error('Raw workbook import requires an existing canonical catalog via --base or --output');
+  if (!args.version) throw new Error('Raw workbook import requires --version YYYY-MM-DD.N');
+  const baseCatalog = JSON.parse(fs.readFileSync(basePath, 'utf8'));
+  const payload = rawApi.createPayload(workbook, XLSX, { sourceFile:path.basename(args.input), baseCatalogVersion:baseCatalog.catalogVersion });
+  const result = overlayRawProductCatalog(baseCatalog, payload, { catalogVersion:args.version });
+  catalog = result.catalog;
+  summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases from raw sheets; ${JSON.stringify(result.stats)}`;
+}
 const generated = `${JSON.stringify(catalog, null, 2)}\n`;
 const outputPath = path.resolve(args.output);
 
@@ -48,5 +67,5 @@ if (args.check) {
 } else {
   fs.mkdirSync(path.dirname(outputPath), { recursive:true });
   fs.writeFileSync(outputPath, generated);
-  console.log(`Compiled ${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases from ${args.input} into ${args.output}`);
+  console.log(`Compiled ${summary} from ${args.input} into ${args.output}`);
 }

--- a/shared/shared-product-catalog.js
+++ b/shared/shared-product-catalog.js
@@ -6,7 +6,8 @@
   if (Array.isArray(root.allProductsData)) {
     root.SUPPLY_BUILTIN_PRODUCT_DATA = root.allProductsData.map(product => ({ ...product }));
     const payload = api.loadFromStorage(root.localStorage);
-    if (payload) {
+    const builtInVersion = root.SUPPLY_PRODUCT_CATALOG_META?.catalogVersion || null;
+    if (payload && api.isCompatibleWithBuiltIn(payload, builtInVersion)) {
       const result = api.applyToSupplyProducts(root.allProductsData, payload);
       root.SUPPLY_SHARED_PRODUCT_CATALOG_META = Object.freeze({
         sourceFile:payload.sourceFile,
@@ -15,13 +16,16 @@
         added:result.added,
         updated:result.updated,
       });
+    } else if (payload) {
+      api.removeFromStorage(root.localStorage);
     }
   }
 })(typeof globalThis === 'object' ? globalThis : this, function sharedProductCatalogFactory() {
   'use strict';
 
-  const STORAGE_KEY = 'jspusa:shared-product-catalog:v1';
-  const SCHEMA_VERSION = 1;
+  const STORAGE_KEY = 'jspusa:shared-product-catalog:v2';
+  const LEGACY_STORAGE_KEY = 'jspusa:shared-product-catalog:v1';
+  const SCHEMA_VERSION = 2;
   const WANTED_SHEETS = new Set(['AMZ所有SKU', '2026', '罐頭']);
   const ORIGINS = new Map([
     ['台灣', 'TW'], ['TW', 'TW'],
@@ -166,6 +170,7 @@
 
     return validatePayload({
       schemaVersion:SCHEMA_VERSION,
+      baseCatalogVersion:text(options.baseCatalogVersion),
       sourceFile:text(options.sourceFile || '產品資訊 Excel').slice(0, 200),
       updatedAt:options.updatedAt || new Date().toISOString(),
       matchedSheets:matchedSheets.map(text),
@@ -207,6 +212,7 @@
     });
     return {
       schemaVersion:SCHEMA_VERSION,
+      baseCatalogVersion:text(payload.baseCatalogVersion).slice(0, 40),
       sourceFile:text(payload.sourceFile || '產品資訊 Excel').slice(0, 200),
       updatedAt:Number.isNaN(Date.parse(payload.updatedAt)) ? new Date().toISOString() : new Date(payload.updatedAt).toISOString(),
       matchedSheets:Array.isArray(payload.matchedSheets) ? payload.matchedSheets.map(name => text(name).slice(0, 100)) : [],
@@ -221,6 +227,7 @@
   function saveToStorage(payload, storage) {
     const validated = validatePayload(payload);
     if (!storage?.setItem) throw new Error('這個瀏覽器無法保存共用產品資料');
+    storage.removeItem?.(LEGACY_STORAGE_KEY);
     storage.setItem(STORAGE_KEY, JSON.stringify(validated));
     return validated;
   }
@@ -237,6 +244,11 @@
 
   function removeFromStorage(storage) {
     storage?.removeItem?.(STORAGE_KEY);
+    storage?.removeItem?.(LEGACY_STORAGE_KEY);
+  }
+
+  function isCompatibleWithBuiltIn(payload, builtInVersion) {
+    return Boolean(payload && builtInVersion && payload.baseCatalogVersion === builtInVersion);
   }
 
   function applyToFbaCatalog(baseCatalog, payload) {
@@ -323,6 +335,7 @@
     saveToStorage,
     loadFromStorage,
     removeFromStorage,
+    isCompatibleWithBuiltIn,
     applyToFbaCatalog,
     applyToSupplyProducts,
   };

--- a/tests/browser/shared-product-catalog.spec.mjs
+++ b/tests/browser/shared-product-catalog.spec.mjs
@@ -36,13 +36,12 @@ test('raw product workbook persists and overlays Supply without added master wor
     buffer:rawProductWorkbook(),
   });
 
-  await expect(page.locator('#masterMetaBox')).toContainText('Supply／FBA 共用產品資料');
-  await expect(page.locator('#uploadStatusCatalog')).toHaveText('產品資料 已共用原始檔');
+  await expect(page.locator('#masterMetaBox')).toContainText('臨時產品測試資料');
   await expect(page.locator('#productCatalogMetaBox')).toContainText('raw-products.xlsx');
   await expect.poll(() => page.evaluate(() => window.getProductByCode('GTP03')?.perCarton)).toBe(101);
   await expect.poll(() => page.evaluate(() => window.getProductByCode('NEW01')?.country)).toBe('TW');
   await expect.poll(() => page.evaluate(() => {
-    const payload = JSON.parse(localStorage.getItem('jspusa:shared-product-catalog:v1') || 'null');
+    const payload = JSON.parse(localStorage.getItem('jspusa:shared-product-catalog:v2') || 'null');
     return payload?.records?.length;
   })).toBe(2);
 
@@ -54,9 +53,9 @@ test('raw product workbook persists and overlays Supply without added master wor
 
   await page.locator('.uploadAdvancedDetails > summary').click();
   await page.locator('#btnResetProductCatalog').click();
-  await expect.poll(() => page.evaluate(() => localStorage.getItem('jspusa:shared-product-catalog:v1'))).toBeNull();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('jspusa:shared-product-catalog:v2'))).toBeNull();
   await expect.poll(() => page.evaluate(() => window.getProductByCode('NEW01'))).toBeNull();
-  await expect(page.locator('#productCatalogMetaBox')).toContainText('目前使用內建產品資料');
+  await expect(page.locator('#productCatalogMetaBox')).toContainText('使用內建產品資料');
 
   expect(unexpectedRequests).toEqual([]);
   expect(browserErrors).toEqual([]);

--- a/tests/product-catalog.test.mjs
+++ b/tests/product-catalog.test.mjs
@@ -437,11 +437,11 @@ test('checked canonical catalog and generated Supply snapshot stay in sync', () 
 
   assert.equal(actual, expected);
   assert.equal(canonical.schemaVersion, 2);
-  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.equal(canonical.catalogVersion, '2026-08-28.4');
   assert.match(canonical.catalogVersion, /^\d{4}-\d{2}-\d{2}(?:\.\d+)?$/);
 });
 
-test('migration preserves 15 legacy Supply packages and makes the FBA 2026-08-25 rows current', () => {
+test('raw release preserves the 15 legacy Supply packages and makes 2026-08-28.4 current', () => {
   const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
   const expectedUnits = new Map(Object.entries({
     '1ABRD002A0':[36, 42],
@@ -462,65 +462,75 @@ test('migration preserves 15 legacy Supply packages and makes the FBA 2026-08-25
   }));
   const versioned = canonical.products.filter(product => product.packagingVersions.length > 1);
 
-  assert.equal(versioned.length, expectedUnits.size);
-  for (const product of versioned) {
-    const [historical, current] = product.packagingVersions;
+  assert.ok(versioned.length >= expectedUnits.size);
+  for (const [productSku, expected] of expectedUnits) {
+    const product = canonical.products.find(item => item.productSku === productSku);
+    const historical = product.packagingVersions[0];
+    const current = product.packagingVersions.at(-1);
     assert.deepEqual(
       [historical.unitsPerCarton, current.unitsPerCarton],
-      expectedUnits.get(product.productSku),
+      expected,
       product.productSku,
     );
     assert.equal(historical.effectiveFrom, '2026-07-19', product.productSku);
     assert.equal(historical.effectiveTo, '2026-08-24', product.productSku);
-    assert.equal(current.effectiveFrom, '2026-08-25', product.productSku);
+    assert.equal(current.effectiveFrom, '2026-08-28', product.productSku);
     assert.equal(current.effectiveTo, null, product.productSku);
     assert.equal(current.source.sheet, 'AMZ 所有SKU', product.productSku);
   }
 
-  const gtp03 = versioned.find(product => product.productSku === 'GTP03');
-  assert.deepEqual(gtp03.packagingVersions[1].cartonDimensionsCm, [58.5, 34.5, 35]);
-  assert.equal(gtp03.packagingVersions[1].cartonsPerPallet, 36);
-  assert.equal(gtp03.packagingVersions[1].grossWeightLb, 26.455471462185308);
+  const gtp03 = canonical.products.find(product => product.productSku === 'GTP03').packagingVersions.at(-1);
+  assert.deepEqual(gtp03.cartonDimensionsCm, [58.5, 34.5, 35]);
+  assert.equal(gtp03.cartonsPerPallet, 36);
+  assert.equal(gtp03.grossWeightLb, 26);
 
   const unknownOrigin = canonical.products.find(product => product.productSku === '1AWDD010A0');
   assert.equal(unknownOrigin.standardFactory, 'VN');
   assert.equal(unknownOrigin.origin, null);
 });
 
-test('canonical union retains 25 FBA-only Product SKUs without exposing incomplete rows to Supply', () => {
+test('raw release promotes 14 complete products while 11 incomplete rows stay out of Supply', () => {
   const canonical = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
-  const expectedFbaOnly = [
+  const promoted = [
     '1AWDD773A0', '1AWDD775A0', '1AXXD001A0', '1AXXD002A0', '1GLTD011A0',
     '1GXXD001A0', '1GXXD002A0', '1VFPD010A0', '1VFPD018A0', '1VFPD050A0',
-    '1VFPD058A0', '1VFRD010A0', '1VFSD010A0', '1VFSD018A0', 'ED011AM',
-    'EZD010', 'EZD010-3', 'EZD020', 'EZD020-3', 'EZD040', 'EZD040-3',
+    '1VFPD058A0', '1VFRD010A0', '1VFSD010A0', '1VFSD018A0',
+  ];
+  const stillIncomplete = [
+    'ED011AM', 'EZD010', 'EZD010-3', 'EZD020', 'EZD020-3', 'EZD040', 'EZD040-3',
     'EZD050', 'EZD050-3', 'EZD060', 'EZD060-3',
   ];
   const bySku = new Map(canonical.products.map(product => [product.productSku, product]));
 
-  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.equal(canonical.catalogVersion, '2026-08-28.4');
   assert.equal(canonical.products.length, 360);
-  for (const productSku of expectedFbaOnly) {
+  for (const productSku of promoted) {
     const product = bySku.get(productSku);
     assert.ok(product, productSku);
-    assert.equal(product.productName, '', productSku);
-    assert.equal(product.origin, null, productSku);
-    assert.equal(product.standardFactory, null, productSku);
-    assert.equal(product.lifecycle, 'incomplete', productSku);
+    assert.equal(product.productName, productSku, productSku);
+    assert.ok(product.origin, productSku);
+    assert.ok(product.standardFactory, productSku);
+    assert.equal(product.lifecycle, 'active', productSku);
     assert.deepEqual(product.approvedOrderSkus, [productSku], productSku);
-    assert.equal(product.packagingVersions[0].cartonsPerPallet, null, productSku);
+    assert.ok(product.packagingVersions.at(-1).cartonsPerPallet, productSku);
+  }
+  for (const productSku of stillIncomplete) {
+    const product = bySku.get(productSku);
+    assert.equal(product.lifecycle, 'incomplete', productSku);
+    assert.equal(product.packagingVersions.at(-1).cartonsPerPallet, null, productSku);
   }
 
   const projected = compileCatalog(canonical, supplyCatalogAdapter);
-  assert.equal(projected.products.length, 335);
-  assert.equal(projected.products.some(product => expectedFbaOnly.includes(product.productCode)), false);
+  assert.equal(projected.products.length, 349);
+  assert.equal(promoted.every(productSku => projected.products.some(product => product.productCode === productSku)), true);
+  assert.equal(projected.products.some(product => stillIncomplete.includes(product.productCode)), false);
 
-  const airDried = bySku.get('1AWDD773A0').packagingVersions[0];
+  const airDried = bySku.get('1AWDD773A0').packagingVersions.at(-1);
   assert.equal(airDried.unitsPerCarton, 38);
-  assert.deepEqual(airDried.cartonDimensionsCm, [50.8, 40.64, 30.48]);
+  assert.deepEqual(airDried.cartonDimensionsCm, [50, 40, 30]);
   assert.equal(airDried.grossWeightLb, 43);
 
-  const aliasLikeProduct = bySku.get('ED011AM').packagingVersions[0];
+  const aliasLikeProduct = bySku.get('ED011AM').packagingVersions.at(-1);
   assert.equal(aliasLikeProduct.unitsPerCarton, null);
   assert.equal(aliasLikeProduct.cartonDimensionsCm, null);
   assert.equal(aliasLikeProduct.grossWeightLb, null);
@@ -558,7 +568,7 @@ test('schema v2 retains the 27 FBA legacy 7-SKU packages plus the initialized AT
   const products = new Map(validated.products.map(product => [product.productSku, product]));
 
   assert.equal(canonical.schemaVersion, 2);
-  assert.equal(canonical.catalogVersion, '2026-08-28.3');
+  assert.equal(canonical.catalogVersion, '2026-08-28.4');
   assert.equal(aliases.size, 28);
   assert.equal(validated.orderSkuAliases.filter(alias => alias.lifecycle === 'approved').length, 22);
   assert.deepEqual(
@@ -570,19 +580,22 @@ test('schema v2 retains the 27 FBA legacy 7-SKU packages plus the initialized AT
     const alias = aliases.get(orderSku);
     assert.ok(alias, orderSku);
     assert.equal(alias.currentPackaging.unitsPerCarton, unitsPerCarton, orderSku);
-    assert.deepEqual(alias.currentPackaging.cartonDimensionsCm, [50.8, 40.64, 30.48], orderSku);
+    assert.deepEqual(alias.currentPackaging.cartonDimensionsCm, [50, 40, 30], orderSku);
+    assert.equal(alias.currentPackaging.cartonsPerPallet, 42, orderSku);
     assert.equal(alias.currentPackaging.grossWeightLb, grossWeightLb, orderSku);
   }
 
   const fbaBackedMapped = validated.orderSkuAliases.filter(alias => alias.lifecycle === 'approved'
     && alias.orderSku !== '7ATSD011AB');
   assert.equal(fbaBackedMapped.length, 21);
-  assert.equal(fbaBackedMapped.filter(alias => {
+  const aliasesWithDistinctPackaging = fbaBackedMapped.filter(alias => {
     const owner = products.get(alias.canonicalProductSku).currentPackaging;
     return alias.currentPackaging.unitsPerCarton !== owner.unitsPerCarton
       || JSON.stringify(alias.currentPackaging.cartonDimensionsCm) !== JSON.stringify(owner.cartonDimensionsCm)
       || alias.currentPackaging.grossWeightLb !== owner.grossWeightLb;
-  }).length, 21);
+  });
+  assert.equal(aliasesWithDistinctPackaging.length, 20);
+  assert.equal(aliasesWithDistinctPackaging.some(alias => alias.orderSku === '7VTBD410AB'), false);
 
   const ats = aliases.get('7ATSD011AB');
   const atsOwner = products.get('ATS01');

--- a/tests/raw-product-catalog-overlay.test.mjs
+++ b/tests/raw-product-catalog-overlay.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { overlayRawProductCatalog } from '../catalog/raw-product-catalog-overlay.js';
+
+function packaging(overrides = {}) {
+  return {
+    version:'2026-08-25',
+    effectiveFrom:'2026-08-25',
+    effectiveTo:null,
+    unitsPerCarton:overrides.unitsPerCarton ?? null,
+    cartonsPerPallet:overrides.cartonsPerPallet ?? null,
+    cartonDimensionsCm:overrides.cartonDimensionsCm ?? null,
+    grossWeightKg:null,
+    grossWeightLb:overrides.grossWeightLb ?? null,
+    orderUnit:{ kind:'single', units:1 },
+  };
+}
+
+function baseCatalog() {
+  return {
+    schemaVersion:2,
+    catalogVersion:'2026-08-28.3',
+    products:[
+      {
+        productSku:'NEW01',
+        productName:'New product',
+        origin:null,
+        standardFactory:null,
+        lifecycle:'incomplete',
+        approvedOrderSkus:['NEW01'],
+        packagingVersions:[packaging({ unitsPerCarton:24, cartonDimensionsCm:[48, 38, 28], grossWeightLb:29 })],
+      },
+      {
+        productSku:'GTP01',
+        productName:'Gootoe Pork',
+        origin:'VN',
+        standardFactory:'VN',
+        lifecycle:'active',
+        approvedOrderSkus:['GTP01', '7GTPD013AB'],
+        packagingVersions:[packaging({ unitsPerCarton:90, cartonsPerPallet:42, cartonDimensionsCm:[50, 40, 30], grossWeightLb:25 })],
+      },
+    ],
+    orderSkuAliases:[
+      {
+        orderSku:'7GTPD013AB',
+        canonicalProductSku:'GTP01',
+        lifecycle:'approved',
+        packagingVersions:[packaging({ unitsPerCarton:90, cartonDimensionsCm:[50, 40, 30], grossWeightLb:25 })],
+      },
+    ],
+  };
+}
+
+test('raw workbook facts become versioned built-in product data and activate complete products', () => {
+  const result = overlayRawProductCatalog(baseCatalog(), { records:[{
+    sku:'NEW01', origin:'TW', unitsPerCarton:24, cartonsPerPallet:30,
+    cartonDimensionsCm:[48, 38, 28], grossWeightLb:29,
+    sourceSheet:'2026', sourceRow:3,
+  }] }, { catalogVersion:'2026-08-28.4' });
+
+  const product = result.catalog.products.find(item => item.productSku === 'NEW01');
+  assert.equal(result.catalog.catalogVersion, '2026-08-28.4');
+  assert.equal(product.lifecycle, 'active');
+  assert.equal(product.origin, 'TW');
+  assert.equal(product.standardFactory, 'TW');
+  assert.equal(product.packagingVersions.length, 1);
+  assert.equal(product.packagingVersions[0].version, '2026-08-28.4');
+  assert.equal(product.packagingVersions[0].cartonsPerPallet, 30);
+  assert.deepEqual(product.packagingVersions[0].source, { sheet:'2026', row:3 });
+  assert.equal(result.stats.activatedProducts, 1);
+});
+
+test('raw 7-prefixed rows update packaging without guessing or changing approved ownership', () => {
+  const result = overlayRawProductCatalog(baseCatalog(), { records:[
+    {
+      sku:'7GTPD013AB', origin:'KH', unitsPerCarton:100, cartonsPerPallet:42,
+      cartonDimensionsCm:[50, 40, 30], grossWeightLb:21,
+      sourceSheet:'2026', sourceRow:70,
+    },
+    {
+      sku:'7NEWSKU01', origin:'KH', unitsPerCarton:50, cartonsPerPallet:42,
+      cartonDimensionsCm:[50, 40, 30], grossWeightLb:17,
+      sourceSheet:'2026', sourceRow:71,
+    },
+  ] }, { catalogVersion:'2026-08-28.4' });
+
+  const approved = result.catalog.orderSkuAliases.find(item => item.orderSku === '7GTPD013AB');
+  const unmapped = result.catalog.orderSkuAliases.find(item => item.orderSku === '7NEWSKU01');
+  assert.equal(approved.canonicalProductSku, 'GTP01');
+  assert.equal(approved.lifecycle, 'approved');
+  assert.equal(approved.packagingVersions.at(-1).unitsPerCarton, 100);
+  assert.equal(unmapped.canonicalProductSku, null);
+  assert.equal(unmapped.lifecycle, 'unmapped-legacy');
+  assert.equal(result.stats.updatedAliases, 1);
+  assert.equal(result.stats.addedAliases, 1);
+});

--- a/tests/shared-product-catalog.test.mjs
+++ b/tests/shared-product-catalog.test.mjs
@@ -31,7 +31,7 @@ function rawWorkbook() {
 const xlsx = { utils:{ sheet_to_json:sheet => sheet.rows } };
 
 test('raw workbook parser keeps the first complete duplicate and reads origin and pallet count', () => {
-  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z' });
+  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z', baseCatalogVersion:'2026-08-28.4' });
   const gtp03 = payload.records.find(record => record.sku === 'GTP03');
 
   assert.equal(payload.records.length, 3);
@@ -44,7 +44,7 @@ test('raw workbook parser keeps the first complete duplicate and reads origin an
 });
 
 test('one browser payload overlays Supply, excludes 7-prefixed aliases, and persists safely', () => {
-  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z' });
+  const payload = api.createPayload(rawWorkbook(), xlsx, { sourceFile:'raw.xlsx', updatedAt:'2026-08-28T00:00:00Z', baseCatalogVersion:'2026-08-28.4' });
   const storage = new Map();
   const browserStorage = {
     getItem:key => storage.get(key) || null,
@@ -53,6 +53,8 @@ test('one browser payload overlays Supply, excludes 7-prefixed aliases, and pers
   };
   api.saveToStorage(payload, browserStorage);
   const restored = api.loadFromStorage(browserStorage);
+  assert.equal(api.isCompatibleWithBuiltIn(restored, '2026-08-28.4'), true);
+  assert.equal(api.isCompatibleWithBuiltIn(restored, '2026-08-28.5'), false);
   const products = [{
     productCode:'GTP03', productName:'Turkey Tendon', boxSize:'50*40*30',
     perCarton:90, perPack:null, perBox:null, perPallet:42, country:'VN',
@@ -75,7 +77,8 @@ test('one browser payload overlays Supply, excludes 7-prefixed aliases, and pers
 
 test('FBA overlay preserves built-in fields when the raw row leaves a value blank', () => {
   const payload = api.validatePayload({
-    schemaVersion:1,
+    schemaVersion:2,
+    baseCatalogVersion:'2026-08-28.4',
     sourceFile:'raw.xlsx',
     updatedAt:'2026-08-28T00:00:00Z',
     records:[{


### PR DESCRIPTION
## Summary
- compile the existing raw product workbook into the built-in Supply catalog
- keep product workbook upload only as a temporary pre-release override
- invalidate stale browser overrides when a newer built-in version ships

## Verification
- npm test (263 passed)
- npm run test:browser (14 passed)
- npm run catalog:check
- npm run build
- npm run verify:dist