### PR TITLE
Derive browser expectations from the catalog

### DIFF
--- a/tests/browser/product-update-entry.spec.mjs
+++ b/tests/browser/product-update-entry.spec.mjs
@@ -13,6 +13,14 @@ import {
 
 const repoRoot = path.resolve(import.meta.dirname, '..', '..');
 const supplyManifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog-alignment.json'), 'utf8'));
+const supplyCatalog = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+const rawExcelReleaseDate = new Date(`${supplyCatalog.catalogVersion.slice(0, 10)}T08:30:00.000Z`);
+rawExcelReleaseDate.setUTCDate(rawExcelReleaseDate.getUTCDate() + 1);
+const rawExcelReleaseVersion = rawExcelReleaseDate.toISOString().slice(0, 10);
+const gtp03 = supplyCatalog.products.find(product => product.productSku === 'GTP03');
+const gtp03DefaultPackaging = gtp03.packagingVersions.find(
+  packaging => packaging.version === gtp03.newOrderPackagingDefaultVersion,
+);
 const fbaManifest = {
   ...supplyManifest,
   site:'fba',
@@ -172,7 +180,7 @@ test('blocking conflict is disabled, cannot be bypassed, and mobile dialog stays
 });
 
 test('raw Excel creates the signed plan in memory and explicit clear is review-only', async ({ page, context }) => {
-  await freezeBrowserTime(page);
+  await page.clock.setFixedTime(rawExcelReleaseDate);
   const browserErrors = monitorBrowserErrors(page);
   const unexpectedRequests = [];
   await installAlignmentRoutes(context);
@@ -189,7 +197,9 @@ test('raw Excel creates the signed plan in memory and explicit clear is review-o
     buffer:rawProductWorkbookBuffer(),
   });
   await expect(dialog.locator('[data-product-update-message]')).toContainText('已在記憶體解析 1 筆');
-  await expect(dialog.locator('[data-product-update-versions]')).toHaveText('2026-08-28.4 → 2026-08-28.5');
+  await expect(dialog.locator('[data-product-update-versions]')).toHaveText(
+    `${supplyCatalog.catalogVersion} → ${rawExcelReleaseVersion}`,
+  );
   await expect(dialog.locator('[data-product-update-clears]')).toBeVisible();
   await dialog.locator('[data-product-update-clears] summary').click();
   const clearCartons = dialog.locator('[data-clear-sku="GTP03"][data-clear-field="cartonsPerPallet"]');
@@ -210,7 +220,7 @@ test('raw Excel creates the signed plan in memory and explicit clear is review-o
     sourceFile:'raw-product.xlsx',
     risk:'review',
     selected:false,
-    clear:{ field:'cartonsPerPallet', before:36, after:null },
+    clear:{ field:'cartonsPerPallet', before:gtp03DefaultPackaging.cartonsPerPallet, after:null },
   });
 
   const planDownloadPromise = page.waitForEvent('download');

--- a/tests/browser/public-acceptance.spec.mjs
+++ b/tests/browser/public-acceptance.spec.mjs
@@ -52,8 +52,9 @@ test('public sanitized data flows through planning, shared navigation, three gro
   await page.locator('.workspaceNavTab[data-workspace="analysis"]').click();
   await page.locator('#otherToolsDetails > summary').click();
   await page.locator('.toolTab[data-panel="suggestedDiscontinuedPanel"]').click();
-  await expect(page.locator('#suggestedDiscontinuedCount')).toHaveText('9');
-  await expect(page.locator('#suggestedDiscontinuedWrap tbody tr')).toHaveCount(9);
+  const suggestionCount = Number(await page.locator('#suggestedDiscontinuedCount').textContent());
+  expect(suggestionCount).toBeGreaterThan(0);
+  await expect(page.locator('#suggestedDiscontinuedWrap tbody tr')).toHaveCount(suggestionCount);
   const ttsSuggestion = page.locator('#suggestedDiscontinuedWrap tbody tr').filter({ hasText:'TTS05AM-1' });
   await expect(ttsSuggestion).toHaveCount(1);
   await expect(ttsSuggestion).toContainText('420 天');

--- a/tests/browser/workspace-accessibility.spec.mjs
+++ b/tests/browser/workspace-accessibility.spec.mjs
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 
 import {
@@ -9,6 +11,13 @@ import {
 } from './browser-helpers.mjs';
 
 const NOW = '2026-08-28T08:30:00.000Z';
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const supplyCatalog = JSON.parse(fs.readFileSync(path.join(repoRoot, 'catalog', 'product-catalog.json'), 'utf8'));
+const gtsl01 = supplyCatalog.products.find(product => product.productSku === 'GTSL01');
+const gtsl01DefaultPackaging = gtsl01.packagingVersions.find(
+  packaging => packaging.version === gtsl01.newOrderPackagingDefaultVersion,
+);
+const GTSL01_UNITS_PER_PALLET = gtsl01DefaultPackaging.unitsPerCarton * gtsl01DefaultPackaging.cartonsPerPallet;
 const KEYBOARD_DRAFT = {
   schemaVersion:2,
   createdAt:NOW,
@@ -148,13 +157,14 @@ test('keyboard alone operates Order groups and exact pallet stepping', async ({ 
   await expect(pallet).toHaveValue('0.5');
   await page.keyboard.press('ArrowUp');
   await expect(pallet).toHaveValue('1');
-  await expect.poll(async () => (await readOrderDraft(page)).rowsByProductSku.GTSL01.quantities.orderDraft).toBe(900);
+  await expect.poll(async () => (await readOrderDraft(page)).rowsByProductSku.GTSL01.quantities.orderDraft)
+    .toBe(GTSL01_UNITS_PER_PALLET);
   await page.keyboard.press('ArrowDown');
   await expect(pallet).toHaveValue('0.5');
   await expect.poll(async () => {
     const row = (await readOrderDraft(page)).rowsByProductSku.GTSL01;
     return { quantity:row.quantities.orderDraft, mode:row.pallet.mode, authoritativeField:row.pallet.authoritativeField };
-  }).toEqual({ quantity:450, mode:'manual', authoritativeField:'pallets' });
+  }).toEqual({ quantity:GTSL01_UNITS_PER_PALLET / 2, mode:'manual', authoritativeField:'pallets' });
 
   expect(unexpectedRequests).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- derive the raw Product Update release date from the current catalog version
- assert discontinued-table count against rendered rows instead of a release-specific literal
- derive GTSL01 pallet-step quantities from its current default packaging

These are test-only changes. They keep browser acceptance valid when an approved catalog release changes carton or pallet facts.

## Local checks
- all three specs parse
- Playwright discovers the expected 7 tests
- `git diff --check` passes