### PR TITLE
Keep Clear from reviving an empty snapshot

### DIFF
--- a/Boss/index.html
+++ b/Boss/index.html
@@ -3517,6 +3517,11 @@
       }
     }
 
+    function isUserInitiatedDetailsToggle(element) {
+      const summary = element?.querySelector(':scope > summary');
+      return Boolean(summary && document.activeElement === summary);
+    }
+
     function wireWorkspacePersistence() {
       if (IS_BOSS_PORTAL) return;
       const preferenceInputIds = new Set([
@@ -3554,7 +3559,9 @@
           scheduleFromUserEvent(event);
         }
       });
-      document.querySelectorAll('details[id]').forEach(element => element.addEventListener('toggle', scheduleFromUserEvent));
+      document.querySelectorAll('details[id]').forEach(element => element.addEventListener('toggle', () => {
+        scheduleWorkspaceAutoSave({ userInitiated:isUserInitiatedDetailsToggle(element) });
+      }));
       window.addEventListener('hashchange', scheduleFromUserEvent);
       window.addEventListener('pagehide', () => {
         if (!workspaceSaveTimer) return;

--- a/index.html
+++ b/index.html
@@ -3505,6 +3505,11 @@
       }
     }
 
+    function isUserInitiatedDetailsToggle(element) {
+      const summary = element?.querySelector(':scope > summary');
+      return Boolean(summary && document.activeElement === summary);
+    }
+
     function wireWorkspacePersistence() {
       if (IS_BOSS_PORTAL) return;
       const preferenceInputIds = new Set([
@@ -3542,7 +3547,9 @@
           scheduleFromUserEvent(event);
         }
       });
-      document.querySelectorAll('details[id]').forEach(element => element.addEventListener('toggle', scheduleFromUserEvent));
+      document.querySelectorAll('details[id]').forEach(element => element.addEventListener('toggle', () => {
+        scheduleWorkspaceAutoSave({ userInitiated:isUserInitiatedDetailsToggle(element) });
+      }));
       window.addEventListener('hashchange', scheduleFromUserEvent);
       window.addEventListener('pagehide', () => {
         if (!workspaceSaveTimer) return;

--- a/tests/workspace-snapshot-page.test.mjs
+++ b/tests/workspace-snapshot-page.test.mjs
@@ -248,6 +248,7 @@ test('Clear is confirmed, cancels pending writes, uses the exact store clear, an
   assert.match(issueFormatter, /issue\.status === 'corrupt'[\s\S]*按上方「清空」後重建/);
   const persistenceWiring = extractFunctionSource(publicHtml, 'wireWorkspacePersistence');
   assert.match(persistenceWiring, /event\?\.isTrusted/);
+  assert.match(persistenceWiring, /details\[id\][\s\S]*isUserInitiatedDetailsToggle\(element\)/);
   assert.match(persistenceWiring, /workspaceH10SelectedAt = new Date\(\)\.toISOString\(\)/);
   assert.match(persistenceWiring, /stageWorkspaceH10Draft\(\)/);
   assert.match(extractFunctionSource(publicHtml, 'restorePublicWorkspace'), /result\.recoveredH10Draft[\s\S]*persistWorkspaceSnapshot\(\{ force:true \}\)/);
@@ -272,6 +273,21 @@ test('Clear is confirmed, cancels pending writes, uses the exact store clear, an
   assert.doesNotMatch(bossDelete, /BOSS_TOKEN_KEY|sessionStorage\.removeItem/);
   assert.ok(WORKSPACE_CLEAR_LOCAL_STORAGE_KEYS.length > 0);
   assert.ok(!WORKSPACE_CLEAR_LOCAL_STORAGE_KEYS.includes('supply-boss-session'));
+});
+
+test('programmatic details resets cannot revive an empty Snapshot after Clear', () => {
+  for (const html of [publicHtml, bossHtml]) {
+    const context = vm.createContext({ document:{ activeElement:null } });
+    vm.runInContext(
+      `${extractFunctionSource(html, 'isUserInitiatedDetailsToggle')}; globalThis.isUserToggle = isUserInitiatedDetailsToggle;`,
+      context,
+    );
+    const summary = {};
+    const details = { querySelector:selector => selector === ':scope > summary' ? summary : null };
+    assert.equal(context.isUserToggle(details), false);
+    context.document.activeElement = summary;
+    assert.equal(context.isUserToggle(details), true);
+  }
 });
 
 test('Boss cloud restore never presents parser failures or unrecognized files as ready', () => {


### PR DESCRIPTION
## Summary
- treat a `<details>` toggle as user-initiated only when its own `<summary>` has focus
- keep programmatic UI reset toggles from lifting the post-Clear autosave suppression
- apply the same wiring to public and Boss compositions

## Root cause
`toggle` events created by programmatic `.open` changes can be browser-trusted. The former `event.isTrusted` check could therefore schedule an empty Snapshot immediately after Clear.

## Verification
- added a focused regression test for programmatic vs focused-summary toggles
- Workspace Snapshot page tests: 16/16 passed
- inline JavaScript contract tests: 31/31 passed