### PR TITLE
Streamline catalog releases and improve coverage colors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,3 +79,7 @@ _Avoid_: Browser product database, ProductMasterTable, cross-site fetch
 **Temporary Product Override**:
 A same-origin browser copy of raw public packaging facts used only to test an unpublished product-data change. It never becomes the maintained source and expires when the Built-in Product Catalog version changes.
 _Avoid_: Shared Product Catalog, daily product upload, master data
+
+**Product Catalog Release**:
+One versioned operation that plans public old-to-new product changes, generates the Supply and FBA Built-in Product Catalog artifacts, verifies both repositories, and—when publishing is explicitly requested—coordinates both deployments and live checks. The two sites remain independently embedded at runtime.
+_Avoid_: Two manual catalog updates, runtime cross-site synchronization, workbook upload

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Only `dist/` is deployable. Repository files, tests, documentation, credentials,
 Supply and FBA normally use product data compiled into each site. Jasper maintains only the existing raw product-information workbook; a release imports `AMZ 所有SKU`, `2026`, and `罐頭` directly, updates the canonical catalog, and generates both built-in snapshots. No extra `產品主檔` worksheet and no routine browser upload are required.
 
 The browser upload remains available only as a temporary pre-release override and is invalidated when a newer built-in catalog ships. See [docs/product-catalog.md](docs/product-catalog.md).
+
+Use `npm run catalog:release -- --input <raw.xlsx> --fba-repo ../FBA --report <report.json>` to create a no-write release plan. Add `--apply --verify` only after reviewing that plan. The installed `release-supply-fba-product-catalog` skill wraps the GitHub pull requests, deployments, and live checks when Jasper asks to publish.

--- a/catalog/product-catalog-release.js
+++ b/catalog/product-catalog-release.js
@@ -1,0 +1,185 @@
+const CATALOG_VERSION = /^(\d{4}-\d{2}-\d{2})(?:\.(\d+))?$/;
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function parseVersion(value) {
+  const match = String(value || '').match(CATALOG_VERSION);
+  if (!match) throw new Error(`Invalid catalog version: ${value}`);
+  return { date:match[1], sequence:match[2] ? Number(match[2]) : 1 };
+}
+
+export function nextCatalogVersion(currentVersion, releaseDate) {
+  const current = parseVersion(currentVersion);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(releaseDate || ''))) {
+    throw new Error(`Invalid release date: ${releaseDate}`);
+  }
+  if (releaseDate < current.date) {
+    throw new Error(`Release date ${releaseDate} precedes current catalog ${currentVersion}`);
+  }
+  if (releaseDate > current.date) return releaseDate;
+  return `${releaseDate}.${current.sequence + 1}`;
+}
+
+export function assertNewCatalogVersion(currentVersion, requestedVersion) {
+  const current = parseVersion(currentVersion);
+  const requested = parseVersion(requestedVersion);
+  const newer = requested.date > current.date
+    || (requested.date === current.date && requested.sequence > current.sequence);
+  if (!newer) throw new Error(`Catalog version ${requestedVersion} must be newer than ${currentVersion}`);
+  return requestedVersion;
+}
+
+function currentPackaging(owner) {
+  return owner?.packagingVersions?.find(packaging => packaging?.effectiveTo === null) || null;
+}
+
+function cartonDimensionsIn(packaging) {
+  if (!Array.isArray(packaging?.cartonDimensionsCm) || packaging.cartonDimensionsCm.length !== 3) return null;
+  return packaging.cartonDimensionsCm.map(value => Math.round(Number(value) / 2.54));
+}
+
+function grossWeightLb(packaging) {
+  const lb = Number(packaging?.grossWeightLb);
+  if (Number.isFinite(lb) && lb > 0) return Math.round(lb);
+  const kg = Number(packaging?.grossWeightKg);
+  return Number.isFinite(kg) && kg > 0 ? Math.round(kg * 2.2046226218) : null;
+}
+
+function packagingFacts(owner) {
+  const packaging = currentPackaging(owner);
+  return {
+    unitsPerCarton:packaging?.unitsPerCarton ?? null,
+    cartonsPerPallet:packaging?.cartonsPerPallet ?? null,
+    cartonDimensionsIn:cartonDimensionsIn(packaging),
+    grossWeightLb:grossWeightLb(packaging),
+  };
+}
+
+function entryFacts(entryType, owner) {
+  if (entryType === 'product') {
+    return {
+      productName:owner.productName,
+      origin:owner.origin,
+      standardFactory:owner.standardFactory,
+      lifecycle:owner.lifecycle,
+      canonicalProductSku:owner.productSku,
+      ...packagingFacts(owner),
+    };
+  }
+  return {
+    productName:null,
+    origin:null,
+    standardFactory:null,
+    lifecycle:owner.lifecycle,
+    canonicalProductSku:owner.canonicalProductSku,
+    ...packagingFacts(owner),
+  };
+}
+
+function catalogEntries(catalog) {
+  const entries = new Map();
+  for (const product of catalog.products || []) {
+    entries.set(`product:${product.productSku}`, {
+      entryType:'product',
+      sku:product.productSku,
+      facts:entryFacts('product', product),
+    });
+  }
+  for (const alias of catalog.orderSkuAliases || []) {
+    entries.set(`order-sku-alias:${alias.orderSku}`, {
+      entryType:'order-sku-alias',
+      sku:alias.orderSku,
+      facts:entryFacts('order-sku-alias', alias),
+    });
+  }
+  return entries;
+}
+
+function changedFields(before, after) {
+  const fields = [];
+  for (const field of Object.keys(after || before || {})) {
+    if (JSON.stringify(before?.[field] ?? null) === JSON.stringify(after?.[field] ?? null)) continue;
+    fields.push({ field, before:clone(before?.[field] ?? null), after:clone(after?.[field] ?? null) });
+  }
+  return fields;
+}
+
+export function createCatalogReleaseReport(beforeCatalog, afterCatalog, metadata = {}) {
+  const beforeEntries = catalogEntries(beforeCatalog);
+  const afterEntries = catalogEntries(afterCatalog);
+  const keys = [...new Set([...beforeEntries.keys(), ...afterEntries.keys()])].sort();
+  const changes = [];
+  for (const key of keys) {
+    const before = beforeEntries.get(key) || null;
+    const after = afterEntries.get(key) || null;
+    const fields = changedFields(before?.facts, after?.facts);
+    if (before && after && fields.length === 0) continue;
+    changes.push({
+      entryType:(after || before).entryType,
+      sku:(after || before).sku,
+      changeType:before ? (after ? 'updated' : 'removed') : 'added',
+      fields,
+      before:clone(before?.facts ?? null),
+      after:clone(after?.facts ?? null),
+    });
+  }
+  const count = changeType => changes.filter(change => change.changeType === changeType).length;
+  return {
+    schemaVersion:1,
+    fromCatalogVersion:beforeCatalog.catalogVersion,
+    toCatalogVersion:afterCatalog.catalogVersion,
+    generatedAt:metadata.generatedAt || new Date().toISOString(),
+    sourceFile:metadata.sourceFile || null,
+    stats:{
+      productsBefore:(beforeCatalog.products || []).length,
+      productsAfter:(afterCatalog.products || []).length,
+      aliasesBefore:(beforeCatalog.orderSkuAliases || []).length,
+      aliasesAfter:(afterCatalog.orderSkuAliases || []).length,
+      added:count('added'),
+      updated:count('updated'),
+      removed:count('removed'),
+      changedEntries:changes.length,
+    },
+    changes,
+  };
+}
+
+export function catalogReleaseBlockers(report) {
+  const blockers = [];
+  const packagingFields = new Set(['unitsPerCarton', 'cartonsPerPallet', 'cartonDimensionsIn', 'grossWeightLb']);
+  for (const change of report.changes || []) {
+    if (change.changeType === 'removed') blockers.push(`${change.sku} would be removed`);
+    for (const field of change.fields || []) {
+      if (change.entryType === 'order-sku-alias' && field.field === 'canonicalProductSku' && field.before !== field.after) {
+        blockers.push(`${change.sku} approved alias owner would change from ${field.before ?? 'null'} to ${field.after ?? 'null'}`);
+      }
+      if (field.field === 'lifecycle' && field.before === 'active' && field.after === 'incomplete') {
+        blockers.push(`${change.sku} would regress from active to incomplete`);
+      }
+      if (packagingFields.has(field.field) && field.before !== null && field.after === null) {
+        blockers.push(`${change.sku}.${field.field} would lose a known value`);
+      }
+    }
+  }
+  return blockers;
+}
+
+function shown(value) {
+  if (value === null || value === undefined || value === '') return '—';
+  if (Array.isArray(value)) return value.join('×');
+  return String(value);
+}
+
+export function renderCatalogReleaseReport(report) {
+  const lines = [
+    `產品資料 ${report.fromCatalogVersion} → ${report.toCatalogVersion}`,
+    `變更 ${report.stats.changedEntries} 筆（新增 ${report.stats.added}、更新 ${report.stats.updated}、移除 ${report.stats.removed}）`,
+  ];
+  for (const change of report.changes) {
+    const details = change.fields.map(field => `${field.field}: ${shown(field.before)} → ${shown(field.after)}`).join('；');
+    lines.push(`- ${change.sku} [${change.changeType}]${details ? ` ${details}` : ''}`);
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/docs/adr/0006-orchestrate-one-product-catalog-release.md
+++ b/docs/adr/0006-orchestrate-one-product-catalog-release.md
@@ -1,0 +1,12 @@
+# Orchestrate one product catalog release
+
+A Product Catalog Release will start from the existing raw product-information workbook and fan out to Supply and FBA through one local release command. The command first produces a no-write old-to-new plan, then may apply the same catalog version to Supply's canonical catalog and generated product data plus FBA's generated snapshot and embedded HTML. A Codex skill coordinates the two repositories' branches, pull requests, deployments, and live verification when the user's request explicitly includes publishing.
+
+Supply remains the canonical source repository and FBA remains an independently deployed projection. The release is one operator action but two checked artifacts and two Pages deployments. This preserves runtime independence while removing the repeated manual GitHub procedure. A version-only plan with no public product changes does not create a release.
+
+## Consequences
+
+- The raw workbook remains local and is never staged; only allowlisted generated product fields enter either repository.
+- Planning must precede applying. Product or Order SKU removal, confirmed alias-owner changes, incomplete regressions, dirty worktrees, stale branches, or unrelated diffs stop the release.
+- Both repository checks must pass before either pull request is merged. Completion requires both deployed sites to expose the same catalog version and their checked-in artifacts.
+- The operation is not atomic across two repositories. A partial remote failure is reported as a version mismatch and repaired explicitly; it is never hidden or called complete.

--- a/docs/product-catalog.md
+++ b/docs/product-catalog.md
@@ -70,10 +70,10 @@
 
 ## 內建資料發布流程
 
-1. 執行 raw 匯入並指定新的 dated catalog version：`npm run catalog:import -- --input <raw.xlsx> --output catalog/product-catalog.json --version <YYYY-MM-DD.N>`。
-2. 檢查 old → new 品號差異、重複衝突、資料待補與 alias owner。
-3. 執行 `npm run catalog:build` 生成 Supply 內建資料，再由 FBA 執行 `npm run generate:catalog -- --source ../Supply/catalog/product-catalog.json`。
-4. 兩站各自完成測試、Pages 部署與 live catalogVersion/hash 驗證後，才宣稱同步發布完成。
+1. 先執行不寫檔的發布計畫：`npm run catalog:release -- --input <raw.xlsx> --fba-repo ../FBA --report <report.json>`。版本未指定時，會以台北日期接續目前版本號。
+2. 計畫會列出每個 Product SKU／Order SKU Alias 的 old → new 箱入數、箱／棧板、紙箱尺寸（in）、箱重（lb）、生命週期與 owner。沒有公開欄位變更時不建立空版本。
+3. 確認沒有移除、alias owner 變更、資料倒退或其他阻擋項目後，執行同一命令並加入 `--apply --verify`；它會一次生成 Supply canonical/snapshot 與 FBA snapshot/HTML，並完成兩站本機驗證。
+4. `release-supply-fba-product-catalog` Skill 在使用者明確要求「發布／上線」時，接著建立兩個 PR、等候兩邊檢查、合併、等候 Pages，再驗證兩個公開站點的相同 `catalogVersion` 與實際內容。
 
 兩個網站在 runtime 都使用各自已驗證的本地 snapshot，不會互相 fetch，因此其中一站暫時無法連線不會拖垮另一站。更新失敗時保留上一個已發布版本。
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "catalog:build": "node scripts/compile-product-catalog.mjs",
     "catalog:check": "node scripts/compile-product-catalog.mjs --check",
     "catalog:import": "node scripts/compile-product-master-workbook.mjs",
+    "catalog:release": "node scripts/release-product-catalog.mjs",
     "check": "npm ci --ignore-scripts --no-audit --no-fund && npm run verify",
     "test": "node --test tests/*.test.mjs",
     "test:browser": "playwright test --config tests/browser/playwright.config.mjs",

--- a/scripts/compile-product-master-workbook.mjs
+++ b/scripts/compile-product-master-workbook.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 import * as XLSX from 'xlsx';
 
@@ -28,44 +29,65 @@ function options(argv) {
   return values;
 }
 
-const args = options(process.argv.slice(2));
-if (!args.input || !args.output) throw new Error('Required options: --input <xlsx> --output <catalog.json>');
-
-const workbook = XLSX.read(fs.readFileSync(path.resolve(args.input)), { type:'buffer', cellDates:true });
-const sheet = workbook.Sheets[PRODUCT_MASTER_SHEET];
-const orderSkuSheet = workbook.Sheets[ORDER_SKU_PACKAGING_SHEET];
-let catalog;
-let summary;
-if (sheet && orderSkuSheet) {
-  const rows = XLSX.utils.sheet_to_json(sheet, { header:1, defval:null, raw:true });
-  const orderSkuRows = XLSX.utils.sheet_to_json(orderSkuSheet, { header:1, defval:null, raw:true });
-  catalog = catalogFromProductMasterRows(rows, orderSkuRows);
-  summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases`;
-} else {
-  const rawApi = globalThis.JSPSharedProductCatalog;
-  if (!rawApi?.isRawWorkbook(workbook)) {
-    throw new Error(`Workbook must contain either ${PRODUCT_MASTER_SHEET}/${ORDER_SKU_PACKAGING_SHEET} or AMZ 所有SKU/2026/罐頭`);
+export function compileProductCatalogWorkbook({ inputPath, outputPath, basePath = outputPath, version, check = false }) {
+  const resolvedInput = path.resolve(inputPath);
+  const resolvedOutput = path.resolve(outputPath);
+  const workbook = XLSX.read(fs.readFileSync(resolvedInput), { type:'buffer', cellDates:true });
+  const sheet = workbook.Sheets[PRODUCT_MASTER_SHEET];
+  const orderSkuSheet = workbook.Sheets[ORDER_SKU_PACKAGING_SHEET];
+  let catalog;
+  let summary;
+  let importStats = null;
+  if (sheet && orderSkuSheet) {
+    const rows = XLSX.utils.sheet_to_json(sheet, { header:1, defval:null, raw:true });
+    const orderSkuRows = XLSX.utils.sheet_to_json(orderSkuSheet, { header:1, defval:null, raw:true });
+    catalog = catalogFromProductMasterRows(rows, orderSkuRows);
+    summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases`;
+  } else {
+    const rawApi = globalThis.JSPSharedProductCatalog;
+    if (!rawApi?.isRawWorkbook(workbook)) {
+      throw new Error(`Workbook must contain either ${PRODUCT_MASTER_SHEET}/${ORDER_SKU_PACKAGING_SHEET} or AMZ 所有SKU/2026/罐頭`);
+    }
+    const resolvedBase = path.resolve(basePath);
+    if (!fs.existsSync(resolvedBase)) throw new Error('Raw workbook import requires an existing canonical catalog via --base or --output');
+    if (!version) throw new Error('Raw workbook import requires --version YYYY-MM-DD.N');
+    const baseCatalog = JSON.parse(fs.readFileSync(resolvedBase, 'utf8'));
+    const payload = rawApi.createPayload(workbook, XLSX, { sourceFile:path.basename(resolvedInput), baseCatalogVersion:baseCatalog.catalogVersion });
+    const result = overlayRawProductCatalog(baseCatalog, payload, { catalogVersion:version });
+    catalog = result.catalog;
+    importStats = {
+      ...result.stats,
+      rawRecords:payload.records.length,
+      skippedRawRecords:payload.stats.skipped,
+      duplicateConflicts:payload.stats.duplicateConflicts,
+      matchedSheets:payload.matchedSheets.map(name => name.trim()),
+    };
+    summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases from raw sheets; ${JSON.stringify(result.stats)}`;
   }
-  const outputPath = path.resolve(args.output);
-  const basePath = path.resolve(args.base || outputPath);
-  if (!fs.existsSync(basePath)) throw new Error('Raw workbook import requires an existing canonical catalog via --base or --output');
-  if (!args.version) throw new Error('Raw workbook import requires --version YYYY-MM-DD.N');
-  const baseCatalog = JSON.parse(fs.readFileSync(basePath, 'utf8'));
-  const payload = rawApi.createPayload(workbook, XLSX, { sourceFile:path.basename(args.input), baseCatalogVersion:baseCatalog.catalogVersion });
-  const result = overlayRawProductCatalog(baseCatalog, payload, { catalogVersion:args.version });
-  catalog = result.catalog;
-  summary = `${catalog.products.length} products and ${catalog.orderSkuAliases.length} Order SKU aliases from raw sheets; ${JSON.stringify(result.stats)}`;
-}
-const generated = `${JSON.stringify(catalog, null, 2)}\n`;
-const outputPath = path.resolve(args.output);
-
-if (args.check) {
-  if (fs.readFileSync(outputPath, 'utf8') !== generated) {
-    throw new Error(`${args.output} is stale relative to ${args.input}`);
+  const generated = `${JSON.stringify(catalog, null, 2)}\n`;
+  if (check) {
+    if (fs.readFileSync(resolvedOutput, 'utf8') !== generated) {
+      throw new Error(`${outputPath} is stale relative to ${inputPath}`);
+    }
+  } else {
+    fs.mkdirSync(path.dirname(resolvedOutput), { recursive:true });
+    fs.writeFileSync(resolvedOutput, generated);
   }
-  console.log(`Verified ${args.output} against ${args.input}`);
-} else {
-  fs.mkdirSync(path.dirname(outputPath), { recursive:true });
-  fs.writeFileSync(outputPath, generated);
-  console.log(`Compiled ${summary} from ${args.input} into ${args.output}`);
+  return { catalog, summary, importStats };
 }
+
+function main() {
+  const args = options(process.argv.slice(2));
+  if (!args.input || !args.output) throw new Error('Required options: --input <xlsx> --output <catalog.json>');
+  const result = compileProductCatalogWorkbook({
+    inputPath:args.input,
+    outputPath:args.output,
+    basePath:args.base || args.output,
+    version:args.version,
+    check:args.check,
+  });
+  if (args.check) console.log(`Verified ${args.output} against ${args.input}`);
+  else console.log(`Compiled ${result.summary} from ${args.input} into ${args.output}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/release-product-catalog.mjs
+++ b/scripts/release-product-catalog.mjs
@@ -1,0 +1,137 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertNewCatalogVersion,
+  catalogReleaseBlockers,
+  createCatalogReleaseReport,
+  nextCatalogVersion,
+  renderCatalogReleaseReport,
+} from '../catalog/product-catalog-release.js';
+import { writeSupplyProductData } from './compile-product-catalog.mjs';
+import { compileProductCatalogWorkbook } from './compile-product-master-workbook.mjs';
+
+const supplyRepo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const canonicalPath = path.join(supplyRepo, 'catalog', 'product-catalog.json');
+const supplySnapshotPath = path.join(supplyRepo, 'product-data.js');
+
+function parseOptions(argv) {
+  const options = { apply:false, verify:false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (key === '--apply' || key === '--verify') {
+      options[key.slice(2)] = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || !value || value.startsWith('--')) throw new Error(`Invalid option near ${key || 'end of command'}`);
+    options[key.slice(2)] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function taipeiDay(now = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone:'Asia/Taipei', year:'numeric', month:'2-digit', day:'2-digit',
+  }).formatToParts(now);
+  const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding:'utf8', stdio:'pipe' });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed in ${cwd}`);
+}
+
+function assertRepo(repoPath, packageName) {
+  const packagePath = path.join(repoPath, 'package.json');
+  if (!fs.existsSync(packagePath)) throw new Error(`Repository not found: ${repoPath}`);
+  const pkg = readJson(packagePath);
+  if (pkg.name !== packageName) throw new Error(`Expected ${packageName} at ${repoPath}, found ${pkg.name || 'unknown package'}`);
+}
+
+function assertClean(repoPath) {
+  const result = spawnSync('git', ['status', '--porcelain'], { cwd:repoPath, encoding:'utf8' });
+  if (result.status !== 0) throw new Error(`Cannot inspect Git status in ${repoPath}`);
+  if (result.stdout.trim()) throw new Error(`Release apply requires a clean worktree: ${repoPath}`);
+}
+
+function writeReport(report, reportPath) {
+  if (!reportPath) return;
+  const resolved = path.resolve(reportPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive:true });
+  fs.writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+function verifyRelease({ inputPath, version, fbaRepo }) {
+  run(process.execPath, ['scripts/compile-product-master-workbook.mjs', '--check', '--input', inputPath, '--output', canonicalPath, '--version', version], supplyRepo);
+  run('npm', ['test'], supplyRepo);
+  run('npm', ['run', 'catalog:check'], supplyRepo);
+  run('npm', ['run', 'build'], supplyRepo);
+  run('npm', ['run', 'verify:dist'], supplyRepo);
+  run('npm', ['test'], fbaRepo);
+  const supplyShared = fs.readFileSync(path.join(supplyRepo, 'shared', 'shared-product-catalog.js'));
+  const fbaShared = fs.readFileSync(path.join(fbaRepo, 'shared-product-catalog.js'));
+  if (!supplyShared.equals(fbaShared)) throw new Error('Supply and FBA shared-product-catalog.js differ');
+}
+
+function main() {
+  const args = parseOptions(process.argv.slice(2));
+  if (!args.input) throw new Error('Required option: --input <raw-product-workbook.xlsx>');
+  if (args.verify && !args.apply) throw new Error('--verify requires --apply');
+  const inputPath = path.resolve(args.input);
+  if (!fs.existsSync(inputPath)) throw new Error(`Input workbook not found: ${inputPath}`);
+  const fbaRepo = path.resolve(args['fba-repo'] || path.join(supplyRepo, '..', 'FBA'));
+  assertRepo(supplyRepo, 'jspusa-supply');
+  assertRepo(fbaRepo, 'fba-workspace');
+
+  const beforeCatalog = readJson(canonicalPath);
+  const version = args.version
+    ? assertNewCatalogVersion(beforeCatalog.catalogVersion, args.version)
+    : nextCatalogVersion(beforeCatalog.catalogVersion, taipeiDay());
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'product-catalog-release-'));
+  try {
+    const candidatePath = path.join(temporaryDirectory, 'product-catalog.json');
+    const { catalog, importStats } = compileProductCatalogWorkbook({
+      inputPath,
+      outputPath:candidatePath,
+      basePath:canonicalPath,
+      version,
+    });
+    const report = createCatalogReleaseReport(beforeCatalog, catalog, {
+      sourceFile:path.basename(inputPath),
+    });
+    report.importStats = importStats;
+    report.blockers = catalogReleaseBlockers(report);
+    report.mode = args.apply ? 'applied' : 'plan';
+    report.supplyRepo = supplyRepo;
+    report.fbaRepo = fbaRepo;
+    writeReport(report, args.report);
+    process.stdout.write(renderCatalogReleaseReport(report));
+
+    if (!args.apply) return;
+    if (report.stats.changedEntries === 0) throw new Error('No public product data changes; release was not applied');
+    if (report.blockers.length) throw new Error(`Catalog release is blocked:\n- ${report.blockers.join('\n- ')}`);
+    assertClean(supplyRepo);
+    assertClean(fbaRepo);
+    fs.writeFileSync(canonicalPath, `${JSON.stringify(catalog, null, 2)}\n`);
+    writeSupplyProductData({ catalogPath:canonicalPath, outputPath:supplySnapshotPath });
+    run(process.execPath, ['scripts/generate-product-catalog.mjs', '--source', canonicalPath], fbaRepo);
+    if (args.verify) verifyRelease({ inputPath, version, fbaRepo });
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive:true, force:true });
+  }
+}
+
+main();

--- a/shared/coverage-indicator.css
+++ b/shared/coverage-indicator.css
@@ -127,18 +127,18 @@
 }
 
 .coverageMeter--low {
-  --coverage-accent-rgb: 255, 159, 10;
-  --coverage-status-color: #8a4b00;
+  --coverage-accent-rgb: 255, 204, 0;
+  --coverage-status-color: #745300;
 }
 
 .coverageMeter--healthy {
-  --coverage-accent-rgb: 48, 209, 88;
-  --coverage-status-color: #166534;
+  --coverage-accent-rgb: 0, 190, 75;
+  --coverage-status-color: #087333;
 }
 
 .coverageMeter--excess {
-  --coverage-accent-rgb: 255, 69, 58;
-  --coverage-status-color: #9f2019;
+  --coverage-accent-rgb: 255, 45, 45;
+  --coverage-status-color: #a41118;
 }
 
 .coverageMeter--low .coverageMeter__fill,
@@ -146,14 +146,14 @@
 .coverageMeter--excess .coverageMeter__fill {
   background: linear-gradient(
     180deg,
-    rgba(var(--coverage-accent-rgb), 0.72) 0%,
-    rgba(var(--coverage-accent-rgb), 0.58) 52%,
-    rgba(var(--coverage-accent-rgb), 0.7) 100%
+    rgba(var(--coverage-accent-rgb), 0.88) 0%,
+    rgba(var(--coverage-accent-rgb), 0.74) 52%,
+    rgba(var(--coverage-accent-rgb), 0.86) 100%
   );
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.58),
     inset 0 -1px 0 rgba(15, 23, 42, 0.08),
-    0 1px 5px rgba(var(--coverage-accent-rgb), 0.2);
+    0 1px 5px rgba(var(--coverage-accent-rgb), 0.28);
 }
 
 .coverageMeter--low .coverageMeter__status,

--- a/skills/release-supply-fba-product-catalog/SKILL.md
+++ b/skills/release-supply-fba-product-catalog/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: release-supply-fba-product-catalog
+description: Prepare, synchronize, publish, or verify Jasper's built-in product catalog across jspusa/Supply and jspusa/FBA from the existing raw product-information Excel. Use for requests to update the shared product database, release product packaging changes, or run the one-step Supply/FBA catalog publication. Do not use for daily JAM, H10, Inventory, or Amazon shipment uploads.
+---
+
+# Release the Supply and FBA product catalog
+
+Run one **Product Catalog Release** while preserving two independently deployed sites.
+
+## Resolve the release inputs
+
+1. Use an exact workbook path supplied by the user. Otherwise inspect only likely product-information `.xlsx` files in Downloads and choose the uniquely newest file whose workbook contains `AMZ 所有SKU`, `2026`, or `罐頭`; ask when the candidate is ambiguous.
+2. Locate the `jspusa/Supply` and `jspusa/FBA` clones. Prefer `/Users/jasper/Desktop/Codex用/Supply` and its sibling `FBA`, but validate `package.json` and Git remotes instead of trusting the path.
+3. Read Supply's `AGENTS.md`, `CONTEXT.md`, and applicable catalog ADRs. Read the available GitHub publication skill before remote operations.
+
+The existing raw workbook is the maintained input. Keep it local, add no maintenance worksheets, and stage only allowlisted generated catalog artifacts.
+
+## Plan before writing
+
+Require clean worktrees and current default branches. From Supply run:
+
+```bash
+npm run catalog:release -- --input <raw.xlsx> --fba-repo <FBA-path> --report <temporary-report.json>
+```
+
+Read the report and account for every changed Product SKU and Order SKU Alias. Report box count, dimensions in inches, carton weight in pounds, cartons per pallet, lifecycle, and confirmed owner as old → new. Stop before applying when:
+
+- there are no public product changes;
+- any entry is removed;
+- an approved alias owner changes;
+- an active product becomes incomplete;
+- either worktree is dirty, behind its remote default branch, or contains unrelated changes.
+
+The first complete raw duplicate remains authoritative; later complete conflicts are evidence, not overwrite permission. Never infer a 7-prefixed alias owner.
+
+## Apply and verify
+
+Create the same versioned feature branch in both repositories, then run:
+
+```bash
+npm run catalog:release -- --input <raw.xlsx> --fba-repo <FBA-path> --version <planned-version> --apply --verify --report <temporary-report.json>
+```
+
+Completion requires exactly these ordinary release diffs:
+
+- Supply: `catalog/product-catalog.json`, `product-data.js`.
+- FBA: `catalog/fba-product-catalog.snapshot.json`, `inbound-plan.html`.
+
+Review and stop on any additional path. Run Supply's browser suite separately when the environment needs permission to bind its local test server.
+
+If the user explicitly requested publication or going live, read [references/publish.md](references/publish.md) and continue. Otherwise stop after the verified local plan or apply result without remote writes.
+
+## Completion
+
+Report the raw workbook basename, catalog version, every old → new SKU change, both test results, both pull requests when created, and both live verification results. A green workflow without matching public content is incomplete. A partial two-repository release is a version mismatch to repair, never a successful release.

--- a/skills/release-supply-fba-product-catalog/agents/openai.yaml
+++ b/skills/release-supply-fba-product-catalog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "發布 Supply/FBA 產品資料"
+  short_description: "一次更新並發布 Supply 與 FBA 內建產品資料"
+  default_prompt: "Use $release-supply-fba-product-catalog to update and publish the built-in Supply and FBA product catalogs from my latest raw product workbook."

--- a/skills/release-supply-fba-product-catalog/references/publish.md
+++ b/skills/release-supply-fba-product-catalog/references/publish.md
@@ -1,0 +1,11 @@
+# Publish both catalog projections
+
+Read this reference only when the user explicitly asked to publish or go live.
+
+1. Confirm both local diffs contain only the four generated release artifacts named in `SKILL.md`. Stage exact paths; never use broad Git add commands.
+2. Commit Supply and FBA separately with the same catalog version in their messages. Push both feature branches.
+3. Reuse matching open pull requests or create two draft pull requests, each with one base/head pair. Include the shared catalog version and local verification in both bodies.
+4. Wait for both pull-request check suites. Keep both draft and stop if either fails. After both pass, mark both ready and merge using the repositories' normal squash policy.
+5. Wait for both main-branch Pages deployments. A merge or Actions success alone is not live proof.
+6. From the updated default branches, verify Supply with its exact live file and browser verifiers. Verify FBA with `npm run verify:live:catalog -- --version <catalog-version>`.
+7. Confirm both public pages expose the same catalog version. If one side fails after the other is live, keep working within the authorized release to repair the failed side; avoid rollback or destructive Git operations unless the user separately authorizes them.

--- a/tests/browser/browser-helpers.mjs
+++ b/tests/browser/browser-helpers.mjs
@@ -449,14 +449,14 @@ async function expectCoverageMeter(cell, {
     return { backgroundColor:style.backgroundColor, backgroundImage:style.backgroundImage };
   });
   const expectedAccent = {
-    yellow:'rgba(255, 159, 10, 0.72)',
-    green:'rgba(48, 209, 88, 0.72)',
-    red:'rgba(255, 69, 58, 0.72)',
+    yellow:'rgba(255, 204, 0, 0.88)',
+    green:'rgba(0, 190, 75, 0.88)',
+    red:'rgba(255, 45, 45, 0.88)',
   }[fillColor];
   expect(expectedAccent).toBeTruthy();
   expect(fillStyle.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   expect(fillStyle.backgroundImage).toContain(expectedAccent);
-  expect(fillStyle.backgroundImage).toContain('0.58');
+  expect(fillStyle.backgroundImage).toContain('0.74');
   expect(fillStyle.backgroundImage).not.toContain('repeating');
 }
 

--- a/tests/coverage-indicator.test.mjs
+++ b/tests/coverage-indicator.test.mjs
@@ -46,10 +46,16 @@ test('yellow, green, and red bands share one Apple-style translucent finish with
   const sharedFill = coverageCss.match(/\.coverageMeter--low \.coverageMeter__fill,\s*\.coverageMeter--healthy \.coverageMeter__fill,\s*\.coverageMeter--excess \.coverageMeter__fill \{([^}]*)\}/s);
   assert.ok(sharedFill, 'all three colored bands should use one shared fill rule');
   assert.match(sharedFill[1], /linear-gradient\(\s*180deg,/s);
-  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.72\)/);
-  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.58\)/);
+  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.88\)/);
+  assert.match(sharedFill[1], /rgba\(var\(--coverage-accent-rgb\), 0\.74\)/);
   assert.match(sharedFill[1], /box-shadow:/);
   assert.doesNotMatch(coverageCss, /repeating-linear-gradient|repeating-radial-gradient/);
+});
+
+test('coverage bands use unmistakable yellow, green, and red accents', () => {
+  assert.match(coverageCss, /\.coverageMeter--low \{[^}]*--coverage-accent-rgb: 255, 204, 0;/s);
+  assert.match(coverageCss, /\.coverageMeter--healthy \{[^}]*--coverage-accent-rgb: 0, 190, 75;/s);
+  assert.match(coverageCss, /\.coverageMeter--excess \{[^}]*--coverage-accent-rgb: 255, 45, 45;/s);
 });
 
 test('coverage meter uses a compact glass surface with restrained highlights and accessible fallbacks', () => {

--- a/tests/product-catalog-release.test.mjs
+++ b/tests/product-catalog-release.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertNewCatalogVersion,
+  catalogReleaseBlockers,
+  createCatalogReleaseReport,
+  nextCatalogVersion,
+  renderCatalogReleaseReport,
+} from '../catalog/product-catalog-release.js';
+
+function packaging(overrides = {}) {
+  return {
+    version:'2026-08-28.4', effectiveFrom:'2026-08-28', effectiveTo:null,
+    unitsPerCarton:24, cartonsPerPallet:42, cartonDimensionsCm:[50.8, 40.64, 30.48],
+    grossWeightKg:null, grossWeightLb:29, orderUnit:{ kind:'single', units:1 },
+    ...overrides,
+  };
+}
+
+function catalog(version, overrides = {}) {
+  return {
+    schemaVersion:2,
+    catalogVersion:version,
+    products:[{
+      productSku:'ABC01', productName:'Product', origin:'VN', standardFactory:'VN', lifecycle:'active',
+      approvedOrderSkus:['ABC01', '7ABCD013AB'], packagingVersions:[packaging(overrides.productPackaging)],
+    }],
+    orderSkuAliases:[{
+      orderSku:'7ABCD013AB', canonicalProductSku:'ABC01', lifecycle:'approved',
+      packagingVersions:[packaging(overrides.aliasPackaging)],
+    }],
+  };
+}
+
+test('next catalog version advances the day or same-day sequence', () => {
+  assert.equal(nextCatalogVersion('2026-08-28.4', '2026-08-28'), '2026-08-28.5');
+  assert.equal(nextCatalogVersion('2026-08-28.4', '2026-08-29'), '2026-08-29');
+  assert.throws(() => nextCatalogVersion('2026-08-28.4', '2026-08-27'), /precedes current catalog/);
+  assert.equal(assertNewCatalogVersion('2026-08-28.4', '2026-08-28.5'), '2026-08-28.5');
+  assert.throws(() => assertNewCatalogVersion('2026-08-28.4', '2026-08-28.4'), /must be newer/);
+});
+
+test('release report ignores a version-only change', () => {
+  const report = createCatalogReleaseReport(catalog('2026-08-28.4'), catalog('2026-08-28.5'), {
+    generatedAt:'2026-08-28T00:00:00.000Z', sourceFile:'raw.xlsx',
+  });
+  assert.equal(report.stats.changedEntries, 0);
+  assert.equal(report.sourceFile, 'raw.xlsx');
+});
+
+test('release report shows product and Order SKU packaging old to new in FBA units', () => {
+  const before = catalog('2026-08-28.4');
+  const after = catalog('2026-08-28.5', {
+    productPackaging:{ unitsPerCarton:30, cartonsPerPallet:36, cartonDimensionsCm:[58.5, 34.5, 35], grossWeightLb:35 },
+    aliasPackaging:{ unitsPerCarton:26, grossWeightLb:30 },
+  });
+  const report = createCatalogReleaseReport(before, after, { generatedAt:'2026-08-28T00:00:00.000Z' });
+
+  assert.equal(report.stats.changedEntries, 2);
+  const product = report.changes.find(change => change.sku === 'ABC01');
+  assert.deepEqual(product.before.cartonDimensionsIn, [20, 16, 12]);
+  assert.deepEqual(product.after.cartonDimensionsIn, [23, 14, 14]);
+  assert.deepEqual(product.fields.find(field => field.field === 'unitsPerCarton'), {
+    field:'unitsPerCarton', before:24, after:30,
+  });
+  const alias = report.changes.find(change => change.sku === '7ABCD013AB');
+  assert.equal(alias.after.canonicalProductSku, 'ABC01');
+  assert.match(renderCatalogReleaseReport(report), /ABC01 \[updated\].*unitsPerCarton: 24 → 30/);
+});
+
+test('release blockers stop removals, alias owner changes, and packaging data loss', () => {
+  const report = {
+    changes:[
+      { sku:'OLD01', entryType:'product', changeType:'removed', fields:[] },
+      { sku:'7ABCD013AB', entryType:'order-sku-alias', changeType:'updated', fields:[
+        { field:'canonicalProductSku', before:'ABC01', after:'ABC02' },
+      ] },
+      { sku:'ABC01', entryType:'product', changeType:'updated', fields:[
+        { field:'unitsPerCarton', before:24, after:null },
+        { field:'lifecycle', before:'active', after:'incomplete' },
+      ] },
+    ],
+  };
+  assert.deepEqual(catalogReleaseBlockers(report), [
+    'OLD01 would be removed',
+    '7ABCD013AB approved alias owner would change from ABC01 to ABC02',
+    'ABC01.unitsPerCarton would lose a known value',
+    'ABC01 would regress from active to incomplete',
+  ]);
+});


### PR DESCRIPTION
Adds the one-command Supply/FBA product catalog release planner and installed Codex skill, with no-op and blocker safeguards. Also makes the order-generator coverage meter yellow, green, and red more vivid while retaining the shared translucent glass finish. Verified with 268 unit tests, catalog checks, deterministic build verification, and 14 browser acceptance tests. The current raw workbook produced a zero-change plan, so no product catalog version was changed in this PR.